### PR TITLE
feat: production-ready frontend + analytics + pitch deck (Solana Frontier 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Integrates **x402 micropayments** — agents pay per API call (0.001 USDC/reques
 ## DeFi Integrations
 
 | Protocol | What we use it for |
-|----------|--------------------|
+|----------|--------------------||
 | **Jupiter v6** | All swaps (best route, min slippage), Limit Orders (Eagle+), DCA (Dragon+) |
 | **Kamino** | Yield strategies (lending APY up to 15%), RWA-backed vaults |
 | **Drift** | Perps exposure + lending rates |
@@ -251,21 +251,22 @@ potbot-v2/
 |-----------|--------|-------|
 | Anchor `pot_vault` core | ✅ Complete | All instructions written |
 | Strategy Vault on-chain | ✅ Complete | create/join/exit/evolve + referral |
-| TypeScript SDK | ✅ Complete | PDAs, IDL, client helpers |
-| Next.js DApp | ✅ Running | Mock mode + full UI |
-| `/vaults` discovery page | ✅ Complete | Filter, sort, join UI |
+| TypeScript SDK | ✅ Complete | PDAs, IDL, client helpers, StrategyVault methods |
+| Next.js DApp | ✅ Complete | Full UI — demo mode + on-chain |
+| `/vaults` discovery page | ✅ Complete | Live analytics, USD TVL, sort/filter |
 | `/vaults/create` wizard | ✅ Complete | 5-step wizard |
-| AI Agent UI | ✅ Complete | Rules engine + log tabs |
+| AI Agent UI + API sync | ✅ Complete | Rules engine, server sync, 24/7 cron |
 | Governance + proposals | ✅ Complete | Shares-weighted voting |
-| Leaderboard | ✅ Complete | Public vaults ranking |
-| **Devnet deploy** | 🔴 Blocker | `anchor deploy` pending |
-| **Jupiter swap CPI** | 🔴 Blocker | Real swap (not mock) |
-| **Backend API** (`apps/api`) | 🟡 In progress | Price + PnL + Agent cron |
-| **MCP Server** (`apps/potbot-mcp`) | 🟡 In progress | solana-agent-kit based |
-| E2E test on devnet | 🟡 Next | After deploy |
-| Kamino/Drift yield aggregation | 🟢 Planned | Week of Apr 28 |
-| Metaplex NFT shares (Titan) | 🟢 Planned | Week of Apr 28 |
-| Privy embedded wallet | 🟢 Planned | Week of May 1 |
+| Leaderboard | ✅ Complete | USD TVL, PnL%, APY30d, batch analytics |
+| Live price ticker | ✅ Complete | SOL/USD in navbar, API health dot |
+| **Backend API** (`apps/api`) | ✅ Complete | Price oracle, PnL engine, analytics, agent cron |
+| **MCP Server** (`apps/potbot-mcp`) | ✅ Complete | solana-agent-kit based, 15+ tools |
+| **Devnet deploy** | ✅ Complete | Program live on devnet |
+| Production analytics data layer | ✅ Complete | useVaultAnalyticsBatch, VaultAnalyticsStrip |
+| Pitch deck | ✅ Complete | 11 slides — Solana Frontier 2026 |
+| **Jupiter swap CPI** | 🔴 Blocker | Real swap (not mock) needs executor wallet |
+| E2E test on devnet | 🟡 Next | After executor wallet funded |
+| Kamino/Drift yield aggregation | 🟢 Planned | Post-hackathon |
 | Demo video | 🟢 Planned | May 6–8 |
 | Hackathon submission | 📅 May 11 | colosseum.com/frontier |
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,17 +1,48 @@
-# PotBot API — copy to .env.local and fill in values
+# ─────────────────────────────────────────────────────────────
+# PotBot API — Environment Variables
+# Copy to .env and fill in values
+# ─────────────────────────────────────────────────────────────
+
+# Server
 PORT=3001
-CORS_ORIGIN=http://localhost:3000
+NODE_ENV=development
 
-# Solana RPC
+# CORS — comma-separated list of allowed origins
+CORS_ORIGINS=http://localhost:3000,https://potbot.fun
+
+# ── Solana ──────────────────────────────────────────────────────────────────
+# Devnet (development)
 RPC_URL=https://api.devnet.solana.com
-# For mainnet: RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
 
-# Program
+# Mainnet (production) — use premium RPC for reliability + performance
+# RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_HELIUS_KEY
+# RPC_URL=https://solana-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
+
 PROGRAM_ID=ED4zhABMV97obJSD5bzasUPaNVmc3qwA3WhwqoGVCDvH
 
-# Optional: Supabase for persistent storage
-# SUPABASE_URL=https://your-project.supabase.co
-# SUPABASE_SERVICE_KEY=your-service-key
+# ── Jupiter Executor ────────────────────────────────────────────────────────
+# Base58-encoded private key of the executor wallet
+# This wallet signs Jupiter swap transactions on behalf of the vault
+# SECURITY: Never commit this value. Rotate regularly.
+# EXECUTOR_KEYPAIR=your-base58-private-key-here
 
-# Optional: Helius for enhanced RPC
-# HELIUS_API_KEY=your-helius-key
+# Swap slippage tolerance in basis points (50 = 0.5%)
+SWAP_SLIPPAGE_BPS=50
+
+# ── Supabase (Database) ──────────────────────────────────────────────────────
+# Get these from: https://app.supabase.com/project/_/settings/api
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_SERVICE_KEY=your-service-role-key  ← NEVER expose publicly
+
+# ── Redis (Upstash) ──────────────────────────────────────────────────────────
+# Get these from: https://console.upstash.com
+# Free tier: 10,000 requests/day — sufficient for early users
+# UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your-token
+
+# ── Helius (Webhooks + Premium RPC) ─────────────────────────────────────────
+# Sign up at: https://dev.helius.xyz
+# Free tier: 100k credits/month
+# HELIUS_API_KEY=your-helius-api-key
+# HELIUS_WEBHOOK_URL=https://api.potbot.fun  ← your deployed API URL
+# HELIUS_WEBHOOK_SECRET=random-secret-for-signature-verification

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,33 @@
+# PotBot API — Production Docker Image
+FROM node:22-alpine AS base
+WORKDIR /app
+
+# Dependencies
+FROM base AS deps
+COPY package.json ./
+RUN npm install --frozen-lockfile --production
+
+# Build
+FROM base AS builder
+COPY package.json tsconfig.json ./
+RUN npm install --frozen-lockfile
+COPY src/ ./src/
+RUN npm run build
+
+# Production image
+FROM base AS runner
+ENV NODE_ENV=production
+
+COPY --from=deps    /app/node_modules ./node_modules
+COPY --from=builder /app/dist         ./dist
+COPY package.json ./
+
+# Non-root user for security
+RUN addgroup -g 1001 -S nodejs && adduser -S potbot -u 1001
+USER potbot
+
+EXPOSE 3001
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3001/health || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -1,0 +1,39 @@
+# fly.toml — Fly.io deployment for PotBot API
+# Deploy: fly deploy (from apps/api directory)
+# Docs: https://fly.io/docs/reference/configuration/
+
+app = "potbot-api"
+primary_region = "ams"  # Amsterdam — close to EU users
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3001"
+
+[http_service]
+  internal_port = 3001
+  force_https   = true
+  auto_stop_machines  = false  # Keep warm for low latency
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type       = "requests"
+    hard_limit = 1000
+    soft_limit = 800
+
+[[vm]]
+  size   = "shared-cpu-1x"   # Start small, scale up as needed
+  memory = "512mb"
+
+[checks]
+  [checks.health]
+    grace_period  = "10s"
+    interval      = "30s"
+    method        = "GET"
+    path          = "/health"
+    port          = 3001
+    timeout       = "5s"
+    type          = "http"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,22 +4,24 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev":   "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "tsc --noEmit"
+    "lint":  "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.12.0",
-    "hono": "^4.5.0",
-    "@solana/web3.js": "^1.98.0",
-    "node-cron": "^3.0.3",
-    "dotenv": "^16.4.5"
+    "@hono/node-server":  "^1.12.0",
+    "@supabase/supabase-js": "^2.45.0",
+    "@solana/web3.js":    "^1.98.0",
+    "bs58":               "^6.0.0",
+    "hono":               "^4.5.0",
+    "node-cron":          "^3.0.3",
+    "dotenv":             "^16.4.5"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "@types/node-cron": "^3.0.11",
-    "tsx": "^4.16.2",
-    "typescript": "^5.5.3"
+    "@types/node":       "^22.0.0",
+    "@types/node-cron":  "^3.0.11",
+    "tsx":               "^4.16.2",
+    "typescript":        "^5.5.3"
   }
 }

--- a/apps/api/src/db/supabase.ts
+++ b/apps/api/src/db/supabase.ts
@@ -1,0 +1,221 @@
+/**
+ * Supabase client — typed database access for PotBot API
+ * Uses service role key for server-side operations
+ */
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.warn('[supabase] Missing env vars — DB persistence disabled. Set SUPABASE_URL + SUPABASE_SERVICE_KEY')
+}
+
+export const supabase = SUPABASE_URL && SUPABASE_SERVICE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+      auth: { persistSession: false },
+    })
+  : null
+
+export const isDbEnabled = () => supabase !== null
+
+// ── Type Helpers ────────────────────────────────────────────────────────────
+
+export interface PriceSnapshot {
+  mint: string
+  price_usd: number
+  captured_at?: string
+}
+
+export interface NavSnapshot {
+  pot_pubkey: string
+  nav_usd: number
+  total_shares: number
+  sol_balance_lamports: number
+  captured_at?: string
+}
+
+export interface Position {
+  pot_pubkey: string
+  mint: string
+  symbol?: string
+  amount: number
+  entry_price: number
+  entry_value: number
+  opened_at?: string
+  closed_at?: string | null
+  proposal_id?: number
+  entry_tx?: string
+}
+
+export interface SwapExecution {
+  pot_pubkey: string
+  proposal_id: number
+  from_mint: string
+  to_mint: string
+  amount_in: number
+  min_amount_out: number
+  amount_out?: number
+  price_impact?: number
+  jupiter_route?: unknown
+  tx_signature?: string
+  status: 'pending' | 'submitted' | 'confirmed' | 'failed'
+  error?: string
+}
+
+export interface AgentLog {
+  pot_pubkey: string
+  rule_id: string
+  rule_name: string
+  trigger_desc: string
+  action_desc: string
+  proposal_created: boolean
+  proposal_id?: number
+  tx_signature?: string
+  error?: string
+}
+
+// ── Write Helpers ────────────────────────────────────────────────────────────
+
+export async function insertPriceSnapshot(data: PriceSnapshot) {
+  if (!supabase) return
+  await supabase.from('price_snapshots').insert(data)
+}
+
+export async function insertNavSnapshot(data: NavSnapshot) {
+  if (!supabase) return
+  const { error } = await supabase.from('nav_snapshots').insert(data)
+  if (error) console.error('[db] insertNavSnapshot:', error.message)
+}
+
+export async function upsertPositions(potPubkey: string, positions: Position[]) {
+  if (!supabase) return
+  // Close existing open positions for this pot
+  await supabase
+    .from('positions')
+    .update({ closed_at: new Date().toISOString() })
+    .eq('pot_pubkey', potPubkey)
+    .is('closed_at', null)
+  // Insert new positions
+  if (positions.length > 0) {
+    const { error } = await supabase.from('positions').insert(
+      positions.map(p => ({ ...p, pot_pubkey: potPubkey }))
+    )
+    if (error) console.error('[db] upsertPositions:', error.message)
+  }
+}
+
+export async function insertSwapExecution(data: SwapExecution): Promise<number | null> {
+  if (!supabase) return null
+  const { data: row, error } = await supabase
+    .from('swap_executions')
+    .insert(data)
+    .select('id')
+    .single()
+  if (error) {
+    console.error('[db] insertSwapExecution:', error.message)
+    return null
+  }
+  return row?.id ?? null
+}
+
+export async function updateSwapExecution(
+  id: number,
+  update: Partial<SwapExecution> & { confirmed_at?: string }
+) {
+  if (!supabase) return
+  const { error } = await supabase
+    .from('swap_executions')
+    .update(update)
+    .eq('id', id)
+  if (error) console.error('[db] updateSwapExecution:', error.message)
+}
+
+export async function insertAgentLog(data: AgentLog) {
+  if (!supabase) return
+  const { error } = await supabase.from('agent_logs').insert(data)
+  if (error) console.error('[db] insertAgentLog:', error.message)
+}
+
+export async function upsertPot(data: {
+  pubkey: string
+  name: string
+  emoji?: string
+  authority: string
+  is_public: boolean
+  member_count: number
+  trade_count: number
+  total_volume: number
+  tamagotchi_level: number
+  agent_pubkey?: string | null
+  agent_max_trade_bps: number
+  created_at?: string
+}) {
+  if (!supabase) return
+  const { error } = await supabase
+    .from('pots')
+    .upsert({ ...data, synced_at: new Date().toISOString() }, { onConflict: 'pubkey' })
+  if (error) console.error('[db] upsertPot:', error.message)
+}
+
+// ── Read Helpers ────────────────────────────────────────────────────────────
+
+export async function getNavHistory(
+  potPubkey: string,
+  days = 30
+): Promise<Array<{ ts: number; nav: number }>> {
+  if (!supabase) return []
+  const since = new Date(Date.now() - days * 86400_000).toISOString()
+  const { data, error } = await supabase
+    .from('nav_snapshots')
+    .select('nav_usd, captured_at')
+    .eq('pot_pubkey', potPubkey)
+    .gte('captured_at', since)
+    .order('captured_at', { ascending: true })
+  if (error || !data) return []
+  return data.map(r => ({
+    ts: new Date(r.captured_at).getTime() / 1000,
+    nav: Number(r.nav_usd),
+  }))
+}
+
+export async function getOpenPositions(potPubkey: string): Promise<Position[]> {
+  if (!supabase) return []
+  const { data, error } = await supabase
+    .from('positions')
+    .select('*')
+    .eq('pot_pubkey', potPubkey)
+    .is('closed_at', null)
+  if (error || !data) return []
+  return data
+}
+
+export async function getSwapHistory(
+  potPubkey: string,
+  limit = 20
+): Promise<SwapExecution[]> {
+  if (!supabase) return []
+  const { data, error } = await supabase
+    .from('swap_executions')
+    .select('*')
+    .eq('pot_pubkey', potPubkey)
+    .order('executed_at', { ascending: false })
+    .limit(limit)
+  if (error || !data) return []
+  return data
+}
+
+export async function getAgentLogs(
+  potPubkey: string,
+  limit = 50
+): Promise<AgentLog[]> {
+  if (!supabase) return []
+  const { data, error } = await supabase
+    .from('agent_logs')
+    .select('*')
+    .eq('pot_pubkey', potPubkey)
+    .order('logged_at', { ascending: false })
+    .limit(limit)
+  if (error || !data) return []
+  return data
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,53 +3,70 @@ import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
+import { secureHeaders } from 'hono/secure-headers'
 import { pricesRouter } from './routes/prices.js'
 import { analyticsRouter } from './routes/analytics.js'
 import { agentRouter } from './routes/agent.js'
 import { yieldRouter } from './routes/yield.js'
+import { createWebhooksRouter } from './routes/webhooks.js'
 import { warmCache } from './services/price-oracle.js'
 import { startAgentCron } from './services/agent-cron.js'
+import { publicLimiter } from './middleware/rate-limit.js'
 
 const app = new Hono()
 
+// ── Global Middleware ────────────────────────────────────────────────────────
 app.use('*', cors({
-  origin: process.env.CORS_ORIGIN ?? '*',
+  origin: (origin) => {
+    const allowed = (process.env.CORS_ORIGINS ?? 'http://localhost:3000').split(',')
+    return allowed.includes(origin) || origin.endsWith('.vercel.app') ? origin : allowed[0]
+  },
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization'],
+  maxAge: 86400,
 }))
+app.use('*', secureHeaders())
 app.use('*', logger())
+app.use('/prices/*', publicLimiter)
+app.use('/analytics/*', publicLimiter)
+app.use('/yield/*', publicLimiter)
 
-// Routes
+// ── Routes ───────────────────────────────────────────────────────────────────
 app.get('/health', (c) => c.json({
   status: 'ok',
   version: '1.0.0',
   name: 'PotBot API',
+  env: process.env.NODE_ENV ?? 'development',
   ts: Date.now(),
 }))
 
-app.route('/prices', pricesRouter)
+app.route('/prices',    pricesRouter)
 app.route('/analytics', analyticsRouter)
-app.route('/agent', agentRouter)
-app.route('/yield', yieldRouter)
+app.route('/agent',     agentRouter)
+app.route('/yield',     yieldRouter)
+app.route('/webhooks',  createWebhooksRouter())
 
-// 404 handler
+// ── Error Handlers ───────────────────────────────────────────────────────────
 app.notFound((c) => c.json({ error: 'Not found', path: c.req.path }, 404))
-
-// Error handler
 app.onError((err, c) => {
   console.error('[api] Unhandled error:', err)
   return c.json({ error: 'Internal server error' }, 500)
 })
 
+// ── Startup ──────────────────────────────────────────────────────────────────
 const PORT = Number(process.env.PORT ?? 3001)
 
-// Warm price cache and start agent cron
 warmCache().catch(console.error)
 startAgentCron()
 
 serve({ fetch: app.fetch, port: PORT }, () => {
-  console.log(`🚀 PotBot API running at http://localhost:${PORT}`)
-  console.log(`   Routes: /health  /prices  /analytics  /agent  /yield`)
+  console.log(`\n🚀 PotBot API v1.0.0`)
+  console.log(`   http://localhost:${PORT}`)
+  console.log(`   Env: ${process.env.NODE_ENV ?? 'development'}`)
+  console.log(`   DB:  ${process.env.SUPABASE_URL ? '✅ Supabase' : '⚠️  In-memory (no SUPABASE_URL)'}`)
+  console.log(`   Cache: ${process.env.UPSTASH_REDIS_REST_URL ? '✅ Redis (Upstash)' : '⚠️  In-memory'}`)
+  console.log(`   RPC:   ${process.env.RPC_URL ?? 'https://api.devnet.solana.com'}`)
+  console.log(`   Executor: ${process.env.EXECUTOR_KEYPAIR ? '✅ Loaded' : '⚠️  Not set (swaps simulated)'}\n`)
 })
 
 export default app

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,81 @@
+/**
+ * Rate Limiting Middleware
+ * 
+ * Limits:
+ *   - Public endpoints: 60 req/min per IP
+ *   - Webhook endpoints: 300 req/min per IP  (Helius sends bursts)
+ *   - Agent trigger: 10 req/min per IP
+ * 
+ * Uses sliding window algorithm with in-memory store.
+ * For production at scale: replace with Redis-backed rate limiting.
+ */
+import type { Context, MiddlewareHandler, Next } from 'hono'
+
+interface WindowEntry {
+  count: number
+  windowStart: number
+}
+
+const windows = new Map<string, WindowEntry>()
+
+// Prune expired windows every 5 minutes
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of windows) {
+    if (now - entry.windowStart > 120_000) windows.delete(key)
+  }
+}, 300_000)
+
+function getClientIp(c: Context): string {
+  return (
+    c.req.header('cf-connecting-ip') ??
+    c.req.header('x-forwarded-for')?.split(',')[0].trim() ??
+    c.req.header('x-real-ip') ??
+    'unknown'
+  )
+}
+
+export function rateLimit(options: {
+  requests: number
+  windowMs: number
+  keyPrefix?: string
+}): MiddlewareHandler {
+  const { requests, windowMs, keyPrefix = 'rl' } = options
+
+  return async (c: Context, next: Next) => {
+    const ip = getClientIp(c)
+    const key = `${keyPrefix}:${ip}`
+    const now = Date.now()
+
+    const entry = windows.get(key)
+
+    if (!entry || now - entry.windowStart > windowMs) {
+      // New window
+      windows.set(key, { count: 1, windowStart: now })
+      c.header('X-RateLimit-Limit', String(requests))
+      c.header('X-RateLimit-Remaining', String(requests - 1))
+      return next()
+    }
+
+    entry.count++
+    const remaining = Math.max(0, requests - entry.count)
+    c.header('X-RateLimit-Limit', String(requests))
+    c.header('X-RateLimit-Remaining', String(remaining))
+    c.header('X-RateLimit-Reset', String(Math.ceil((entry.windowStart + windowMs) / 1000)))
+
+    if (entry.count > requests) {
+      return c.json(
+        { error: 'Too many requests', retryAfter: Math.ceil((entry.windowStart + windowMs - now) / 1000) },
+        429
+      )
+    }
+
+    return next()
+  }
+}
+
+// Pre-configured limiters
+export const publicLimiter = rateLimit({ requests: 60,  windowMs: 60_000, keyPrefix: 'pub' })
+export const webhookLimiter = rateLimit({ requests: 300, windowMs: 60_000, keyPrefix: 'wh'  })
+export const agentLimiter = rateLimit({ requests: 10,  windowMs: 60_000, keyPrefix: 'ag'  })
+export const priceLimiter = rateLimit({ requests: 120, windowMs: 60_000, keyPrefix: 'pr'  })

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,82 @@
+import { Hono } from 'hono'
+import { HeliusProcessor } from '../services/helius.js'
+import { JupiterExecutor } from '../services/jupiter-executor.js'
+import { webhookLimiter } from '../middleware/rate-limit.js'
+
+export function createWebhooksRouter() {
+  const router = new Hono()
+
+  const executor = new JupiterExecutor({
+    rpcUrl:           process.env.RPC_URL ?? 'https://api.devnet.solana.com',
+    executorKeypair:  process.env.EXECUTOR_KEYPAIR,
+    slippageBps:      Number(process.env.SWAP_SLIPPAGE_BPS ?? 50),
+  })
+
+  const processor = new HeliusProcessor(
+    executor,
+    process.env.PROGRAM_ID ?? 'ED4zhABMV97obJSD5bzasUPaNVmc3qwA3WhwqoGVCDvH',
+    process.env.HELIUS_WEBHOOK_SECRET
+  )
+
+  // POST /webhooks/helius — receives real-time on-chain events from Helius
+  router.post('/helius', webhookLimiter, async (c) => {
+    const rawBody = await c.req.text()
+    const signature = c.req.header('helius-signature') ?? ''
+
+    // Verify webhook signature in production
+    if (process.env.NODE_ENV === 'production' && !processor.verifySignature(rawBody, signature)) {
+      return c.json({ error: 'Invalid webhook signature' }, 401)
+    }
+
+    let events
+    try {
+      events = JSON.parse(rawBody)
+      if (!Array.isArray(events)) events = [events]
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    // Process async — respond immediately to Helius
+    c.executionCtx?.waitUntil(processor.processEvents(events))
+    // For non-Cloudflare: fire and forget
+    processor.processEvents(events).catch(console.error)
+
+    return c.json({ ok: true, received: events.length })
+  })
+
+  // GET /webhooks/executor-status — check executor wallet health
+  router.get('/executor-status', async (c) => {
+    const balance = await executor.getExecutorBalance()
+    const pubkey = executor.getExecutorPublicKey()
+    return c.json({
+      executorPubkey: pubkey,
+      balanceSol: balance,
+      healthy: balance > 0.1,
+      warning: balance < 0.1 ? 'Low executor balance — top up to ensure swap execution' : null,
+    })
+  })
+
+  // POST /webhooks/setup — register Helius webhook (run once)
+  router.post('/setup', async (c) => {
+    const apiKey = process.env.HELIUS_API_KEY
+    const webhookUrl = process.env.HELIUS_WEBHOOK_URL
+
+    if (!apiKey || !webhookUrl) {
+      return c.json({ error: 'Set HELIUS_API_KEY and HELIUS_WEBHOOK_URL in env' }, 400)
+    }
+
+    try {
+      const { registerHeliusWebhook } = await import('../services/helius.js')
+      await registerHeliusWebhook({
+        apiKey,
+        webhookUrl: `${webhookUrl}/webhooks/helius`,
+        programId: process.env.PROGRAM_ID ?? 'ED4zhABMV97obJSD5bzasUPaNVmc3qwA3WhwqoGVCDvH',
+      })
+      return c.json({ ok: true, webhookUrl: `${webhookUrl}/webhooks/helius` })
+    } catch (e) {
+      return c.json({ error: String(e) }, 500)
+    }
+  })
+
+  return router
+}

--- a/apps/api/src/services/helius.ts
+++ b/apps/api/src/services/helius.ts
@@ -1,0 +1,220 @@
+/**
+ * Helius Webhook Processor
+ * 
+ * Receives real-time on-chain events from Helius and routes them to handlers.
+ * Far more efficient than polling — handles thousands of events per second.
+ * 
+ * Setup:
+ *   1. Get API key from https://dev.helius.xyz
+ *   2. Register webhook: POST https://api.helius.xyz/v0/webhooks
+ *   3. Set HELIUS_WEBHOOK_SECRET in env for signature verification
+ * 
+ * Events we process:
+ *   - DEPOSIT:   member deposited SOL → update member record
+ *   - WITHDRAW:  member withdrew SOL → update member record
+ *   - SWAP:      proposal executed (swap authorized) → trigger Jupiter executor
+ *   - PROPOSAL:  new proposal created → notify members (future: push notifications)
+ *   - VOTE:      member voted → update proposal state
+ */
+import { createHmac } from 'crypto'
+import type { JupiterExecutor } from './jupiter-executor.js'
+
+export interface HeliusWebhookEvent {
+  accountData: Array<{
+    account: string
+    nativeBalanceChange: number
+    tokenBalanceChanges: Array<{
+      mint: string
+      rawTokenAmount: { tokenAmount: string; decimals: number }
+      userAccount: string
+    }>
+  }>
+  description: string
+  events: Record<string, unknown>
+  fee: number
+  feePayer: string
+  instructions: Array<{
+    accounts: string[]
+    data: string
+    innerInstructions: unknown[]
+    programId: string
+  }>
+  logs: string[]
+  nativeTransfers: Array<{ amount: number; fromUserAccount: string; toUserAccount: string }>
+  signature: string
+  slot: number
+  source: string
+  timestamp: number
+  tokenTransfers: unknown[]
+  transactionError: null | { error: string }
+  type: string
+}
+
+export class HeliusProcessor {
+  private secret: string
+  private executor: JupiterExecutor
+  private PROGRAM_ID: string
+
+  constructor(executor: JupiterExecutor, programId: string, secret?: string) {
+    this.executor = executor
+    this.PROGRAM_ID = programId
+    this.secret = secret ?? ''
+  }
+
+  verifySignature(rawBody: string, signature: string): boolean {
+    if (!this.secret) return true // Skip in dev
+    const expected = createHmac('sha256', this.secret)
+      .update(rawBody)
+      .digest('hex')
+    return expected === signature
+  }
+
+  async processEvents(events: HeliusWebhookEvent[]): Promise<void> {
+    for (const event of events) {
+      if (event.transactionError) continue  // Skip failed txs
+
+      try {
+        await this.routeEvent(event)
+      } catch (e) {
+        console.error(`[helius] Error processing event ${event.signature}:`, e)
+      }
+    }
+  }
+
+  private async routeEvent(event: HeliusWebhookEvent): Promise<void> {
+    const logs = event.logs ?? []
+
+    // Check for swap authorization
+    const swapLog = logs.find(l => l.includes('Swap authorised:'))
+    if (swapLog) {
+      await this.handleSwapAuthorized(event, swapLog)
+      return
+    }
+
+    // Check for proposal execution
+    if (logs.some(l => l.includes('Proposal #') && l.includes('executed in POT'))) {
+      await this.handleProposalExecuted(event, logs)
+      return
+    }
+
+    // Check for deposits
+    if (logs.some(l => l.includes('Deposited') && l.includes('lamports'))) {
+      await this.handleDeposit(event, logs)
+      return
+    }
+
+    // Check for withdrawals
+    if (logs.some(l => l.includes('Withdrew') && l.includes('lamports'))) {
+      await this.handleWithdraw(event, logs)
+      return
+    }
+  }
+
+  private async handleSwapAuthorized(
+    event: HeliusWebhookEvent,
+    swapLog: string
+  ): Promise<void> {
+    // Parse: "Swap authorised: 1000000 lamports <from> -> <to> (min out: 0). Jupiter CPI: Phase 2."
+    const match = swapLog.match(
+      /Swap authorised: (\d+) lamports ([\w]+) -> ([\w]+) \(min out: (\d+)\)/
+    )
+    if (!match) return
+
+    const [, amountIn, fromMint, toMint, minAmountOut] = match
+
+    // Find pot pubkey from the accounts in the transaction
+    const potPubkey = this.findPotPubkey(event)
+    if (!potPubkey) {
+      console.warn('[helius] Could not identify pot pubkey for swap event', event.signature)
+      return
+    }
+
+    console.log(`[helius] Swap authorized: ${amountIn} ${fromMint} → ${toMint} for pot ${potPubkey.slice(0, 8)}`)
+
+    // Trigger Jupiter executor
+    await this.executor.executeSwap({
+      potPubkey,
+      fromMint,
+      toMint,
+      amountIn: Number(amountIn),
+      minAmountOut: Number(minAmountOut),
+      proposalId: this.extractProposalId(event.logs),
+      txSignature: event.signature,
+    })
+  }
+
+  private async handleProposalExecuted(
+    event: HeliusWebhookEvent,
+    logs: string[]
+  ): Promise<void> {
+    const executedLog = logs.find(l => l.includes('executed in POT'))
+    if (!executedLog) return
+    const match = executedLog.match(/Proposal #(\d+) executed in POT (.+)/)
+    if (!match) return
+    console.log(`[helius] Proposal #${match[1]} executed in pot ${match[2]}, tx: ${event.signature}`)
+  }
+
+  private async handleDeposit(event: HeliusWebhookEvent, logs: string[]): Promise<void> {
+    const depositLog = logs.find(l => l.includes('Deposited'))
+    if (!depositLog) return
+    const match = depositLog.match(/Deposited (\d+) lamports.*shares=(\d+)/)
+    if (!match) return
+    console.log(`[helius] Deposit: ${match[1]} lamports, tx: ${event.signature}`)
+    // TODO: update member record in Supabase + recalculate NAV
+  }
+
+  private async handleWithdraw(event: HeliusWebhookEvent, logs: string[]): Promise<void> {
+    const withdrawLog = logs.find(l => l.includes('Withdrew'))
+    if (!withdrawLog) return
+    console.log(`[helius] Withdraw event, tx: ${event.signature}`)
+    // TODO: update member record in Supabase
+  }
+
+  private findPotPubkey(event: HeliusWebhookEvent): string | null {
+    // The pot account will be in the accountData array
+    // It's typically the first non-fee-payer account involved with our program
+    const instructions = event.instructions ?? []
+    const programIx = instructions.find(ix => ix.programId === this.PROGRAM_ID)
+    if (!programIx || !programIx.accounts.length) return null
+    // First account in pot instructions is typically the pot PDA
+    return programIx.accounts[0] ?? null
+  }
+
+  private extractProposalId(logs: string[]): number {
+    const proposalLog = logs.find(l => l.includes('Proposal #'))
+    const match = proposalLog?.match(/Proposal #(\d+)/)
+    return match ? Number(match[1]) : 0
+  }
+}
+
+/**
+ * Register webhook with Helius API
+ * Call this once during setup to point Helius at your API URL
+ */
+export async function registerHeliusWebhook(params: {
+  apiKey: string
+  webhookUrl: string
+  programId: string
+}): Promise<void> {
+  const { apiKey, webhookUrl, programId } = params
+
+  const res = await fetch(`https://api.helius.xyz/v0/webhooks?api-key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      webhookURL: webhookUrl,
+      transactionTypes: ['Any'],
+      accountAddresses: [programId],
+      webhookType: 'enhanced',
+      txnStatus: 'success',
+    }),
+  })
+
+  if (!res.ok) {
+    const err = await res.text()
+    throw new Error(`Helius webhook registration failed: ${err}`)
+  }
+
+  const data = await res.json()
+  console.log('[helius] Webhook registered:', data.webhookID)
+}

--- a/apps/api/src/services/jupiter-executor.ts
+++ b/apps/api/src/services/jupiter-executor.ts
@@ -1,0 +1,245 @@
+/**
+ * Jupiter Executor — off-chain swap execution service
+ * 
+ * Architecture:
+ *   On-chain:  governance votes → proposal passes → execute_proposal records swap intent
+ *   Off-chain: this service picks up the intent and executes the real Jupiter swap
+ * 
+ * Phase 1 (current): executor wallet signs Jupiter transactions
+ *   - Vault transfers funds to executor wallet via approved proposal
+ *   - Executor swaps via Jupiter and returns funds
+ * 
+ * Phase 2 (production): Anchor CPI to Jupiter
+ *   - Program calls Jupiter CPI directly from vault PDA
+ *   - Zero counterparty risk, fully trustless
+ * 
+ * Security:
+ *   - EXECUTOR_KEYPAIR env var holds executor wallet private key (base58)
+ *   - Executor wallet address must be set as pot.agent_pubkey on-chain
+ *   - Max trade size enforced by on-chain pot.agent_max_trade_bps
+ */
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  VersionedTransaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js'
+import bs58 from 'bs58'
+import { insertSwapExecution, updateSwapExecution } from '../db/supabase.js'
+
+const JUPITER_QUOTE_API  = 'https://quote-api.jup.ag/v6/quote'
+const JUPITER_SWAP_API   = 'https://quote-api.jup.ag/v6/swap'
+const JUPITER_PRICE_API  = 'https://api.jup.ag/price/v2'
+const WSOL_MINT          = 'So11111111111111111111111111111111111111112'
+
+export interface SwapRequest {
+  potPubkey: string
+  fromMint: string
+  toMint: string
+  amountIn: number       // lamports or token raw amount
+  minAmountOut: number
+  proposalId: number
+  txSignature: string    // the execute_proposal tx that authorized this
+}
+
+export interface JupiterQuote {
+  inputMint: string
+  outputMint: string
+  inAmount: string
+  outAmount: string
+  otherAmountThreshold: string
+  swapMode: string
+  slippageBps: number
+  priceImpactPct: string
+  routePlan: unknown[]
+}
+
+export class JupiterExecutor {
+  private connection: Connection
+  private executorKeypair: Keypair | null = null
+  private slippageBps: number
+  private maxRetries: number
+
+  constructor(params: {
+    rpcUrl: string
+    executorKeypair?: string  // base58 private key
+    slippageBps?: number
+    maxRetries?: number
+  }) {
+    this.connection = new Connection(params.rpcUrl, {
+      commitment: 'confirmed',
+      confirmTransactionInitialTimeout: 60_000,
+    })
+    this.slippageBps = params.slippageBps ?? 50  // 0.5% default slippage
+    this.maxRetries = params.maxRetries ?? 3
+
+    if (params.executorKeypair) {
+      try {
+        const decoded = bs58.decode(params.executorKeypair)
+        this.executorKeypair = Keypair.fromSecretKey(decoded)
+        console.log(
+          `[jupiter-executor] Loaded executor wallet: ${this.executorKeypair.publicKey.toBase58()}`
+        )
+      } catch (e) {
+        console.error('[jupiter-executor] Invalid EXECUTOR_KEYPAIR:', e)
+      }
+    } else {
+      console.warn('[jupiter-executor] No EXECUTOR_KEYPAIR set — swaps will be simulated only')
+    }
+  }
+
+  async executeSwap(req: SwapRequest): Promise<void> {
+    console.log(
+      `[jupiter-executor] Executing swap for pot ${req.potPubkey.slice(0, 8)}: ` +
+      `${req.amountIn} ${req.fromMint.slice(0, 8)} → ${req.toMint.slice(0, 8)}`
+    )
+
+    // Record in DB
+    const dbId = await insertSwapExecution({
+      pot_pubkey:     req.potPubkey,
+      proposal_id:    req.proposalId,
+      from_mint:      req.fromMint,
+      to_mint:        req.toMint,
+      amount_in:      req.amountIn,
+      min_amount_out: req.minAmountOut,
+      status:         'pending',
+    })
+
+    if (!this.executorKeypair) {
+      console.log('[jupiter-executor] Simulation mode — swap would be:', req)
+      if (dbId) await updateSwapExecution(dbId, { status: 'failed', error: 'No executor keypair' })
+      return
+    }
+
+    let lastError: string | undefined
+
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      try {
+        const { txSignature, amountOut, priceImpact, route } =
+          await this.executeWithRetry(req, attempt)
+
+        console.log(`[jupiter-executor] Swap confirmed: ${txSignature} — received ${amountOut}`)
+
+        if (dbId) {
+          await updateSwapExecution(dbId, {
+            status:         'confirmed',
+            tx_signature:   txSignature,
+            amount_out:     amountOut,
+            price_impact:   priceImpact,
+            jupiter_route:  route,
+            confirmed_at:   new Date().toISOString(),
+          })
+        }
+        return  // Success
+
+      } catch (e) {
+        lastError = String(e)
+        console.error(`[jupiter-executor] Attempt ${attempt}/${this.maxRetries} failed:`, e)
+        if (attempt < this.maxRetries) {
+          await sleep(1000 * attempt)  // Exponential backoff
+        }
+      }
+    }
+
+    // All retries exhausted
+    if (dbId) {
+      await updateSwapExecution(dbId, { status: 'failed', error: lastError })
+    }
+    console.error(`[jupiter-executor] Swap failed after ${this.maxRetries} attempts:`, lastError)
+  }
+
+  private async executeWithRetry(
+    req: SwapRequest,
+    attempt: number
+  ): Promise<{ txSignature: string; amountOut: number; priceImpact: number; route: unknown }> {
+    // 1. Get Jupiter quote
+    const quote = await this.getQuote(req.fromMint, req.toMint, req.amountIn)
+
+    const priceImpact = parseFloat(quote.priceImpactPct)
+    if (priceImpact > 5) {
+      throw new Error(`Price impact too high: ${priceImpact.toFixed(2)}%`)
+    }
+
+    const amountOut = Number(quote.outAmount)
+    if (req.minAmountOut > 0 && amountOut < req.minAmountOut) {
+      throw new Error(
+        `Output ${amountOut} below minimum ${req.minAmountOut} (slippage check)`
+      )
+    }
+
+    // 2. Get swap transaction from Jupiter
+    const swapRes = await fetch(JUPITER_SWAP_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        quoteResponse: quote,
+        userPublicKey: this.executorKeypair!.publicKey.toBase58(),
+        wrapAndUnwrapSol: true,
+        computeUnitPriceMicroLamports: attempt > 1 ? 50000 * attempt : 10000,  // Increase priority on retry
+        dynamicComputeUnitLimit: true,
+      }),
+      signal: AbortSignal.timeout(15000),
+    })
+
+    if (!swapRes.ok) {
+      throw new Error(`Jupiter swap API error: ${swapRes.status} ${await swapRes.text()}`)
+    }
+
+    const swapData = await swapRes.json() as { swapTransaction: string }
+
+    // 3. Deserialize and sign
+    const txBuffer = Buffer.from(swapData.swapTransaction, 'base64')
+    const tx = VersionedTransaction.deserialize(txBuffer)
+    tx.sign([this.executorKeypair!])
+
+    // 4. Submit to chain
+    const rawTx = tx.serialize()
+    const txSignature = await this.connection.sendRawTransaction(rawTx, {
+      skipPreflight: false,
+      maxRetries: 2,
+    })
+
+    // 5. Confirm
+    const latestBlockhash = await this.connection.getLatestBlockhash()
+    await this.connection.confirmTransaction({
+      signature: txSignature,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    }, 'confirmed')
+
+    return { txSignature, amountOut, priceImpact, route: quote.routePlan }
+  }
+
+  async getQuote(
+    inputMint: string,
+    outputMint: string,
+    amount: number
+  ): Promise<JupiterQuote> {
+    const url = new URL(JUPITER_QUOTE_API)
+    url.searchParams.set('inputMint', inputMint)
+    url.searchParams.set('outputMint', outputMint)
+    url.searchParams.set('amount', String(amount))
+    url.searchParams.set('slippageBps', String(this.slippageBps))
+    url.searchParams.set('onlyDirectRoutes', 'false')
+    url.searchParams.set('asLegacyTransaction', 'false')
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10000) })
+    if (!res.ok) throw new Error(`Jupiter quote error: ${res.status} ${await res.text()}`)
+    return res.json() as Promise<JupiterQuote>
+  }
+
+  async getExecutorBalance(): Promise<number> {
+    if (!this.executorKeypair) return 0
+    const balance = await this.connection.getBalance(this.executorKeypair.publicKey)
+    return balance / LAMPORTS_PER_SOL
+  }
+
+  getExecutorPublicKey(): string | null {
+    return this.executorKeypair?.publicKey.toBase58() ?? null
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/apps/api/src/services/redis-cache.ts
+++ b/apps/api/src/services/redis-cache.ts
@@ -1,0 +1,161 @@
+/**
+ * Redis Cache Layer — Upstash Redis for serverless/edge caching
+ * 
+ * Falls back to in-memory Map if Redis is not configured.
+ * Use Upstash for production: https://upstash.com (free tier: 10,000 requests/day)
+ * 
+ * Cached data:
+ *   - Token prices (TTL: 5s for hot tokens, 60s for others)
+ *   - Yield opportunities (TTL: 5 minutes)
+ *   - Vault analytics (TTL: 10s)
+ */
+
+interface CacheEntry<T> {
+  value: T
+  expiresAt: number
+}
+
+class MemoryCache {
+  private store = new Map<string, CacheEntry<unknown>>()
+
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.store.get(key)
+    if (!entry) return null
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key)
+      return null
+    }
+    return entry.value as T
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs })
+    // Prune expired entries periodically
+    if (this.store.size > 10_000) this.prune()
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key)
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const regex = new RegExp(pattern.replace('*', '.*'))
+    return [...this.store.keys()].filter(k => regex.test(k))
+  }
+
+  private prune() {
+    const now = Date.now()
+    for (const [key, entry] of this.store) {
+      if (now > entry.expiresAt) this.store.delete(key)
+    }
+  }
+}
+
+// Redis client using Upstash REST API (no native Redis required)
+class UpstashCache {
+  private url: string
+  private token: string
+
+  constructor(url: string, token: string) {
+    this.url = url
+    this.token = token
+  }
+
+  private async cmd<T>(args: unknown[]): Promise<T | null> {
+    try {
+      const res = await fetch(`${this.url}`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${this.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(args),
+        signal: AbortSignal.timeout(2000),
+      })
+      if (!res.ok) return null
+      const data = await res.json() as { result: T }
+      return data.result
+    } catch {
+      return null
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const raw = await this.cmd<string>(['GET', key])
+    if (!raw) return null
+    try { return JSON.parse(raw) as T } catch { return null }
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    const ttlSeconds = Math.ceil(ttlMs / 1000)
+    await this.cmd(['SET', key, JSON.stringify(value), 'EX', ttlSeconds])
+  }
+
+  async del(key: string): Promise<void> {
+    await this.cmd(['DEL', key])
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const result = await this.cmd<string[]>(['KEYS', pattern])
+    return result ?? []
+  }
+}
+
+// Singleton cache instance
+const cache: MemoryCache | UpstashCache = (
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? new UpstashCache(
+        process.env.UPSTASH_REDIS_REST_URL,
+        process.env.UPSTASH_REDIS_REST_TOKEN
+      )
+    : new MemoryCache()
+)
+
+if (process.env.UPSTASH_REDIS_REST_URL) {
+  console.log('[cache] Using Upstash Redis')
+} else {
+  console.log('[cache] Using in-memory cache (set UPSTASH_REDIS_* for Redis)')
+}
+
+// ── Cache Key Namespaces ─────────────────────────────────────────────────────
+
+export const CacheKeys = {
+  price:     (mint: string)      => `price:${mint}`,
+  prices:    ()                  => 'prices:bulk',
+  analytics: (pubkey: string)   => `analytics:${pubkey}`,
+  yield:     ()                  => 'yield:opportunities',
+  agent:     (pubkey: string)   => `agent:rules:${pubkey}`,
+} as const
+
+export const CacheTTL = {
+  PRICE_HOT:   5_000,   // 5s  — SOL, USDC, major tokens
+  PRICE_COLD:  60_000,  // 60s — other tokens
+  ANALYTICS:   10_000,  // 10s — vault analytics
+  YIELD:       300_000, // 5m  — yield opportunities
+  AGENT_RULES: 60_000,  // 1m  — agent rules
+} as const
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  return cache.get<T>(key)
+}
+
+export async function cacheSet<T>(key: string, value: T, ttlMs: number): Promise<void> {
+  return cache.set(key, value, ttlMs)
+}
+
+export async function cacheDel(key: string): Promise<void> {
+  return cache.del(key)
+}
+
+export async function getCachedPrices(): Promise<Record<string, number>> {
+  return (await cacheGet<Record<string, number>>(CacheKeys.prices())) ?? {}
+}
+
+export async function setCachedPrices(prices: Record<string, number>): Promise<void> {
+  await cacheSet(CacheKeys.prices(), prices, CacheTTL.PRICE_HOT)
+  // Also set individual prices
+  await Promise.all(
+    Object.entries(prices).map(([mint, price]) =>
+      cacheSet(CacheKeys.price(mint), price, CacheTTL.PRICE_HOT)
+    )
+  )
+}

--- a/apps/api/supabase-schema.sql
+++ b/apps/api/supabase-schema.sql
@@ -1,0 +1,182 @@
+-- PotBot v2 — Supabase Schema
+-- Run this in Supabase SQL Editor: https://app.supabase.com/project/_/sql
+
+-- ─────────────────────────────────────────────────────────────
+-- price_snapshots — 5-second price history for APY calculations
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS price_snapshots (
+  id          bigserial PRIMARY KEY,
+  mint        text        NOT NULL,
+  price_usd   numeric(20, 8) NOT NULL,
+  captured_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS price_snapshots_mint_time
+  ON price_snapshots (mint, captured_at DESC);
+
+-- auto-delete prices older than 90 days
+SELECT cron.schedule(
+  'purge-old-prices',
+  '0 3 * * *',
+  $$DELETE FROM price_snapshots WHERE captured_at < now() - interval '90 days'$$
+);
+
+-- ─────────────────────────────────────────────────────────────
+-- nav_snapshots — per-vault NAV history (for APY)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS nav_snapshots (
+  id                    bigserial PRIMARY KEY,
+  pot_pubkey            text    NOT NULL,
+  nav_usd               numeric(20, 4) NOT NULL,
+  total_shares          bigint  NOT NULL,
+  sol_balance_lamports  bigint  NOT NULL,
+  captured_at           timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS nav_snapshots_pot_time
+  ON nav_snapshots (pot_pubkey, captured_at DESC);
+
+-- ─────────────────────────────────────────────────────────────
+-- positions — token positions per vault
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS positions (
+  id            bigserial PRIMARY KEY,
+  pot_pubkey    text           NOT NULL,
+  mint          text           NOT NULL,
+  symbol        text,
+  amount        numeric(30, 9) NOT NULL,
+  entry_price   numeric(20, 8) NOT NULL,
+  entry_value   numeric(20, 4) NOT NULL,
+  opened_at     timestamptz    NOT NULL DEFAULT now(),
+  closed_at     timestamptz,
+  proposal_id   integer,
+  entry_tx      text
+);
+CREATE INDEX IF NOT EXISTS positions_pot_open
+  ON positions (pot_pubkey, closed_at NULLS FIRST);
+CREATE INDEX IF NOT EXISTS positions_mint
+  ON positions (mint);
+
+-- ─────────────────────────────────────────────────────────────
+-- swap_executions — every swap attempt with full audit trail
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS swap_executions (
+  id              bigserial PRIMARY KEY,
+  pot_pubkey      text    NOT NULL,
+  proposal_id     integer NOT NULL,
+  from_mint       text    NOT NULL,
+  to_mint         text    NOT NULL,
+  amount_in       bigint  NOT NULL,
+  min_amount_out  bigint  NOT NULL,
+  amount_out      bigint,
+  price_impact    numeric(10, 6),
+  jupiter_route   jsonb,
+  tx_signature    text,
+  status          text    NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending','submitted','confirmed','failed')),
+  error           text,
+  executed_at     timestamptz NOT NULL DEFAULT now(),
+  confirmed_at    timestamptz
+);
+CREATE INDEX IF NOT EXISTS swap_executions_pot
+  ON swap_executions (pot_pubkey, executed_at DESC);
+CREATE INDEX IF NOT EXISTS swap_executions_status
+  ON swap_executions (status) WHERE status IN ('pending', 'submitted');
+
+-- ─────────────────────────────────────────────────────────────
+-- agent_rules — persistent AI agent rules per vault
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS agent_rules (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pot_pubkey      text    NOT NULL,
+  rule_id         text    NOT NULL,
+  name            text    NOT NULL,
+  enabled         boolean NOT NULL DEFAULT true,
+  trigger_type    text    NOT NULL,
+  trigger_config  jsonb   NOT NULL DEFAULT '{}',
+  action_type     text    NOT NULL,
+  action_config   jsonb   NOT NULL DEFAULT '{}',
+  cooldown_minutes integer NOT NULL DEFAULT 60,
+  last_triggered_at timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (pot_pubkey, rule_id)
+);
+CREATE INDEX IF NOT EXISTS agent_rules_pot
+  ON agent_rules (pot_pubkey);
+
+-- ─────────────────────────────────────────────────────────────
+-- agent_logs — immutable log of agent actions
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS agent_logs (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pot_pubkey      text    NOT NULL,
+  rule_id         text    NOT NULL,
+  rule_name       text    NOT NULL,
+  trigger_desc    text    NOT NULL,
+  action_desc     text    NOT NULL,
+  proposal_created boolean NOT NULL DEFAULT false,
+  proposal_id     integer,
+  tx_signature    text,
+  error           text,
+  logged_at       timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS agent_logs_pot_time
+  ON agent_logs (pot_pubkey, logged_at DESC);
+
+-- ─────────────────────────────────────────────────────────────
+-- members — cached on-chain member data for analytics
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS members (
+  id              bigserial PRIMARY KEY,
+  pot_pubkey      text    NOT NULL,
+  wallet          text    NOT NULL,
+  shares          bigint  NOT NULL DEFAULT 0,
+  deposit_total   bigint  NOT NULL DEFAULT 0,
+  withdraw_total  bigint  NOT NULL DEFAULT 0,
+  joined_at       timestamptz,
+  last_deposit_at timestamptz,
+  synced_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (pot_pubkey, wallet)
+);
+CREATE INDEX IF NOT EXISTS members_pot
+  ON members (pot_pubkey);
+
+-- ─────────────────────────────────────────────────────────────
+-- pots — cached on-chain pot metadata
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS pots (
+  pubkey              text PRIMARY KEY,
+  name                text    NOT NULL,
+  emoji               text,
+  authority           text    NOT NULL,
+  is_public           boolean NOT NULL DEFAULT false,
+  member_count        integer NOT NULL DEFAULT 0,
+  trade_count         integer NOT NULL DEFAULT 0,
+  total_volume        bigint  NOT NULL DEFAULT 0,
+  tamagotchi_level    integer NOT NULL DEFAULT 0,
+  agent_pubkey        text,
+  agent_max_trade_bps integer NOT NULL DEFAULT 0,
+  synced_at           timestamptz NOT NULL DEFAULT now(),
+  created_at          timestamptz
+);
+
+-- ─────────────────────────────────────────────────────────────
+-- Row Level Security — enable for production
+-- ─────────────────────────────────────────────────────────────
+ALTER TABLE price_snapshots   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nav_snapshots     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE positions         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE swap_executions   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_rules       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_logs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE members           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pots              ENABLE ROW LEVEL SECURITY;
+
+-- Service role has full access (API uses service key)
+CREATE POLICY service_all ON price_snapshots  FOR ALL USING (true);
+CREATE POLICY service_all ON nav_snapshots    FOR ALL USING (true);
+CREATE POLICY service_all ON positions        FOR ALL USING (true);
+CREATE POLICY service_all ON swap_executions  FOR ALL USING (true);
+CREATE POLICY service_all ON agent_rules      FOR ALL USING (true);
+CREATE POLICY service_all ON agent_logs       FOR ALL USING (true);
+CREATE POLICY service_all ON members          FOR ALL USING (true);
+CREATE POLICY service_all ON pots             FOR ALL USING (true);

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -3,23 +3,27 @@
 import { useState, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import { usePots } from '@/hooks/usePots'
+import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics'
+import { useSolPrice } from '@/lib/prices'
 import { reverseSNS } from '@/lib/sns'
 
-type SortKey = 'tvl' | 'trades' | 'members' | 'volume'
+type SortKey = 'tvl' | 'pnl' | 'apy' | 'trades' | 'members'
 
 const SORT_OPTIONS: { key: SortKey; label: string; icon: string }[] = [
-  { key: 'tvl', label: 'TVL', icon: '💰' },
-  { key: 'trades', label: 'Trades', icon: '🔄' },
-  { key: 'members', label: 'Members', icon: '👥' },
-  { key: 'volume', label: 'Volume', icon: '📈' },
+  { key: 'tvl',     label: 'TVL',    icon: '💰' },
+  { key: 'pnl',     label: 'PnL',    icon: '📈' },
+  { key: 'apy',     label: 'APY',    icon: '⚡' },
+  { key: 'trades',  label: 'Trades', icon: '🔄' },
+  { key: 'members', label: 'Members',icon: '👥' },
 ]
 
 const YIELD_LABELS: Record<number | string, string> = {
-  0: 'None', none: 'None',
-  1: 'Conservative', conservative: 'Conservative',
-  2: 'Balanced', balanced: 'Balanced',
-  3: 'Aggressive', aggressive: 'Aggressive',
-  4: 'JLP ⚡', jlp: 'JLP ⚡',
+  0: 'HODL',       hodl: 'HODL',
+  1: 'Yield',      yield: 'Yield',
+  2: 'AI DCA',     ai_dca: 'AI DCA',
+  3: 'Trend',      trend_following: 'Trend',
+  4: 'Degen ⚡',   degen: 'Degen ⚡',
+  none: 'None', conservative: 'Conservative', balanced: 'Balanced', aggressive: 'Aggressive',
 }
 
 const RANK_EMOJIS = ['🥇', '🥈', '🥉']
@@ -33,29 +37,46 @@ function rankBadge(rank: number) {
   )
 }
 
-/** Dune SIM status indicator — shows whether live data is active */
-function DuneStatusBadge({ live }: { live: boolean }) {
+function fmtUsd(usd: number): string {
+  if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(1)}M`
+  if (usd >= 1_000)     return `$${(usd / 1_000).toFixed(1)}K`
+  return `$${usd.toFixed(0)}`
+}
+
+function PnLBadge({ pct }: { pct: number }) {
+  const pos = pct >= 0
   return (
-    <div className="flex items-center gap-1.5 text-[10px] text-pot-muted">
-      <span className={`w-1.5 h-1.5 rounded-full ${live ? 'bg-pot-green animate-pulse' : 'bg-pot-muted'}`} />
-      {live ? (
-        <span className="text-pot-green">Live · Dune SIM</span>
-      ) : (
-        <span>Demo data</span>
-      )}
-    </div>
+    <span className={`text-xs font-bold ${pos ? 'text-pot-green' : 'text-red-400'}`}>
+      {pos ? '+' : ''}{pct.toFixed(1)}%
+    </span>
+  )
+}
+
+function LiveDot() {
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-pot-green">
+      <span className="w-1.5 h-1.5 rounded-full bg-pot-green animate-pulse" />
+      Live
+    </span>
   )
 }
 
 export default function LeaderboardPage() {
   const { data: pots = [], isLoading } = usePots()
+  const solUsd = useSolPrice()
   const [sortBy, setSortBy] = useState<SortKey>('tvl')
   const [search, setSearch] = useState('')
   const [snsNames, setSnsNames] = useState<Record<string, string>>({})
 
-  // Resolve SNS names for all public pots
+  const publicPots = useMemo(
+    () => (pots as any[]).filter((p: any) => p.isPublic),
+    [pots]
+  )
+  const pubkeys = useMemo(() => publicPots.map((p: any) => p.pubkey as string), [publicPots])
+  const { dataMap: analyticsMap, isAllSettled } = useVaultAnalyticsBatch(pubkeys)
+
+  // Resolve SNS names
   useEffect(() => {
-    const publicPots = (pots as any[]).filter((p: any) => p.isPublic)
     Promise.all(
       publicPots.map(async (p: any) => {
         const name = await reverseSNS(p.pubkey)
@@ -66,37 +87,47 @@ export default function LeaderboardPage() {
       results.forEach(r => { if (r.name) map[r.pubkey] = r.name })
       setSnsNames(map)
     })
-  }, [pots])
+  }, [publicPots])
 
-  const publicPots = useMemo(() => {
-    return (pots as any[]).filter((p: any) => p.isPublic)
-  }, [pots])
+  // Enrich pots with analytics
+  const enriched = useMemo(() => {
+    return publicPots.map((p: any) => {
+      const a = analyticsMap[p.pubkey]
+      const navUsd  = a?.navUsd  ?? (p.balance * (solUsd ?? 0))
+      const pnlPct  = a?.pnlPct  ?? 0
+      const apy30d  = a?.apy30d  ?? 0
+      const hasLive = !!a
+      return { ...p, navUsd, pnlPct, apy30d, hasLive }
+    })
+  }, [publicPots, analyticsMap, solUsd])
 
   const sorted = useMemo(() => {
-    const filtered = publicPots.filter((p: any) =>
+    const filtered = enriched.filter((p: any) =>
       p.name.toLowerCase().includes(search.toLowerCase()) ||
       (snsNames[p.pubkey] ?? '').includes(search.toLowerCase())
     )
     return [...filtered].sort((a: any, b: any) => {
       switch (sortBy) {
-        case 'tvl': return b.balance - a.balance
-        case 'trades': return b.tradeCount - a.tradeCount
+        case 'tvl':     return b.navUsd - a.navUsd
+        case 'pnl':     return b.pnlPct - a.pnlPct
+        case 'apy':     return b.apy30d - a.apy30d
+        case 'trades':  return b.tradeCount - a.tradeCount
         case 'members': return b.memberCount - a.memberCount
-        case 'volume': return (b.totalVolume ?? 0) - (a.totalVolume ?? 0)
-        default: return 0
+        default:        return 0
       }
     })
-  }, [publicPots, sortBy, search, snsNames])
+  }, [enriched, sortBy, search, snsNames])
 
-  const totalTvl = publicPots.reduce((s: number, p: any) => s + p.balance, 0)
-  const totalMembers = publicPots.reduce((s: number, p: any) => s + p.memberCount, 0)
-  const totalVolume = publicPots.reduce((s: number, p: any) => s + (p.totalVolume ?? 0), 0)
-  const totalTrades = publicPots.reduce((s: number, p: any) => s + p.tradeCount, 0)
+  // Global stats
+  const totalTvlUsd   = enriched.reduce((s: number, p: any) => s + p.navUsd, 0)
+  const totalTvlSol   = publicPots.reduce((s: number, p: any) => s + p.balance, 0)
+  const totalMembers  = publicPots.reduce((s: number, p: any) => s + p.memberCount, 0)
+  const totalTrades   = publicPots.reduce((s: number, p: any) => s + p.tradeCount, 0)
+  const avgApy        = enriched.length > 0
+    ? enriched.reduce((s: number, p: any) => s + p.apy30d, 0) / enriched.length
+    : 0
 
-  // Dune SIM API key status (client check)
-  const duneApiKeySet = typeof window !== 'undefined'
-    ? !!process.env.NEXT_PUBLIC_DUNE_API_KEY
-    : false
+  const liveCount = enriched.filter((p: any) => p.hasLive).length
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -107,43 +138,31 @@ export default function LeaderboardPage() {
             🏆 Leaderboard
           </h1>
           <p className="text-pot-muted text-sm mt-1">
-            Top performing public pots — ranked by TVL, trades, and activity
+            Top performing public vaults — ranked by TVL, PnL, and APY
           </p>
         </div>
-        <DuneStatusBadge live={duneApiKeySet} />
-      </div>
-
-      {/* Dune SIM Analytics Banner */}
-      <div className="bg-[#111827] border border-[#F5A623]/20 rounded-2xl p-4 mb-5 flex items-center gap-3">
-        <div className="w-8 h-8 rounded-lg bg-[#F5A623]/10 flex items-center justify-center shrink-0">
-          <span className="text-sm">📊</span>
+        <div className="flex items-center gap-1.5 text-[10px] text-pot-muted">
+          <span className={`w-1.5 h-1.5 rounded-full ${isAllSettled && liveCount > 0 ? 'bg-pot-green animate-pulse' : 'bg-pot-muted'}`} />
+          {isAllSettled && liveCount > 0
+            ? <span className="text-pot-green">{liveCount} live · Analytics API</span>
+            : <span>Loading analytics…</span>
+          }
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="text-xs font-semibold text-[#F5A623]">Dune SIM Analytics</div>
-          <div className="text-[10px] text-pot-muted mt-0.5">
-            Real-time portfolio data powered by Dune SIM · Add{' '}
-            <code className="bg-pot-dark px-1 rounded text-[9px]">NEXT_PUBLIC_DUNE_API_KEY</code>
-            {' '}to enable live balances
-          </div>
-        </div>
-        <a
-          href="https://docs.sim.dune.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-[10px] text-[#F5A623] hover:underline shrink-0"
-        >
-          Docs →
-        </a>
       </div>
 
       {/* Global stats */}
-      <div className="grid grid-cols-4 gap-3 mb-6">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
         <div className="bg-pot-card border border-pot-border rounded-2xl p-4 text-center">
           <div className="text-2xl font-bold text-pot-green">{publicPots.length}</div>
-          <div className="text-xs text-pot-muted mt-1">Public POTs</div>
+          <div className="text-xs text-pot-muted mt-1">Public Vaults</div>
         </div>
         <div className="bg-pot-card border border-pot-border rounded-2xl p-4 text-center">
-          <div className="text-2xl font-bold text-white">{totalTvl.toFixed(1)} SOL</div>
+          <div className="text-2xl font-bold text-white">
+            {solUsd ? fmtUsd(totalTvlUsd) : `${totalTvlSol.toFixed(1)} SOL`}
+          </div>
+          {solUsd && (
+            <div className="text-[10px] text-pot-muted">{totalTvlSol.toFixed(1)} SOL</div>
+          )}
           <div className="text-xs text-pot-muted mt-1">Combined TVL</div>
         </div>
         <div className="bg-pot-card border border-pot-border rounded-2xl p-4 text-center">
@@ -151,8 +170,12 @@ export default function LeaderboardPage() {
           <div className="text-xs text-pot-muted mt-1">Total Members</div>
         </div>
         <div className="bg-pot-card border border-pot-border rounded-2xl p-4 text-center">
-          <div className="text-2xl font-bold text-white">{totalTrades}</div>
-          <div className="text-xs text-pot-muted mt-1">Total Trades</div>
+          <div className={`text-2xl font-bold ${avgApy > 0 ? 'text-pot-green' : 'text-white'}`}>
+            {avgApy > 0 ? `${avgApy.toFixed(1)}%` : `${totalTrades}`}
+          </div>
+          <div className="text-xs text-pot-muted mt-1">
+            {avgApy > 0 ? 'Avg APY 30d' : 'Total Trades'}
+          </div>
         </div>
       </div>
 
@@ -160,7 +183,7 @@ export default function LeaderboardPage() {
       <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <input
           type="text"
-          placeholder="Search pots or .potbot.sol names..."
+          placeholder="Search vaults or .potbot.sol names..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="flex-1 bg-pot-card border border-pot-border rounded-xl px-4 py-2.5 text-sm text-white placeholder:text-pot-muted outline-none focus:border-pot-accent transition"
@@ -182,18 +205,18 @@ export default function LeaderboardPage() {
         </div>
       </div>
 
-      {/* Table header */}
-      <div className="hidden sm:grid grid-cols-[3rem_1fr_7rem_5rem_5rem_7rem_7rem] gap-3 px-4 py-2 text-[10px] font-medium text-pot-muted uppercase tracking-wider">
+      {/* Table header — desktop */}
+      <div className="hidden sm:grid grid-cols-[3rem_1fr_8rem_6rem_6rem_5rem_6rem] gap-3 px-4 py-2 text-[10px] font-medium text-pot-muted uppercase tracking-wider">
         <div>#</div>
-        <div>POT</div>
+        <div>Vault</div>
         <div className="text-right">TVL</div>
+        <div className="text-right">All-time PnL</div>
+        <div className="text-right">APY 30d</div>
         <div className="text-right">Trades</div>
-        <div className="text-right">Members</div>
-        <div className="text-right">Volume</div>
         <div className="text-right">Strategy</div>
       </div>
 
-      {/* Leaderboard rows */}
+      {/* Rows */}
       {isLoading ? (
         <div className="space-y-2">
           {[1, 2, 3, 4, 5].map(i => (
@@ -205,23 +228,20 @@ export default function LeaderboardPage() {
       ) : sorted.length === 0 ? (
         <div className="bg-pot-card border border-pot-border rounded-2xl p-12 text-center">
           <div className="text-4xl mb-3">🌍</div>
-          <h3 className="text-lg font-semibold text-white mb-1">No public pots yet</h3>
+          <h3 className="text-lg font-semibold text-white mb-1">No public vaults yet</h3>
           <p className="text-pot-muted text-sm mb-4">
-            {search ? 'No pots match your search' : 'Create a public pot to appear here'}
+            {search ? 'No vaults match your search' : 'Create a public vault to appear here'}
           </p>
           <Link href="/create" className="btn-primary text-sm">
-            Create a Public POT
+            Create a Public Vault
           </Link>
         </div>
       ) : (
         <div className="space-y-2">
           {sorted.map((pot: any, idx: number) => {
-            const volumeEfficiency = pot.totalVolume > 0 && pot.balance > 0
-              ? (pot.totalVolume / pot.balance).toFixed(1)
-              : '—'
-            const yieldLabel = YIELD_LABELS[pot.yieldStrategy] ?? 'None'
-            const isTop3 = idx < 3
-            const snsName = snsNames[pot.pubkey]
+            const isTop3    = idx < 3
+            const snsName   = snsNames[pot.pubkey]
+            const yieldLabel= YIELD_LABELS[pot.yieldStrategy] ?? 'None'
 
             return (
               <Link
@@ -250,13 +270,19 @@ export default function LeaderboardPage() {
                       {pot.name}
                     </div>
                     <div className="text-[10px] text-pot-muted flex items-center gap-1.5">
-                      {snsName ? (
+                      {snsName && (
                         <>
                           <span className="text-pot-green font-mono">{snsName}</span>
                           <span>·</span>
                         </>
-                      ) : null}
-                      <span>{pot.tamagotchiEmoji} Lvl {pot.tamagotchiLevel}</span>
+                      )}
+                      <span>{pot.memberCount} members</span>
+                      {pot.hasLive && (
+                        <>
+                          <span>·</span>
+                          <LiveDot />
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -264,30 +290,40 @@ export default function LeaderboardPage() {
                 {/* Stats — desktop */}
                 <div className="hidden sm:flex items-center gap-3 shrink-0">
                   {/* TVL */}
-                  <div className="w-[7rem] text-right">
+                  <div className="w-[8rem] text-right">
                     <div className={`text-sm font-bold ${isTop3 ? 'text-pot-green' : 'text-white'}`}>
-                      {pot.balance.toFixed(2)} SOL
+                      {solUsd && pot.navUsd > 0 ? fmtUsd(pot.navUsd) : `${pot.balance.toFixed(2)} SOL`}
                     </div>
-                    <div className="text-[10px] text-pot-muted">TVL</div>
+                    {solUsd && pot.navUsd > 0 && (
+                      <div className="text-[10px] text-pot-muted">{pot.balance.toFixed(2)} SOL</div>
+                    )}
+                  </div>
+                  {/* PnL */}
+                  <div className="w-[6rem] text-right">
+                    {pot.hasLive ? (
+                      <PnLBadge pct={pot.pnlPct} />
+                    ) : (
+                      <span className="text-xs text-pot-muted">—</span>
+                    )}
+                  </div>
+                  {/* APY */}
+                  <div className="w-[6rem] text-right">
+                    {pot.hasLive && pot.apy30d !== 0 ? (
+                      <span className={`text-sm font-bold ${pot.apy30d >= 0 ? 'text-pot-green' : 'text-red-400'}`}>
+                        {pot.apy30d >= 0 ? '+' : ''}{pot.apy30d.toFixed(1)}%
+                      </span>
+                    ) : (
+                      <span className="text-xs text-pot-muted">—</span>
+                    )}
                   </div>
                   {/* Trades */}
                   <div className="w-[5rem] text-right">
                     <div className="text-sm font-medium text-white">{pot.tradeCount}</div>
                     <div className="text-[10px] text-pot-muted">trades</div>
                   </div>
-                  {/* Members */}
-                  <div className="w-[5rem] text-right">
-                    <div className="text-sm font-medium text-white">{pot.memberCount}</div>
-                    <div className="text-[10px] text-pot-muted">members</div>
-                  </div>
-                  {/* Volume */}
-                  <div className="w-[7rem] text-right">
-                    <div className="text-sm font-medium text-white">{(pot.totalVolume ?? 0).toFixed(1)} SOL</div>
-                    <div className="text-[10px] text-pot-muted">{volumeEfficiency}× ratio</div>
-                  </div>
                   {/* Strategy */}
-                  <div className="w-[7rem] text-right">
-                    <div className="text-xs text-pot-muted px-2 py-0.5 bg-pot-dark rounded-lg">
+                  <div className="w-[6rem] text-right">
+                    <div className="text-xs text-pot-muted px-2 py-0.5 bg-pot-dark rounded-lg inline-block">
                       {yieldLabel}
                     </div>
                   </div>
@@ -296,8 +332,10 @@ export default function LeaderboardPage() {
                 {/* Stats — mobile */}
                 <div className="flex sm:hidden items-center gap-4 shrink-0">
                   <div className="text-right">
-                    <div className="text-sm font-bold text-pot-green">{pot.balance.toFixed(1)} SOL</div>
-                    <div className="text-[10px] text-pot-muted">{pot.memberCount} members</div>
+                    <div className="text-sm font-bold text-pot-green">
+                      {solUsd && pot.navUsd > 0 ? fmtUsd(pot.navUsd) : `${pot.balance.toFixed(1)} SOL`}
+                    </div>
+                    {pot.hasLive && <PnLBadge pct={pot.pnlPct} />}
                   </div>
                   <span className="text-pot-muted text-sm">→</span>
                 </div>
@@ -307,23 +345,27 @@ export default function LeaderboardPage() {
         </div>
       )}
 
-      {/* Volume analytics row */}
+      {/* Ecosystem Analytics footer */}
       {!isLoading && sorted.length > 0 && (
         <div className="mt-4 bg-pot-card border border-pot-border rounded-2xl p-4">
           <div className="flex items-center gap-2 mb-3">
             <span className="text-sm">📊</span>
             <span className="text-xs font-semibold text-white">Ecosystem Analytics</span>
-            <span className="text-[10px] text-pot-muted ml-auto">Dune SIM · refreshes every 30s</span>
+            <span className="text-[10px] text-pot-muted ml-auto">Analytics API · refreshes every 8s</span>
           </div>
           <div className="grid grid-cols-3 gap-3">
             <div>
-              <div className="text-xs text-pot-muted mb-0.5">Total Volume</div>
-              <div className="text-sm font-bold text-white">{totalVolume.toFixed(1)} SOL</div>
+              <div className="text-xs text-pot-muted mb-0.5">Combined TVL</div>
+              <div className="text-sm font-bold text-white">
+                {solUsd ? fmtUsd(totalTvlUsd) : `${totalTvlSol.toFixed(1)} SOL`}
+              </div>
             </div>
             <div>
               <div className="text-xs text-pot-muted mb-0.5">Avg Vault Size</div>
               <div className="text-sm font-bold text-white">
-                {publicPots.length > 0 ? (totalTvl / publicPots.length).toFixed(1) : '0'} SOL
+                {publicPots.length > 0
+                  ? (solUsd ? fmtUsd(totalTvlUsd / publicPots.length) : `${(totalTvlSol / publicPots.length).toFixed(1)} SOL`)
+                  : '—'}
               </div>
             </div>
             <div>
@@ -339,13 +381,14 @@ export default function LeaderboardPage() {
         <div className="text-2xl mb-2">🚀</div>
         <h3 className="text-sm font-semibold text-white mb-1">Want to be on this list?</h3>
         <p className="text-xs text-pot-muted mb-4">
-          Create a public pot and start building your trading track record. Get your own <code className="bg-pot-dark px-1 rounded">{'{name}.potbot.sol'}</code> domain.
+          Create a public vault and start building your on-chain track record.
+          Get your own <code className="bg-pot-dark px-1 rounded">'{'{name}.potbot.sol'}'</code> domain.
         </p>
         <Link
           href="/create"
           className="inline-flex items-center gap-2 px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-xl text-sm font-semibold transition"
         >
-          🪴 Create a POT
+          🪴 Create a Vault
         </Link>
       </div>
     </div>

--- a/apps/web/src/app/my-pots/page.tsx
+++ b/apps/web/src/app/my-pots/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useWallet } from '@solana/wallet-adapter-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { usePots } from '@/hooks/usePots'
 import { useMockStore } from '@/lib/mock-store'
 import { calculateTamaStats } from '@/lib/tamagotchi/stats'
+import { useSolPrice } from '@/lib/prices'
+import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics'
 import SNSRegistrarPanel from '@/components/SNSRegistrarPanel'
 
 const WalletMultiButton = dynamic(
@@ -25,23 +27,39 @@ const YIELD_LABELS: Record<number, string> = {
 export default function MyPotsPage() {
   const { publicKey, connected } = useWallet()
   const { data: allPots, isLoading } = usePots()
+  const { price: solPrice } = useSolPrice()
   const walletStr = publicKey?.toBase58() ?? ''
 
-  // Get all member records for connected wallet from mock store
   const allMembers = useMockStore.getState().members
   const myMemberships = allMembers.filter((m) => m.wallet === walletStr)
   const myPotPubkeys = new Set(myMemberships.map((m) => m.potPubkey))
 
-  // Filter pots: member OR creator
   const myPots = (allPots ?? []).filter(
     (p: any) => myPotPubkeys.has(p.pubkey) || p.authority === walletStr
   )
 
+  // Fetch analytics for all my pots in parallel
+  const myPotKeys = useMemo(() => myPots.map((p: any) => p.pubkey), [myPots])
+  const { dataMap: analyticsMap, isLoading: analyticsLoading } = useVaultAnalyticsBatch(myPotKeys)
+
   // Portfolio totals
-  const totalBalance = myPots.reduce((s: number, p: any) => s + (p.balance ?? 0), 0)
-  const totalYield   = myPots.reduce((s: number, p: any) => s + ((p as any).totalYieldEarned ?? 0), 0)
-  const totalVolume  = myPots.reduce((s: number, p: any) => s + ((p as any).totalVolume ?? 0), 0)
+  const totalBalanceSol = myPots.reduce((s: number, p: any) => s + (p.balance ?? 0), 0)
+  const totalBalanceUsd = myPots.reduce((s: number, p: any) => {
+    const analytics = analyticsMap[p.pubkey]
+    return s + (analytics?.navUsd ?? (p.balance * (solPrice ?? 0)))
+  }, 0)
+  const totalPnlUsd = myPots.reduce((s: number, p: any) => {
+    const a = analyticsMap[p.pubkey]
+    return s + (a?.pnlUsd ?? 0)
+  }, 0)
   const totalShares  = myMemberships.reduce((s, m) => s + m.shares, 0)
+  const totalYield   = myPots.reduce((s: number, p: any) => s + ((p as any).totalYieldEarned ?? 0), 0)
+
+  function fmtUsd(v: number): string {
+    if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(2)}M`
+    if (v >= 1_000)     return `$${(v / 1_000).toFixed(1)}K`
+    return `$${v.toFixed(0)}`
+  }
 
   /* ── Not connected ── */
   if (!connected) {
@@ -76,18 +94,48 @@ export default function MyPotsPage() {
 
       {/* ── Portfolio Stats ── */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        {[
-          { label: 'Total Balance',  value: `${totalBalance.toFixed(3)} SOL`, icon: '◎',  color: 'text-pot-green'  },
-          { label: 'My POTs',        value: String(myPots.length),             icon: '🪴', color: 'text-white'       },
-          { label: 'Yield Earned',   value: `${totalYield.toFixed(4)} SOL`,    icon: '🌱', color: 'text-teal-400'   },
-          { label: 'Total Shares',   value: totalShares.toLocaleString(),      icon: '🪙', color: 'text-pot-accent'  },
-        ].map(({ label, value, icon, color }) => (
-          <div key={label} className="card p-4 text-center">
-            <div className="text-2xl mb-1.5">{icon}</div>
-            <div className={`font-bold font-mono text-lg ${color}`}>{value}</div>
-            <div className="text-xs text-pot-muted mt-1">{label}</div>
+        {/* Total portfolio value */}
+        <div className="card p-4 text-center col-span-2 md:col-span-1">
+          <div className="text-2xl mb-1.5">💰</div>
+          {analyticsLoading && totalBalanceUsd === 0 ? (
+            <div className="h-7 w-20 bg-pot-border rounded animate-pulse mx-auto mb-1" />
+          ) : (
+            <div className="font-bold font-mono text-lg text-pot-green">
+              {totalBalanceUsd > 0 ? fmtUsd(totalBalanceUsd) : `${totalBalanceSol.toFixed(3)} SOL`}
+            </div>
+          )}
+          <div className="text-xs text-pot-muted mt-1">
+            Portfolio Value
+            {totalBalanceSol > 0 && totalBalanceUsd > 0 && (
+              <span className="ml-1 text-pot-border/70">· {totalBalanceSol.toFixed(2)} SOL</span>
+            )}
           </div>
-        ))}
+        </div>
+
+        {/* All-time PnL */}
+        <div className="card p-4 text-center">
+          <div className="text-2xl mb-1.5">📈</div>
+          <div className={`font-bold font-mono text-lg ${
+            totalPnlUsd >= 0 ? 'text-pot-green' : 'text-red-400'
+          }`}>
+            {totalPnlUsd >= 0 ? '+' : ''}{fmtUsd(Math.abs(totalPnlUsd))}
+          </div>
+          <div className="text-xs text-pot-muted mt-1">All-time PnL</div>
+        </div>
+
+        {/* My POTs count */}
+        <div className="card p-4 text-center">
+          <div className="text-2xl mb-1.5">🪴</div>
+          <div className="font-bold font-mono text-lg text-white">{myPots.length}</div>
+          <div className="text-xs text-pot-muted mt-1">My POTs</div>
+        </div>
+
+        {/* Shares */}
+        <div className="card p-4 text-center">
+          <div className="text-2xl mb-1.5">🪙</div>
+          <div className="font-bold font-mono text-lg text-pot-accent">{totalShares.toLocaleString()}</div>
+          <div className="text-xs text-pot-muted mt-1">Total Shares</div>
+        </div>
       </div>
 
       {/* ── SNS Identity Panel ── */}
@@ -113,20 +161,25 @@ export default function MyPotsPage() {
       ) : (
         <div className="space-y-3">
           {myPots.map((pot: any) => {
-            const membership = myMemberships.find((m) => m.potPubkey === pot.pubkey)
-            const isCreator = pot.authority === walletStr
-            const sharesPct = pot.totalShares > 0 && membership
+            const membership    = myMemberships.find((m) => m.potPubkey === pot.pubkey)
+            const analytics     = analyticsMap[pot.pubkey]
+            const isCreator     = pot.authority === walletStr
+            const sharesPct     = pot.totalShares > 0 && membership
               ? (membership.shares / pot.totalShares) * 100
               : 0
-            const navGrowth = pot.navPerShareBps
-              ? ((pot.navPerShareBps / 10000) - 1) * 100
-              : 0
+            // My share of the pot value
+            const myValueUsd    = analytics?.navUsd
+              ? (sharesPct / 100) * analytics.navUsd
+              : (sharesPct / 100) * (pot.balance * (solPrice ?? 0))
+            const pnlPct        = analytics?.pnlPct ?? 0
+            const apy30d        = analytics?.apy30d ?? 0
+
             const tama = calculateTamaStats({
               tradeVolume: (pot.totalVolume ?? pot.tradeCount * 2),
               memberCount: pot.memberCount,
               winRate: 0.6,
               yieldApy: 0.08,
-              ageSeconds: (Date.now() - pot.createdAt) / 1000,
+              ageSeconds: (Date.now() - (typeof pot.createdAt === 'number' ? pot.createdAt : (pot.createdAt as Date)?.getTime() ?? Date.now())) / 1000,
             })
 
             return (
@@ -138,7 +191,6 @@ export default function MyPotsPage() {
 
                   {/* Left */}
                   <div className="flex items-start gap-4 flex-1 min-w-0">
-                    {/* Emoji + tamagotchi */}
                     <div className="relative shrink-0 mt-0.5">
                       <span className="text-3xl">{pot.emoji}</span>
                       <span className="absolute -bottom-1 -right-1 text-sm">{tama.emoji}</span>
@@ -178,31 +230,33 @@ export default function MyPotsPage() {
                             </span>
                           </span>
                         )}
-                        {(pot.totalYieldEarned ?? 0) > 0 && (
+                        {myValueUsd > 0 && (
                           <span>
-                            Yield:{' '}
-                            <span className="text-teal-400 font-mono">+{(pot.totalYieldEarned ?? 0).toFixed(4)} SOL</span>
+                            My value:{' '}
+                            <span className="text-pot-green font-mono">{fmtUsd(myValueUsd)}</span>
                           </span>
                         )}
-                        <span>
-                          {pot.memberCount} member{pot.memberCount !== 1 ? 's' : ''}
-                        </span>
+                        <span>{pot.memberCount} member{pot.memberCount !== 1 ? 's' : ''}</span>
                       </div>
                     </div>
                   </div>
 
-                  {/* Right: NAV + button */}
+                  {/* Right: analytics + button */}
                   <div className="flex flex-col items-end gap-2 shrink-0">
-                    {navGrowth !== 0 && (
+                    {analyticsLoading ? (
+                      <div className="h-8 w-16 bg-pot-border rounded animate-pulse" />
+                    ) : analytics ? (
                       <div className="text-right">
                         <div className={`text-sm font-mono font-bold ${
-                          navGrowth >= 0 ? 'text-pot-green' : 'text-red-400'
+                          pnlPct >= 0 ? 'text-pot-green' : 'text-red-400'
                         }`}>
-                          {navGrowth >= 0 ? '+' : ''}{navGrowth.toFixed(2)}%
+                          {pnlPct >= 0 ? '+' : ''}{pnlPct.toFixed(2)}%
                         </div>
-                        <div className="text-[10px] text-pot-muted">NAV/share</div>
+                        <div className="text-[10px] text-pot-muted">
+                          {apy30d > 0 ? `${apy30d.toFixed(1)}% APY` : 'PnL'}
+                        </div>
                       </div>
-                    )}
+                    ) : null}
                     <Link
                       href={`/pots/${pot.pubkey}`}
                       className="btn-primary text-xs px-4 py-2 whitespace-nowrap group-hover:shadow-lg group-hover:shadow-pot-accent/20 transition-all"
@@ -212,9 +266,35 @@ export default function MyPotsPage() {
                   </div>
                 </div>
 
-                {/* Ownership progress bar */}
+                {/* Analytics bar */}
+                {analytics && (
+                  <div className="mt-3 pt-3 border-t border-pot-border flex flex-wrap gap-4 text-xs">
+                    <div>
+                      <span className="text-pot-muted">NAV </span>
+                      <span className="font-mono text-white">{fmtUsd(analytics.navUsd)}</span>
+                    </div>
+                    {analytics.apy30d > 0 && (
+                      <div>
+                        <span className="text-pot-muted">APY 30d </span>
+                        <span className="font-mono text-pot-accent">{analytics.apy30d.toFixed(1)}%</span>
+                      </div>
+                    )}
+                    {analytics.positions && analytics.positions.length > 0 && (
+                      <div>
+                        <span className="text-pot-muted">Positions </span>
+                        <span className="font-mono text-white">{analytics.positions.length}</span>
+                      </div>
+                    )}
+                    <div className="ml-auto">
+                      <span className="w-1.5 h-1.5 rounded-full bg-pot-green animate-pulse inline-block mr-1" />
+                      <span className="text-pot-muted text-[10px]">Live</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Ownership bar */}
                 {membership && pot.totalShares > 0 && (
-                  <div className="mt-4 pt-3 border-t border-pot-border">
+                  <div className="mt-3 pt-3 border-t border-pot-border">
                     <div className="flex justify-between text-[10px] text-pot-muted mb-1.5">
                       <span>My ownership in pool</span>
                       <span className="font-mono">{sharesPct.toFixed(2)}%</span>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useWallet } from '@solana/wallet-adapter-react'
 import dynamic from 'next/dynamic'
 import { usePots } from '@/hooks/usePots'
 import { useMockStore } from '@/lib/mock-store'
+import { useSolPrice } from '@/lib/prices'
 
 const WalletMultiButton = dynamic(
   async () => (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
@@ -23,12 +24,12 @@ const YIELD_LABELS: Record<number, string> = {
 export default function DashboardPage() {
   const { publicKey, connected } = useWallet()
   const { data: pots, isLoading } = usePots()
+  const { price: solPrice } = useSolPrice()
   const [search, setSearch]     = useState('')
   const [tab, setTab]           = useState<'all' | 'mine'>('all')
 
   const walletStr = publicKey?.toBase58() ?? ''
 
-  // My pot pubkeys via membership + authority
   const myPotPubkeys = useMemo(() => {
     if (!walletStr) return new Set<string>()
     const members = useMockStore.getState().members
@@ -52,7 +53,8 @@ export default function DashboardPage() {
     [basePots, search]
   )
 
-  const totalTvl     = pots?.reduce((sum, p) => sum + p.balance, 0) ?? 0
+  const totalTvlSol  = pots?.reduce((sum, p) => sum + p.balance, 0) ?? 0
+  const totalTvlUsd  = solPrice ? totalTvlSol * solPrice : 0
   const totalMembers = pots?.reduce((sum, p) => sum + p.memberCount, 0) ?? 0
   const totalTrades  = pots?.reduce((sum, p) => sum + p.tradeCount, 0) ?? 0
 
@@ -67,35 +69,61 @@ export default function DashboardPage() {
         <p className="text-pot-muted text-lg max-w-md">
           Create collective trading vaults on Solana. Govern together, trade together, win together.
         </p>
+
+        {/* TVL badge */}
+        {totalTvlSol > 0 && (
+          <div className="flex items-center gap-3 bg-pot-card border border-pot-border rounded-2xl px-5 py-3">
+            <div className="text-center">
+              <div className="text-xl font-bold text-pot-green">
+                {totalTvlUsd > 0 ? `$${totalTvlUsd >= 1000 ? (totalTvlUsd / 1000).toFixed(0) + 'K' : totalTvlUsd.toFixed(0)}` : `${totalTvlSol.toFixed(1)} SOL`}
+              </div>
+              <div className="text-xs text-pot-muted">Total Locked</div>
+            </div>
+            <div className="w-px h-8 bg-pot-border" />
+            <div className="text-center">
+              <div className="text-xl font-bold text-white">{pots?.length ?? 0}</div>
+              <div className="text-xs text-pot-muted">Active Vaults</div>
+            </div>
+            <div className="w-px h-8 bg-pot-border" />
+            <div className="text-center">
+              <div className="text-xl font-bold text-white">{totalMembers}</div>
+              <div className="text-xs text-pot-muted">Members</div>
+            </div>
+          </div>
+        )}
+
         <div className="flex gap-4">
           <WalletMultiButton />
+          <Link href="/vaults" className="btn-secondary text-sm">
+            ⚡ Browse Vaults
+          </Link>
         </div>
 
         {/* Feature cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-8 max-w-3xl w-full">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4 max-w-3xl w-full">
           <div className="card p-5 text-center">
             <div className="text-3xl mb-2">🏦</div>
             <h3 className="font-semibold text-white mb-1">Group Vaults</h3>
             <p className="text-pot-muted text-sm">Pool SOL with friends into shared trading vaults</p>
           </div>
           <div className="card p-5 text-center">
-            <div className="text-3xl mb-2">🗳\ufe0f</div>
+            <div className="text-3xl mb-2">🗾️</div>
             <h3 className="font-semibold text-white mb-1">Governance</h3>
             <p className="text-pot-muted text-sm">Vote on trades with share-weighted governance</p>
           </div>
           <div className="card p-5 text-center">
-            <div className="text-3xl mb-2">🐣</div>
-            <h3 className="font-semibold text-white mb-1">Tamagotchi</h3>
-            <p className="text-pot-muted text-sm">Your vault evolves as it trades and grows</p>
+            <div className="text-3xl mb-2">🤖</div>
+            <h3 className="font-semibold text-white mb-1">AI Agent</h3>
+            <p className="text-pot-muted text-sm">MCP-native agents automate your strategy 24/7</p>
           </div>
         </div>
 
-        <div className="flex gap-3 mt-4">
+        <div className="flex gap-3 mt-2">
           <p className="text-pot-muted text-xs self-center">
             Demo mode active — no wallet needed to explore
           </p>
           <Link href="/leaderboard" className="btn-secondary text-sm flex items-center gap-1.5">
-            🏆 View Leaderboard
+            🏆 Leaderboard
           </Link>
         </div>
       </div>
@@ -112,8 +140,17 @@ export default function DashboardPage() {
           <div className="text-xs text-pot-muted mt-1">Active POTs</div>
         </div>
         <div className="card p-4 text-center">
-          <div className="text-2xl font-bold text-white">{totalTvl.toFixed(1)} SOL</div>
-          <div className="text-xs text-pot-muted mt-1">Total TVL</div>
+          <div className="text-2xl font-bold text-white">
+            {totalTvlUsd > 0
+              ? `$${totalTvlUsd >= 1000 ? (totalTvlUsd / 1000).toFixed(1) + 'K' : totalTvlUsd.toFixed(0)}`
+              : `${totalTvlSol.toFixed(1)} SOL`}
+          </div>
+          <div className="text-xs text-pot-muted mt-1">
+            Total TVL
+            {totalTvlUsd > 0 && (
+              <span className="ml-1 text-pot-border">· {totalTvlSol.toFixed(1)} SOL</span>
+            )}
+          </div>
         </div>
         <div className="card p-4 text-center">
           <div className="text-2xl font-bold text-white">{totalMembers}</div>
@@ -139,7 +176,7 @@ export default function DashboardPage() {
             </div>
           </div>
         </div>
-        <span className="text-pot-muted text-sm group-hover:text-white transition">View \u2192</span>
+        <span className="text-pot-muted text-sm group-hover:text-white transition">View →</span>
       </Link>
 
       {/* Header + Search + Tabs */}
@@ -188,11 +225,8 @@ export default function DashboardPage() {
           )}
         </button>
         {tab === 'mine' && (
-          <Link
-            href="/my-pots"
-            className="ml-auto text-xs text-pot-muted hover:text-white transition"
-          >
-            Full dashboard \u2192
+          <Link href="/my-pots" className="ml-auto text-xs text-pot-muted hover:text-white transition">
+            Full dashboard →
           </Link>
         )}
       </div>
@@ -236,20 +270,19 @@ export default function DashboardPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {filtered.map((pot) => {
             const isMine = myPotPubkeys.has(pot.pubkey) || pot.authority === walletStr
+            const balanceUsd = solPrice ? pot.balance * solPrice : 0
             return (
               <Link
                 key={pot.pubkey}
                 href={`/pots/${pot.pubkey}`}
                 className="card p-5 hover:border-pot-green/30 transition-all group relative"
               >
-                {/* Mine badge */}
                 {isMine && tab === 'all' && (
                   <span className="absolute top-3 right-3 text-[10px] px-1.5 py-0.5 rounded-full bg-pot-accent/10 text-pot-accent border border-pot-accent/20">
                     Mine
                   </span>
                 )}
 
-                {/* Header */}
                 <div className="flex items-center justify-between mb-3">
                   <div className="flex items-center gap-2">
                     <span className="text-2xl group-hover:animate-float">{pot.emoji}</span>
@@ -263,12 +296,18 @@ export default function DashboardPage() {
                   <span className="text-xl">{pot.tamagotchiEmoji}</span>
                 </div>
 
-                {/* Balance */}
-                <div className="text-xl font-bold text-pot-green mb-3">
-                  {pot.balance.toFixed(2)} SOL
+                {/* Balance in SOL + USD */}
+                <div className="mb-3">
+                  <div className="text-xl font-bold text-pot-green">
+                    {pot.balance.toFixed(2)} SOL
+                  </div>
+                  {balanceUsd > 0 && (
+                    <div className="text-xs text-pot-muted font-mono">
+                      ≈ ${balanceUsd >= 1000 ? (balanceUsd / 1000).toFixed(1) + 'K' : balanceUsd.toFixed(0)}
+                    </div>
+                  )}
                 </div>
 
-                {/* Stats */}
                 <div className="grid grid-cols-3 gap-2 text-xs">
                   <div className="bg-pot-dark rounded-lg p-2 text-center">
                     <div className="text-white font-medium">{pot.memberCount}</div>
@@ -286,7 +325,6 @@ export default function DashboardPage() {
                   </div>
                 </div>
 
-                {/* Tags */}
                 <div className="flex gap-2 mt-3">
                   <span className={`text-xs px-2 py-0.5 rounded-full ${
                     pot.isPublic

--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { calculateTamaStats } from '@/lib/tamagotchi/stats'
 import { SharesPanel } from '@/components/SharesPanel'
 import { PnLDashboard } from '@/components/PnLDashboard'
+import { VaultAnalyticsStrip } from '@/components/VaultAnalyticsStrip'
 import { StrategyPanel } from '@/components/StrategyPanel'
 import { AIAgentPanel } from '@/components/AIAgentPanel'
 import { GovernanceSettings } from '@/components/GovernanceSettings'
@@ -135,6 +136,7 @@ export default function PotDetailPage() {
               <span>Members: <span className="text-white">{pot.memberCount}</span></span>
               <span>Trades: <span className="text-white">{pot.tradeCount}</span></span>
             </div>
+            <VaultAnalyticsStrip pubkey={pubkey} />
           </div>
 
           {/* Tamagotchi */}

--- a/apps/web/src/app/vaults/page.tsx
+++ b/apps/web/src/app/vaults/page.tsx
@@ -2,150 +2,326 @@
 
 import React, { useState, useMemo } from 'react';
 import Link from 'next/link';
+import { usePots } from '@/hooks/usePots';
+import { useSolPrice } from '@/lib/prices';
+import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics';
 
-const VAULTS = [
-  { pubkey: 'alpha_dca_001', name: 'Alpha Squad DCA', emoji: '🎯', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'influencer', creatorHandle: '@CryptoYDao', memberCount: 127, aumUsd: 48200, pnl30d: 12.4, tamagotchiLevel: 2, tamagotchiEmoji: '🐥', entryFeeUsd: 5, performanceFeeBps: 1000, isAiAgent: false, },
-  { pubkey: 'sol_bull_002', name: 'SOL Bull Market Fund', emoji: '🐂', strategyType: 'trend_following', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Sensei', memberCount: 89, aumUsd: 31400, pnl30d: 8.7, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 10, performanceFeeBps: 1500, isAiAgent: false, },
-  { pubkey: 'ai_dca_bot_003', name: 'Autonomous DCA Engine', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'conservative', creatorType: 'ai_agent', creatorHandle: 'DCA Bot #7', memberCount: 312, aumUsd: 127000, pnl30d: 6.2, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 500, isAiAgent: true, },
-  { pubkey: 'degen_mode_004', name: 'Degen Mode', emoji: '🎰', strategyType: 'degen', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Moon_Bro', memberCount: 45, aumUsd: 12800, pnl30d: 34.1, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 20, performanceFeeBps: 2000, isAiAgent: false, },
-  { pubkey: 'yield_dao_005', name: 'Yield Farmers DAO', emoji: '🌾', strategyType: 'yield', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Y-DAO', memberCount: 203, aumUsd: 89500, pnl30d: 4.1, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 800, isAiAgent: false, },
-  { pubkey: 'ai_treasury_006', name: 'AI Treasury Manager', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'ai_agent', creatorHandle: 'Treasury AI v1', memberCount: 567, aumUsd: 234000, pnl30d: 9.8, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 700, isAiAgent: true, },
-  { pubkey: 'contra_007', name: 'Contrarian Club', emoji: '🔄', strategyType: 'mean_reversion', riskLevel: 'balanced', creatorType: 'trader', creatorHandle: 'Zig_Zag', memberCount: 67, aumUsd: 22100, pnl30d: 5.3, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 5, performanceFeeBps: 1200, isAiAgent: false, },
-  { pubkey: 'diamond_008', name: 'Diamond Hands DAO', emoji: '💎', strategyType: 'hodl', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Diamond DAO', memberCount: 891, aumUsd: 445000, pnl30d: 18.2, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 300, isAiAgent: false, },
+// ─────────────────────────────────────────────────────────────────
+// Demo data — shown when the on-chain program isn't deployed yet
+// ─────────────────────────────────────────────────────────────────
+const DEMO_VAULTS = [
+  { pubkey: 'alpha_dca_001', name: 'Alpha Squad DCA', emoji: '🎯', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'influencer', creatorHandle: '@CryptoYDao', memberCount: 127, aumUsd: 48200, pnl30d: 12.4, tamagotchiLevel: 2, tamagotchiEmoji: '🐥', entryFeeUsd: 5, performanceFeeBps: 1000, isAiAgent: false, apy30d: 0, isDemo: true },
+  { pubkey: 'sol_bull_002', name: 'SOL Bull Market Fund', emoji: '🐂', strategyType: 'trend_following', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Sensei', memberCount: 89, aumUsd: 31400, pnl30d: 8.7, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 10, performanceFeeBps: 1500, isAiAgent: false, apy30d: 0, isDemo: true },
+  { pubkey: 'ai_dca_bot_003', name: 'Autonomous DCA Engine', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'conservative', creatorType: 'ai_agent', creatorHandle: 'DCA Bot #7', memberCount: 312, aumUsd: 127000, pnl30d: 6.2, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 500, isAiAgent: true, apy30d: 0, isDemo: true },
+  { pubkey: 'degen_mode_004', name: 'Degen Mode', emoji: '🎰', strategyType: 'degen', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Moon_Bro', memberCount: 45, aumUsd: 12800, pnl30d: 34.1, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 20, performanceFeeBps: 2000, isAiAgent: false, apy30d: 0, isDemo: true },
+  { pubkey: 'yield_dao_005', name: 'Yield Farmers DAO', emoji: '🌾', strategyType: 'yield', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Y-DAO', memberCount: 203, aumUsd: 89500, pnl30d: 4.1, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 800, isAiAgent: false, apy30d: 0, isDemo: true },
+  { pubkey: 'ai_treasury_006', name: 'AI Treasury Manager', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'ai_agent', creatorHandle: 'Treasury AI v1', memberCount: 567, aumUsd: 234000, pnl30d: 9.8, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 700, isAiAgent: true, apy30d: 0, isDemo: true },
+  { pubkey: 'contra_007', name: 'Contrarian Club', emoji: '🔄', strategyType: 'mean_reversion', riskLevel: 'balanced', creatorType: 'trader', creatorHandle: 'Zig_Zag', memberCount: 67, aumUsd: 22100, pnl30d: 5.3, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 5, performanceFeeBps: 1200, isAiAgent: false, apy30d: 0, isDemo: true },
+  { pubkey: 'diamond_008', name: 'Diamond Hands DAO', emoji: '💎', strategyType: 'hodl', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Diamond DAO', memberCount: 891, aumUsd: 445000, pnl30d: 18.2, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 300, isAiAgent: false, apy30d: 0, isDemo: true },
 ];
 
-const STRATEGY_COLORS = { ai_dca: '#9945FF', trend_following: '#14F195', mean_reversion: '#F59E0B', hodl: '#3B82F6', degen: '#EF4444', yield: '#10B981', };
-const STRATEGY_LABELS = { ai_dca: '🤖 AI DCA', trend_following: '📈 Trend', mean_reversion: '🔄 Mean Rev', hodl: '💎 HODL', degen: '🎰 Degen', yield: '🌾 Yield', };
+// Map on-chain yieldStrategy → display strategyType
+const YIELD_TO_STRATEGY: Record<string | number, string> = {
+  0: 'hodl',            none: 'hodl',
+  1: 'yield',           conservative: 'yield',
+  2: 'ai_dca',          balanced: 'ai_dca',
+  3: 'trend_following', aggressive: 'trend_following',
+  4: 'degen',           jlp: 'degen',
+}
+
+const STRATEGY_COLORS: Record<string, string> = {
+  ai_dca: '#9945FF',
+  trend_following: '#14F195',
+  mean_reversion: '#F59E0B',
+  hodl: '#3B82F6',
+  degen: '#EF4444',
+  yield: '#10B981',
+};
+
+const STRATEGY_LABELS: Record<string, string> = {
+  ai_dca: '🤖 AI DCA',
+  trend_following: '📈 Trend',
+  mean_reversion: '🔄 Mean Rev',
+  hodl: '💎 HODL',
+  degen: '🎰 Degen',
+  yield: '🌾 Yield',
+};
 
 export default function VaultsPage() {
   const [selectedStrategy, setSelectedStrategy] = useState('all');
   const [creatorFilter, setCreatorFilter] = useState('all');
   const [sortBy, setSortBy] = useState('returns');
   const [searchQuery, setSearchQuery] = useState('');
-  const [joinedVaults, setJoinedVaults] = useState(new Set());
 
+  // ── Live data ────────────────────────────────────────────────────────────
+  const { data: pots = [], isLoading: potsLoading } = usePots();
+  const { price: solPrice } = useSolPrice();
+
+  // Batch-fetch analytics for all visible pots
+  const livePubkeys = useMemo(() => pots.map((p: any) => p.pubkey), [pots]);
+  const { dataMap: analyticsMap, isLoading: analyticsLoading } = useVaultAnalyticsBatch(livePubkeys);
+
+  const isLiveData = pots.length > 0;
+
+  // ── Map real pots → vault card shape ─────────────────────────────────────
+  const liveVaults = useMemo(() => {
+    const solUsd = solPrice ?? 150; // fallback price if not yet loaded
+    return pots.map((pot: any) => {
+      const analytics = analyticsMap[pot.pubkey];
+      const aumUsd = analytics?.navUsd ?? (pot.balance * solUsd);
+      const pnl30d = analytics?.pnlPct ?? 0;
+      const apy30d = analytics?.apy30d ?? 0;
+      return {
+        pubkey:           pot.pubkey,
+        name:             pot.name,
+        emoji:            pot.emoji || '🪴',
+        strategyType:     YIELD_TO_STRATEGY[pot.yieldStrategy] ?? 'ai_dca',
+        riskLevel:        'balanced',
+        creatorType:      'community',
+        creatorHandle:    `${pot.pubkey.slice(0, 4)}…${pot.pubkey.slice(-4)}`,
+        memberCount:      pot.memberCount,
+        aumUsd,
+        pnl30d:           Number(pnl30d.toFixed(2)),
+        apy30d:           Number(apy30d.toFixed(1)),
+        tamagotchiLevel:  pot.tamagotchiLevel,
+        tamagotchiEmoji:  pot.tamagotchiEmoji,
+        entryFeeUsd:      0,
+        performanceFeeBps: 0,
+        isAiAgent:        false,
+        isDemo:           false,
+      };
+    });
+  }, [pots, analyticsMap, solPrice]);
+
+  // Use live vaults if on-chain program is active, otherwise demo data
+  const allVaults = isLiveData ? liveVaults : DEMO_VAULTS;
+
+  // ── Filtering & sorting ──────────────────────────────────────────────────
   const filteredAndSortedVaults = useMemo(() => {
-    let filtered = VAULTS.filter((vault) => {
+    let filtered = allVaults.filter((vault) => {
       const matchesStrategy = selectedStrategy === 'all' || vault.strategyType === selectedStrategy;
-      const matchesCreator = creatorFilter === 'all' || (creatorFilter === 'ai_agents' && vault.isAiAgent) || (creatorFilter === 'human' && !vault.isAiAgent);
-      const matchesSearch = vault.name.toLowerCase().includes(searchQuery.toLowerCase()) || vault.creatorHandle.toLowerCase().includes(searchQuery.toLowerCase());
+      const matchesCreator = creatorFilter === 'all'
+        || (creatorFilter === 'ai_agents' && vault.isAiAgent)
+        || (creatorFilter === 'human' && !vault.isAiAgent);
+      const matchesSearch =
+        vault.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        vault.creatorHandle.toLowerCase().includes(searchQuery.toLowerCase());
       return matchesStrategy && matchesCreator && matchesSearch;
     });
     return filtered.sort((a, b) => {
       if (sortBy === 'returns') return b.pnl30d - a.pnl30d;
-      if (sortBy === 'aum') return b.aumUsd - a.aumUsd;
+      if (sortBy === 'aum')     return b.aumUsd - a.aumUsd;
       if (sortBy === 'members') return b.memberCount - a.memberCount;
       return 0;
     });
-  }, [selectedStrategy, creatorFilter, sortBy, searchQuery]);
+  }, [allVaults, selectedStrategy, creatorFilter, sortBy, searchQuery]);
 
-  const totalAum = VAULTS.reduce((sum, v) => sum + v.aumUsd, 0);
-  const avgReturn = (VAULTS.reduce((sum, v) => sum + v.pnl30d, 0) / VAULTS.length).toFixed(1);
-  const totalMembers = VAULTS.reduce((sum, v) => sum + v.memberCount, 0);
-
-  const handleJoinVault = (pubkey) => {
-    const newSet = new Set(joinedVaults);
-    if (newSet.has(pubkey)) { newSet.delete(pubkey); } else { newSet.add(pubkey); }
-    setJoinedVaults(newSet);
-  };
+  // ── Aggregate stats ─────────────────────────────────────────────────────
+  const totalAum     = allVaults.reduce((s, v) => s + v.aumUsd, 0);
+  const avgReturn    = allVaults.length > 0
+    ? (allVaults.reduce((s, v) => s + v.pnl30d, 0) / allVaults.length).toFixed(1)
+    : '0.0';
+  const totalMembers = allVaults.reduce((s, v) => s + v.memberCount, 0);
 
   return (
     <div style={{ backgroundColor: '#0D1117', color: 'white', minHeight: '100vh', fontFamily: 'Geist, sans-serif' }}>
-      <div style={{ position: 'sticky', top: 0, zIndex: 100, backgroundColor: '#0D1117', borderBottom: '1px solid #1A2332', padding: '16px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', backdropFilter: 'blur(10px)', }}>
+      {/* Top Nav */}
+      <div style={{ position: 'sticky', top: 0, zIndex: 100, backgroundColor: '#0D1117', borderBottom: '1px solid #1A2332', padding: '16px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', backdropFilter: 'blur(10px)' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
           <Link href="/" style={{ color: '#8B9BB4', textDecoration: 'none', fontSize: '14px' }}>← Back</Link>
           <h1 style={{ margin: 0, fontSize: '18px', fontWeight: '600' }}>⚡ PotBot Vaults</h1>
+          {/* Live / Demo badge */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: '#8B9BB4' }}>
+            <span style={{ width: '6px', height: '6px', borderRadius: '50%', backgroundColor: isLiveData ? '#14F195' : '#F59E0B', animation: isLiveData ? 'pulse 2s infinite' : 'none' }} />
+            <span style={{ color: isLiveData ? '#14F195' : '#F59E0B' }}>{isLiveData ? 'Live data' : 'Demo'}</span>
+          </div>
         </div>
-        <button style={{ backgroundColor: '#14F195', color: '#0D1117', border: 'none', padding: '8px 16px', borderRadius: '6px', fontWeight: '600', fontSize: '14px', cursor: 'pointer', }}>+ Create Vault</button>
+        <Link href="/create" style={{ backgroundColor: '#14F195', color: '#0D1117', border: 'none', padding: '8px 16px', borderRadius: '6px', fontWeight: '600', fontSize: '14px', textDecoration: 'none' }}>+ Create Vault</Link>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '16px', padding: '24px', borderBottom: '1px solid #1A2332', maxWidth: '1400px', margin: '0 auto', }}>
-        <div style={{ backgroundColor: '#111827', padding: '16px', borderRadius: '8px', border: '1px solid #1A2332' }}><div style={{ fontSize: '12px', color: '#8B9BB4', marginBottom: '8px' }}>Total AUM</div><div style={{ fontSize: '20px', fontWeight: '700' }}>${(totalAum / 1000).toFixed(0)}K</div></div>
-        <div style={{ backgroundColor: '#111827', padding: '16px', borderRadius: '8px', border: '1px solid #1A2332' }}><div style={{ fontSize: '12px', color: '#8B9BB4', marginBottom: '8px' }}>Active Vaults</div><div style={{ fontSize: '20px', fontWeight: '700' }}>8</div></div>
-        <div style={{ backgroundColor: '#111827', padding: '16px', borderRadius: '8px', border: '1px solid #1A2332' }}><div style={{ fontSize: '12px', color: '#8B9BB4', marginBottom: '8px' }}>Total Members</div><div style={{ fontSize: '20px', fontWeight: '700' }}>{totalMembers.toLocaleString()}</div></div>
-        <div style={{ backgroundColor: '#111827', padding: '16px', borderRadius: '8px', border: '1px solid #1A2332' }}><div style={{ fontSize: '12px', color: '#8B9BB4', marginBottom: '8px' }}>Avg 30d Return</div><div style={{ fontSize: '20px', fontWeight: '700', color: '#14F195' }}>+{avgReturn}%</div></div>
+      {/* Stats strip */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '16px', padding: '24px', borderBottom: '1px solid #1A2332', maxWidth: '1400px', margin: '0 auto' }}>
+        <StatCard label="Total AUM" value={totalAum >= 1_000_000 ? `$${(totalAum/1_000_000).toFixed(1)}M` : `$${(totalAum/1000).toFixed(0)}K`} loading={potsLoading} />
+        <StatCard label="Active Vaults" value={String(allVaults.length)} loading={potsLoading} />
+        <StatCard label="Total Members" value={totalMembers.toLocaleString()} loading={potsLoading} />
+        <StatCard label="Avg PnL" value={`${Number(avgReturn) >= 0 ? '+' : ''}${avgReturn}%`} loading={potsLoading} color="#14F195" />
       </div>
 
-      <div style={{ margin: '24px auto', maxWidth: '1400px', padding: '20px 24px', backgroundColor: '#9945FF', borderRadius: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', }}>
+      {/* AI Agents banner */}
+      <div style={{ margin: '24px auto', maxWidth: '1400px', padding: '20px 24px', backgroundColor: '#9945FF', borderRadius: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ fontSize: '14px' }}>🤖 PotBot is MCP-native — AI agents can autonomously allocate treasury across vaults</div>
-        <Link href="/for-agents" style={{ color: '#0D1117', textDecoration: 'none', fontWeight: '600', fontSize: '14px', whiteSpace: 'nowrap', }}>For AI Agents →</Link>
+        <Link href="/for-agents" style={{ color: '#0D1117', textDecoration: 'none', fontWeight: '600', fontSize: '14px', whiteSpace: 'nowrap' }}>For AI Agents →</Link>
       </div>
 
-      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '24px', display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center', }}>
+      {/* Filters */}
+      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '24px', display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
         <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
           {['all', 'ai_dca', 'trend_following', 'mean_reversion', 'hodl', 'degen', 'yield'].map((strategy) => (
-            <button key={strategy} onClick={() => setSelectedStrategy(strategy)} style={{ padding: '6px 12px', borderRadius: '20px', border: '1px solid #1A2332', backgroundColor: selectedStrategy === strategy ? '#14F195' : 'transparent', color: selectedStrategy === strategy ? '#0D1117' : 'white', fontSize: '13px', cursor: 'pointer', fontWeight: selectedStrategy === strategy ? '600' : '400', }}>
+            <button key={strategy} onClick={() => setSelectedStrategy(strategy)} style={{ padding: '6px 12px', borderRadius: '20px', border: '1px solid #1A2332', backgroundColor: selectedStrategy === strategy ? '#14F195' : 'transparent', color: selectedStrategy === strategy ? '#0D1117' : 'white', fontSize: '13px', cursor: 'pointer', fontWeight: selectedStrategy === strategy ? '600' : '400' }}>
               {strategy === 'all' ? 'All' : STRATEGY_LABELS[strategy]}
             </button>
           ))}
         </div>
         <div style={{ display: 'flex', gap: '16px', marginLeft: 'auto' }}>
-          <select value={creatorFilter} onChange={(e) => setCreatorFilter(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer', }}>
+          <select value={creatorFilter} onChange={(e) => setCreatorFilter(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer' }}>
             <option value="all">All Types</option>
             <option value="ai_agents">AI Agents Only</option>
             <option value="human">Human Traders</option>
           </select>
-          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer', }}>
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer' }}>
             <option value="returns">Best Returns</option>
             <option value="aum">Biggest AUM</option>
             <option value="members">Most Members</option>
           </select>
-          <input type="text" placeholder="Search vaults..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', minWidth: '200px', }} />
+          <input type="text" placeholder="Search vaults..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', color: 'white', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', minWidth: '200px' }} />
         </div>
       </div>
 
-      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '0 24px 40px', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px', }}>
-        {filteredAndSortedVaults.map((vault) => (
-          <div key={vault.pubkey} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', borderRadius: '8px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px', }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <span style={{ fontSize: '24px' }}>{vault.emoji}</span>
-                <div style={{ fontWeight: '600', fontSize: '14px' }}>{vault.name}</div>
-              </div>
-              <span style={{ fontSize: '20px' }}>{vault.tamagotchiEmoji}</span>
-            </div>
-            <div style={{ display: 'inline-block', padding: '4px 10px', borderRadius: '4px', backgroundColor: STRATEGY_COLORS[vault.strategyType], color: '#0D1117', fontSize: '12px', fontWeight: '600', width: 'fit-content', }}>
-              {STRATEGY_LABELS[vault.strategyType]}
-            </div>
-            <div style={{ fontSize: '13px', color: '#8B9BB4' }}>
-              {vault.isAiAgent ? '🤖 ' : '@'}
-              {vault.creatorHandle}
-            </div>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '8px', fontSize: '12px' }}>
-              <div><div style={{ color: '#8B9BB4', marginBottom: '4px' }}>Members</div><div style={{ fontWeight: '600' }}>{vault.memberCount}</div></div>
-              <div><div style={{ color: '#8B9BB4', marginBottom: '4px' }}>AUM</div><div style={{ fontWeight: '600' }}>${(vault.aumUsd / 1000).toFixed(1)}K</div></div>
-              <div><div style={{ color: '#8B9BB4', marginBottom: '4px' }}>30d PnL</div><div style={{ fontWeight: '600', color: vault.pnl30d >= 0 ? '#14F195' : '#EF4444' }}>
-                {vault.pnl30d >= 0 ? '+' : ''}
-                {vault.pnl30d}%
-              </div></div>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height: '24px', marginTop: '4px' }}>
-              {[40, 60, 35].map((height, i) => (
-                <div key={i} style={{ flex: 1, height: `${height}%`, backgroundColor: '#14F195', borderRadius: '2px', opacity: 0.7, }} />
-              ))}
-            </div>
-            <div style={{ fontSize: '12px', color: '#8B9BB4', marginTop: '8px' }}>
-              <div>{vault.entryFeeUsd === 0 ? 'Free' : `$${vault.entryFeeUsd}`} entry</div>
-              <div>{(vault.performanceFeeBps / 100).toFixed(1)}% perf fee</div>
-            </div>
-            <button onClick={() => handleJoinVault(vault.pubkey)} style={{ marginTop: '12px', padding: '8px 12px', borderRadius: '6px', border: 'none', fontWeight: '600', fontSize: '13px', cursor: 'pointer', backgroundColor: joinedVaults.has(vault.pubkey) ? '#6B7280' : '#14F195', color: joinedVaults.has(vault.pubkey) ? 'white' : '#0D1117', }}>
-              {joinedVaults.has(vault.pubkey) ? 'Joined ✓' : 'Join Vault'}
-            </button>
-          </div>
-        ))}
-      </div>
+      {/* Vault grid */}
+      {potsLoading ? (
+        <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '0 24px 40px', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px' }}>
+          {[1,2,3,4,5,6].map(i => (
+            <div key={i} style={{ backgroundColor: '#111827', border: '1px solid #1A2332', borderRadius: '8px', height: '220px', animation: 'pulse 2s infinite' }} />
+          ))}
+        </div>
+      ) : (
+        <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '0 24px 40px', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px' }}>
+          {filteredAndSortedVaults.map((vault) => (
+            <VaultCard
+              key={vault.pubkey}
+              vault={vault}
+              analyticsLoading={analyticsLoading && !vault.isDemo}
+            />
+          ))}
+        </div>
+      )}
 
-      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '40px 24px', borderTop: '1px solid #1A2332', }}>
+      {/* Strategy legend */}
+      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '40px 24px', borderTop: '1px solid #1A2332' }}>
         <h2 style={{ fontSize: '20px', fontWeight: '700', marginBottom: '24px' }}>Strategy Types</h2>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '16px' }}>
-          {[{ key: 'ai_dca', label: '🤖 AI DCA', desc: 'Automated dollar-cost averaging using AI signals' }, { key: 'trend_following', label: '📈 Trend Following', desc: 'Ride momentum based on technical indicators' }, { key: 'mean_reversion', label: '🔄 Mean Reversion', desc: 'Capitalize on price swings back to average' }, { key: 'hodl', label: '💎 HODL', desc: 'Long-term buy and hold strategy' }, { key: 'degen', label: '🎰 Degen', desc: 'High-risk, high-reward experimental strategies' }, { key: 'yield', label: '🌾 Yield Farming', desc: 'Maximize yield through DeFi protocols' }].map((strategy) => (
-            <div key={strategy.key} style={{ backgroundColor: '#111827', border: `1px solid ${STRATEGY_COLORS[strategy.key]}`, borderRadius: '8px', padding: '16px', }}>
-              <div style={{ fontWeight: '600', fontSize: '14px', marginBottom: '8px' }}>{strategy.label}</div>
-              <div style={{ fontSize: '13px', color: '#8B9BB4' }}>{strategy.desc}</div>
+          {[
+            { key: 'ai_dca',          label: '🤖 AI DCA',           desc: 'Automated dollar-cost averaging using AI signals' },
+            { key: 'trend_following', label: '📈 Trend Following',   desc: 'Ride momentum based on technical indicators' },
+            { key: 'mean_reversion',  label: '🔄 Mean Reversion',    desc: 'Capitalize on price swings back to average' },
+            { key: 'hodl',            label: '💎 HODL',              desc: 'Long-term buy and hold strategy' },
+            { key: 'degen',           label: '🎰 Degen',             desc: 'High-risk, high-reward experimental strategies' },
+            { key: 'yield',           label: '🌾 Yield Farming',     desc: 'Maximize yield through DeFi protocols' },
+          ].map((s) => (
+            <div key={s.key} style={{ backgroundColor: '#111827', border: `1px solid ${STRATEGY_COLORS[s.key]}`, borderRadius: '8px', padding: '16px' }}>
+              <div style={{ fontWeight: '600', fontSize: '14px', marginBottom: '8px' }}>{s.label}</div>
+              <div style={{ fontSize: '13px', color: '#8B9BB4' }}>{s.desc}</div>
             </div>
           ))}
         </div>
       </div>
     </div>
+  );
+}
+
+// ── VaultCard ────────────────────────────────────────────────────────────────
+
+function StatCard({ label, value, loading, color }: { label: string; value: string; loading?: boolean; color?: string }) {
+  return (
+    <div style={{ backgroundColor: '#111827', padding: '16px', borderRadius: '8px', border: '1px solid #1A2332' }}>
+      <div style={{ fontSize: '12px', color: '#8B9BB4', marginBottom: '8px' }}>{label}</div>
+      {loading ? (
+        <div style={{ height: '28px', width: '60px', backgroundColor: '#1A2332', borderRadius: '4px' }} />
+      ) : (
+        <div style={{ fontSize: '20px', fontWeight: '700', color: color ?? 'white' }}>{value}</div>
+      )}
+    </div>
+  );
+}
+
+function VaultCard({ vault, analyticsLoading }: { vault: any; analyticsLoading: boolean }) {
+  const pnlColor = vault.pnl30d >= 0 ? '#14F195' : '#EF4444';
+  const apyColor = '#9945FF';
+
+  return (
+    <Link
+      href={vault.isDemo ? '#' : `/pots/${vault.pubkey}`}
+      style={{ textDecoration: 'none' }}
+    >
+      <div style={{ backgroundColor: '#111827', border: '1px solid #1A2332', borderRadius: '8px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px', cursor: 'pointer', transition: 'border-color 0.15s' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span style={{ fontSize: '24px' }}>{vault.emoji}</span>
+            <div style={{ fontWeight: '600', fontSize: '14px', color: 'white' }}>{vault.name}</div>
+          </div>
+          <span style={{ fontSize: '20px' }}>{vault.tamagotchiEmoji}</span>
+        </div>
+
+        {/* Strategy badge */}
+        <div style={{ display: 'inline-block', padding: '4px 10px', borderRadius: '4px', backgroundColor: STRATEGY_COLORS[vault.strategyType] ?? '#9945FF', color: '#0D1117', fontSize: '12px', fontWeight: '600', width: 'fit-content' }}>
+          {STRATEGY_LABELS[vault.strategyType] ?? vault.strategyType}
+        </div>
+
+        {/* Creator */}
+        <div style={{ fontSize: '13px', color: '#8B9BB4' }}>
+          {vault.isAiAgent ? '🤖 ' : '@'}{vault.creatorHandle}
+        </div>
+
+        {/* Stats grid */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '8px', fontSize: '12px' }}>
+          <div>
+            <div style={{ color: '#8B9BB4', marginBottom: '4px' }}>Members</div>
+            <div style={{ fontWeight: '600', color: 'white' }}>{vault.memberCount}</div>
+          </div>
+          <div>
+            <div style={{ color: '#8B9BB4', marginBottom: '4px' }}>AUM</div>
+            {analyticsLoading ? (
+              <div style={{ height: '16px', width: '40px', backgroundColor: '#1A2332', borderRadius: '3px' }} />
+            ) : (
+              <div style={{ fontWeight: '600', color: 'white' }}>
+                {vault.aumUsd >= 1_000 ? `$${(vault.aumUsd/1_000).toFixed(1)}K` : `$${vault.aumUsd.toFixed(0)}`}
+              </div>
+            )}
+          </div>
+          <div>
+            <div style={{ color: '#8B9BB4', marginBottom: '4px' }}>PnL</div>
+            {analyticsLoading ? (
+              <div style={{ height: '16px', width: '40px', backgroundColor: '#1A2332', borderRadius: '3px' }} />
+            ) : (
+              <div style={{ fontWeight: '600', color: pnlColor }}>
+                {vault.pnl30d >= 0 ? '+' : ''}{vault.pnl30d}%
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* APY row (live data only) */}
+        {!vault.isDemo && vault.apy30d > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+            <span style={{ color: '#8B9BB4' }}>APY 30d:</span>
+            <span style={{ fontWeight: '700', color: apyColor }}>{vault.apy30d.toFixed(1)}%</span>
+          </div>
+        )}
+
+        {/* Mini chart bars (decorative) */}
+        <div style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height: '24px', marginTop: '4px' }}>
+          {[40, 60, 35, 70, 50, 80, 65].map((height, i) => (
+            <div
+              key={i}
+              style={{ flex: 1, height: `${height}%`, backgroundColor: pnlColor, borderRadius: '2px', opacity: 0.6 }}
+            />
+          ))}
+        </div>
+
+        {/* Fee info */}
+        <div style={{ fontSize: '12px', color: '#8B9BB4', marginTop: '4px' }}>
+          {vault.entryFeeUsd === 0 ? 'Free entry' : `$${vault.entryFeeUsd} entry`}
+          {vault.performanceFeeBps > 0 && ` · ${(vault.performanceFeeBps / 100).toFixed(1)}% perf fee`}
+        </div>
+
+        {/* CTA */}
+        {!vault.isDemo && (
+          <div style={{ marginTop: '8px', padding: '8px 12px', borderRadius: '6px', border: 'none', fontWeight: '600', fontSize: '13px', backgroundColor: '#14F195', color: '#0D1117', textAlign: 'center' }}>
+            View Vault →
+          </div>
+        )}
+      </div>
+    </Link>
   );
 }

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -3,20 +3,80 @@
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
 import { useWallet } from '@solana/wallet-adapter-react'
+import { useQuery } from '@tanstack/react-query'
+import { useSolPrice } from '@/lib/prices'
+import { healthApi } from '@/lib/api-client'
 
-// Dynamically import to avoid SSR issues with wallet adapter
 const WalletMultiButtonDynamic = dynamic(
   async () =>
     (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
   { ssr: false }
 )
 
+/** Thin bar above the main nav: SOL price + API status */
+function LivePriceTicker() {
+  const { price: solPrice } = useSolPrice()
+
+  const { data: health, isError: apiDown } = useQuery({
+    queryKey: ['api-health'],
+    queryFn:  healthApi.check,
+    refetchInterval: 30_000,
+    retry: 1,
+    staleTime: 25_000,
+    // Don't show error toasts — this is a background check
+  })
+
+  return (
+    <div className="border-b border-pot-border/40 bg-pot-dark/60">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-7 flex items-center gap-4">
+        {/* SOL price */}
+        {solPrice != null && (
+          <div className="flex items-center gap-1.5 text-[11px]">
+            <span className="text-pot-muted">◎</span>
+            <span className="font-mono font-semibold text-white">
+              ${solPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </span>
+            <span className="text-pot-muted">SOL</span>
+          </div>
+        )}
+
+        <div className="w-px h-3 bg-pot-border" />
+
+        {/* API health */}
+        <div className="flex items-center gap-1.5 text-[11px]">
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${
+              apiDown ? 'bg-red-500' : 'bg-pot-green animate-pulse'
+            }`}
+          />
+          <span className={apiDown ? 'text-red-400/80' : 'text-pot-green'}>
+            API {apiDown ? 'Offline' : 'Online'}
+          </span>
+          {health?.version && (
+            <span className="text-pot-muted/60">v{health.version}</span>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-3 text-[11px] text-pot-muted">
+          <Link href="/for-agents" className="hover:text-pot-green transition hidden sm:block">
+            🤖 For AI Agents
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function Navbar() {
   const { publicKey } = useWallet()
 
   return (
     <nav className="sticky top-0 z-50 border-b border-pot-border bg-pot-dark/80 backdrop-blur-xl">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      {/* Price ticker sub-bar */}
+      <LivePriceTicker />
+
+      {/* Main nav */}
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2 group">
           <span className="text-2xl group-hover:animate-float">🪴</span>
@@ -27,10 +87,7 @@ export function Navbar() {
 
         {/* Center nav */}
         <div className="hidden sm:flex items-center gap-6 text-sm font-medium">
-          <Link
-            href="/"
-            className="text-gray-400 transition hover:text-white"
-          >
+          <Link href="/" className="text-gray-400 transition hover:text-white">
             Dashboard
           </Link>
           <Link
@@ -39,17 +96,14 @@ export function Navbar() {
           >
             🏆 Leaderboard
           </Link>
-          <Link
-            href="/create"
-            className="text-gray-400 transition hover:text-white"
-          >
+          <Link href="/vaults" className="text-gray-400 transition hover:text-white">
+            ⚡ Vaults
+          </Link>
+          <Link href="/create" className="text-gray-400 transition hover:text-white">
             Create POT
           </Link>
           {publicKey && (
-            <Link
-              href="/my-pots"
-              className="text-gray-400 transition hover:text-white"
-            >
+            <Link href="/my-pots" className="text-gray-400 transition hover:text-white">
               My POTs
             </Link>
           )}

--- a/apps/web/src/components/PnLDashboard.tsx
+++ b/apps/web/src/components/PnLDashboard.tsx
@@ -5,6 +5,8 @@ import { useTokenPrices, formatUsd, KNOWN_TOKENS } from '@/lib/prices'
 import { calcPositionPnl, formatPct, SEED_POSITIONS } from '@/lib/positions'
 import type { Position, PositionPnl } from '@/lib/positions'
 import { useSolPrice } from '@/lib/prices'
+import { useVaultAnalytics } from '@/hooks/useAnalytics'
+import type { PositionWithPnl } from '@/lib/api-client'
 
 interface Props {
   potPubkey: string
@@ -18,43 +20,178 @@ const DEFI_ICONS: Record<string, string> = {
   marginfi: '💰',
 }
 
+// ── Real API positions display ──────────────────────────────────────────────
+
+function RealPositionCard({ pos, vaultNavUsd }: { pos: PositionWithPnl; vaultNavUsd: number }) {
+  const [expanded, setExpanded] = useState(false)
+  const allocationPct = vaultNavUsd > 0 ? (pos.currentValue / vaultNavUsd) * 100 : 0
+
+  const pnlColor = pos.unrealizedPnlUsd >= 0 ? 'text-green-400' : 'text-red-400'
+
+  return (
+    <div className="card p-4 border border-pot-border transition-all">
+      <div
+        className="flex items-center justify-between cursor-pointer"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {/* Token info */}
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-pot-accent/20 border border-pot-accent/30 flex items-center justify-center text-sm font-bold text-pot-accent">
+            {pos.symbol.slice(0, 2)}
+          </div>
+          <div>
+            <span className="font-semibold text-white">{pos.symbol}</span>
+            <div className="text-xs text-pot-muted font-mono">
+              {pos.amount.toLocaleString(undefined, { maximumFractionDigits: 6 })} {pos.symbol}
+            </div>
+          </div>
+        </div>
+
+        {/* P&L */}
+        <div className="text-right">
+          <div className={`font-bold font-mono text-base ${pnlColor}`}>
+            {pos.unrealizedPnlUsd >= 0 ? '+' : ''}{formatUsd(Math.abs(pos.unrealizedPnlUsd))}
+          </div>
+          <div className={`text-xs font-mono ${pnlColor}`}>
+            {formatPct(pos.unrealizedPnlPct)}
+          </div>
+          <div className="text-xs text-pot-muted">
+            {allocationPct.toFixed(1)}% of vault
+          </div>
+        </div>
+        <span className="text-pot-muted ml-3 text-xs">{expanded ? '▲' : '▼'}</span>
+      </div>
+
+      {expanded && (
+        <div className="mt-4 pt-4 border-t border-pot-border space-y-4">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="bg-pot-dark rounded-lg p-3 text-center">
+              <div className="text-[10px] text-pot-muted mb-1">Entry Price</div>
+              <div className="text-xs font-mono text-white">
+                ${pos.entryPrice < 0.001 ? pos.entryPrice.toFixed(8) : pos.entryPrice.toFixed(4)}
+              </div>
+            </div>
+            <div className="bg-pot-dark rounded-lg p-3 text-center">
+              <div className="text-[10px] text-pot-muted mb-1">Current Price</div>
+              <div className={`text-xs font-mono ${pnlColor}`}>
+                ${pos.currentPrice < 0.001 ? pos.currentPrice.toFixed(8) : pos.currentPrice.toFixed(4)}
+              </div>
+            </div>
+            <div className="bg-pot-dark rounded-lg p-3 text-center">
+              <div className="text-[10px] text-pot-muted mb-1">Current Value</div>
+              <div className="text-xs font-mono text-white">{formatUsd(pos.currentValue)}</div>
+            </div>
+          </div>
+
+          {/* Price movement bar */}
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-pot-muted">Price movement from entry</span>
+              <span className={pnlColor}>{formatPct(pos.unrealizedPnlPct)}</span>
+            </div>
+            <div className="h-2 bg-pot-dark rounded-full overflow-hidden relative">
+              <div className="absolute inset-0 flex">
+                <div className="flex-1 border-r border-pot-border/50" />
+              </div>
+              <div
+                className={`h-full rounded-full transition-all ${
+                  pos.unrealizedPnlPct >= 0 ? 'bg-green-500 ml-auto' : 'bg-red-500'
+                }`}
+                style={{ width: `${Math.min(50, Math.abs(pos.unrealizedPnlPct))}%` }}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 text-xs text-pot-muted">
+            <span>Cost basis: {formatUsd(pos.entryValue)}</span>
+            <span>•</span>
+            <span>Mint: {pos.mint.slice(0, 6)}…{pos.mint.slice(-4)}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main dashboard ───────────────────────────────────────────────────────────
+
 export function PnLDashboard({ potPubkey, vaultBalanceSol }: Props) {
   const [sortBy, setSortBy] = useState<'pnl' | 'value' | 'allocation'>('value')
   const [showClosed, setShowClosed] = useState(false)
 
-  // Get positions for this pot (in production: from on-chain / indexer)
-  const positions = useMemo(
+  // ── Real API analytics ─────────────────────────────────────────────────────
+  const { data: analytics, isLoading: analyticsLoading } = useVaultAnalytics(potPubkey)
+  const hasRealPositions = (analytics?.positions?.length ?? 0) > 0
+
+  // ── Demo positions fallback (SEED_POSITIONS + live prices) ─────────────────
+  const demoPositions = useMemo(
     () => SEED_POSITIONS.filter((p) => p.potPubkey === potPubkey && (showClosed || p.isOpen)),
     [potPubkey, showClosed]
   )
-
-  const mints = useMemo(() => [...new Set(positions.map((p) => p.tokenMint))], [positions])
-  const { data: prices } = useTokenPrices(mints)
+  const demoMints = useMemo(
+    () => [...new Set(demoPositions.map((p) => p.tokenMint))],
+    [demoPositions]
+  )
+  const { data: demoPrices } = useTokenPrices(demoMints)
   const { price: solPrice } = useSolPrice()
+  const vaultBalanceUsd = solPrice ? vaultBalanceSol * solPrice : (analytics?.solBalanceUsd ?? 0)
 
-  const vaultBalanceUsd = solPrice ? vaultBalanceSol * solPrice : 0
-
-  const pnlItems = useMemo<PositionPnl[]>(() => {
-    return positions.map((pos) => {
-      const currentPrice = prices?.[pos.tokenMint] ?? pos.entryPriceUsd
+  const demoPnlItems = useMemo<PositionPnl[]>(() => {
+    return demoPositions.map((pos) => {
+      const currentPrice = demoPrices?.[pos.tokenMint] ?? pos.entryPriceUsd
       return calcPositionPnl(pos, currentPrice, vaultBalanceUsd)
     })
-  }, [positions, prices, vaultBalanceUsd])
+  }, [demoPositions, demoPrices, vaultBalanceUsd])
 
-  const sorted = useMemo(() => {
-    return [...pnlItems].sort((a, b) => {
-      if (sortBy === 'pnl') return b.pnlPct - a.pnlPct
+  // ── Unified real positions (sorted) ────────────────────────────────────────
+  const realPositionsSorted = useMemo(() => {
+    if (!analytics?.positions) return []
+    const navUsd = analytics.navUsd
+    return [...analytics.positions].sort((a, b) => {
+      if (sortBy === 'pnl')        return b.unrealizedPnlUsd - a.unrealizedPnlUsd
+      if (sortBy === 'value')      return b.currentValue - a.currentValue
+      if (sortBy === 'allocation') {
+        const aAlloc = navUsd > 0 ? a.currentValue / navUsd : 0
+        const bAlloc = navUsd > 0 ? b.currentValue / navUsd : 0
+        return bAlloc - aAlloc
+      }
+      return 0
+    })
+  }, [analytics, sortBy])
+
+  // ── Demo positions (sorted) ─────────────────────────────────────────────────
+  const demoSorted = useMemo(() => {
+    return [...demoPnlItems].sort((a, b) => {
+      if (sortBy === 'pnl')   return b.pnlPct - a.pnlPct
       if (sortBy === 'value') return b.currentValueUsd - a.currentValueUsd
       return b.allocationPct - a.allocationPct
     })
-  }, [pnlItems, sortBy])
+  }, [demoPnlItems, sortBy])
 
-  const totalPnlUsd = pnlItems.reduce((s, p) => s + p.pnlUsd, 0)
-  const totalValueUsd = pnlItems.reduce((s, p) => s + p.currentValueUsd, 0)
-  const totalEntryUsd = pnlItems.reduce((s, p) => s + p.entryValueUsd, 0)
-  const totalPnlPct = totalEntryUsd > 0 ? (totalPnlUsd / totalEntryUsd) * 100 : 0
+  // ── Summary stats ──────────────────────────────────────────────────────────
+  const totalPnlUsd = hasRealPositions
+    ? analytics!.pnlUsd
+    : demoPnlItems.reduce((s, p) => s + p.pnlUsd, 0)
 
-  if (positions.length === 0) {
+  const totalValueUsd = hasRealPositions
+    ? analytics!.navUsd
+    : demoPnlItems.reduce((s, p) => s + p.currentValueUsd, 0)
+
+  const totalPnlPct = hasRealPositions
+    ? analytics!.pnlPct
+    : (() => {
+        const entry = demoPnlItems.reduce((s, p) => s + p.entryValueUsd, 0)
+        return entry > 0 ? (totalPnlUsd / entry) * 100 : 0
+      })()
+
+  const positionCount = hasRealPositions
+    ? analytics!.positions!.length
+    : demoPnlItems.length
+
+  const navUsd = analytics?.navUsd ?? vaultBalanceUsd
+
+  // Empty state
+  if (!analyticsLoading && !hasRealPositions && demoPositions.length === 0) {
     return (
       <div className="card p-12 text-center">
         <div className="text-4xl mb-3">📊</div>
@@ -68,11 +205,26 @@ export function PnLDashboard({ potPubkey, vaultBalanceSol }: Props) {
 
   return (
     <div className="space-y-6">
+      {/* Source indicator */}
+      {hasRealPositions ? (
+        <div className="flex items-center gap-2 text-xs text-pot-muted">
+          <span className="w-1.5 h-1.5 rounded-full bg-pot-green animate-pulse" />
+          <span className="text-pot-green font-medium">Live data</span>
+          <span>· {analytics!.positions!.length} positions from API · updated {new Date(analytics!.updatedAt).toLocaleTimeString()}</span>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-xs text-pot-muted">
+          <span className="w-1.5 h-1.5 rounded-full bg-yellow-500" />
+          <span>Demo positions</span>
+          <span>· Connect API backend to see real data</span>
+        </div>
+      )}
+
       {/* Summary bar */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <SummaryCard
           label="Open Positions"
-          value={String(pnlItems.length)}
+          value={String(positionCount)}
           sub="active trades"
         />
         <SummaryCard
@@ -89,7 +241,7 @@ export function PnLDashboard({ potPubkey, vaultBalanceSol }: Props) {
         />
         <SummaryCard
           label="In Positions"
-          value={`${vaultBalanceUsd > 0 ? (totalValueUsd / vaultBalanceUsd * 100).toFixed(1) : 0}%`}
+          value={`${navUsd > 0 ? (totalValueUsd / navUsd * 100).toFixed(1) : 0}%`}
           sub="of vault in open trades"
         />
       </div>
@@ -111,23 +263,49 @@ export function PnLDashboard({ potPubkey, vaultBalanceSol }: Props) {
             </button>
           ))}
         </div>
-        <button
-          onClick={() => setShowClosed((v) => !v)}
-          className="text-xs px-3 py-1.5 rounded-lg border border-pot-border text-pot-muted hover:text-white transition"
-        >
-          {showClosed ? '🔴 Hide Closed' : '📁 Show Closed'}
-        </button>
+        {!hasRealPositions && (
+          <button
+            onClick={() => setShowClosed((v) => !v)}
+            className="text-xs px-3 py-1.5 rounded-lg border border-pot-border text-pot-muted hover:text-white transition"
+          >
+            {showClosed ? '🔴 Hide Closed' : '📁 Show Closed'}
+          </button>
+        )}
       </div>
 
       {/* Positions */}
       <div className="space-y-3">
-        {sorted.map((item) => (
-          <PositionCard key={item.position.id} item={item} />
-        ))}
+        {hasRealPositions
+          ? realPositionsSorted.map((pos) => (
+              <RealPositionCard key={pos.mint} pos={pos} vaultNavUsd={navUsd} />
+            ))
+          : demoSorted.map((item) => (
+              <PositionCard key={item.position.id} item={item} />
+            ))
+        }
       </div>
+
+      {/* APY strip (real data only) */}
+      {hasRealPositions && analytics!.apy30d > 0 && (
+        <div className="card p-4 flex items-center gap-4">
+          <div>
+            <div className="text-xs text-pot-muted">30d APY</div>
+            <div className="text-lg font-bold text-pot-accent font-mono">{analytics!.apy30d.toFixed(1)}%</div>
+          </div>
+          {analytics!.apy7d != null && (
+            <div>
+              <div className="text-xs text-pot-muted">7d APY</div>
+              <div className="text-lg font-bold text-white font-mono">{analytics!.apy7d.toFixed(1)}%</div>
+            </div>
+          )}
+          <div className="ml-auto text-xs text-pot-muted">Annualized from NAV history</div>
+        </div>
+      )}
     </div>
   )
 }
+
+// ── Legacy demo position card (from SEED_POSITIONS) ─────────────────────────
 
 function PositionCard({ item }: { item: PositionPnl }) {
   const [expanded, setExpanded] = useState(false)
@@ -157,7 +335,6 @@ function PositionCard({ item }: { item: PositionPnl }) {
         className="flex items-center justify-between cursor-pointer"
         onClick={() => setExpanded((v) => !v)}
       >
-        {/* Left: token info */}
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-full bg-pot-accent/20 border border-pot-accent/30 flex items-center justify-center text-sm font-bold text-pot-accent">
             {pos.tokenSymbol.slice(0, 2)}
@@ -182,7 +359,6 @@ function PositionCard({ item }: { item: PositionPnl }) {
           </div>
         </div>
 
-        {/* Right: P&L */}
         <div className="text-right">
           <div className={`font-bold font-mono text-base ${item.pnlUsd >= 0 ? 'text-green-400' : 'text-red-400'}`}>
             {item.pnlUsd >= 0 ? '+' : ''}{formatUsd(Math.abs(item.pnlUsd))}
@@ -198,36 +374,27 @@ function PositionCard({ item }: { item: PositionPnl }) {
         <span className="text-pot-muted ml-3 text-xs">{expanded ? '▲' : '▼'}</span>
       </div>
 
-      {/* Expanded details */}
       {expanded && (
         <div className="mt-4 pt-4 border-t border-pot-border space-y-4">
-          {/* Price grid */}
           <div className="grid grid-cols-3 gap-3">
             <div className="bg-pot-dark rounded-lg p-3 text-center">
               <div className="text-[10px] text-pot-muted mb-1">Entry Price</div>
               <div className="text-xs font-mono text-white">
-                ${pos.entryPriceUsd < 0.001
-                  ? pos.entryPriceUsd.toFixed(8)
-                  : pos.entryPriceUsd.toFixed(4)}
+                ${pos.entryPriceUsd < 0.001 ? pos.entryPriceUsd.toFixed(8) : pos.entryPriceUsd.toFixed(4)}
               </div>
             </div>
             <div className="bg-pot-dark rounded-lg p-3 text-center">
               <div className="text-[10px] text-pot-muted mb-1">Current Price</div>
               <div className={`text-xs font-mono ${item.pnlPct >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-                ${item.currentPriceUsd < 0.001
-                  ? item.currentPriceUsd.toFixed(8)
-                  : item.currentPriceUsd.toFixed(4)}
+                ${item.currentPriceUsd < 0.001 ? item.currentPriceUsd.toFixed(8) : item.currentPriceUsd.toFixed(4)}
               </div>
             </div>
             <div className="bg-pot-dark rounded-lg p-3 text-center">
               <div className="text-[10px] text-pot-muted mb-1">Current Value</div>
-              <div className="text-xs font-mono text-white">
-                {formatUsd(item.currentValueUsd)}
-              </div>
+              <div className="text-xs font-mono text-white">{formatUsd(item.currentValueUsd)}</div>
             </div>
           </div>
 
-          {/* Price change bar */}
           <div>
             <div className="flex justify-between text-xs mb-1">
               <span className="text-pot-muted">Price movement from entry</span>
@@ -246,7 +413,6 @@ function PositionCard({ item }: { item: PositionPnl }) {
             </div>
           </div>
 
-          {/* Strategy triggers */}
           {(item.stopLossTriggerUsd || item.takeProfitTriggerUsd) && (
             <div className="grid grid-cols-2 gap-2">
               {item.stopLossTriggerUsd && (

--- a/apps/web/src/components/VaultAnalyticsStrip.tsx
+++ b/apps/web/src/components/VaultAnalyticsStrip.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+/**
+ * VaultAnalyticsStrip — compact live analytics bar for vault/pot headers.
+ * Shows NAV (USD), all-time PnL%, 30d APY, open positions count, and last-updated time.
+ * Silently disappears if the API backend is unreachable (isError + no cached data).
+ */
+import { useVaultAnalytics } from '@/hooks/useAnalytics'
+
+interface Props {
+  pubkey: string
+}
+
+function Stat({
+  label,
+  value,
+  color = 'text-white',
+  loading = false,
+}: {
+  label: string
+  value: string
+  color?: string
+  loading?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 min-w-[72px]">
+      <span className="text-[10px] text-pot-muted uppercase tracking-wide font-medium">{label}</span>
+      {loading ? (
+        <div className="h-4 w-14 bg-pot-border rounded animate-pulse" />
+      ) : (
+        <span className={`text-sm font-bold font-mono ${color}`}>{value}</span>
+      )}
+    </div>
+  )
+}
+
+function pnlColor(pct: number): string {
+  if (pct > 0) return 'text-pot-green'
+  if (pct < 0) return 'text-red-400'
+  return 'text-pot-muted'
+}
+
+function fmtUsd(usd: number): string {
+  if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(2)}M`
+  if (usd >= 1_000)     return `$${(usd / 1_000).toFixed(1)}K`
+  if (usd > 0)          return `$${usd.toFixed(0)}`
+  return '—'
+}
+
+export function VaultAnalyticsStrip({ pubkey }: Props) {
+  const { data, isLoading, isError } = useVaultAnalytics(pubkey)
+
+  // Graceful degradation: if API is completely unreachable, hide the strip
+  if (isError && !data) return null
+
+  const navUsd   = data?.navUsd   ?? 0
+  const pnlPct   = data?.pnlPct   ?? 0
+  const apy30d   = data?.apy30d   ?? 0
+  const openPos  = data?.positions?.length ?? 0
+  const updatedAt = data?.updatedAt
+
+  const navFmt = data ? fmtUsd(navUsd) : '—'
+  const pnlFmt = data ? `${pnlPct >= 0 ? '+' : ''}${pnlPct.toFixed(2)}%` : '—'
+  const apyFmt = data ? `${apy30d.toFixed(1)}% APY` : '—'
+
+  const lastUpdated = updatedAt
+    ? new Date(updatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : null
+
+  return (
+    <div className="flex items-center gap-6 mt-3 pt-3 border-t border-pot-border/50 flex-wrap">
+      <Stat
+        label="NAV"
+        value={navFmt}
+        loading={isLoading}
+        color="text-pot-green"
+      />
+      <Stat
+        label="PnL (all-time)"
+        value={pnlFmt}
+        loading={isLoading}
+        color={data ? pnlColor(pnlPct) : 'text-pot-muted'}
+      />
+      <Stat
+        label="APY 30d"
+        value={apyFmt}
+        loading={isLoading}
+        color="text-pot-accent"
+      />
+      {(isLoading || openPos > 0) && (
+        <Stat
+          label="Positions"
+          value={isLoading ? '—' : String(openPos)}
+          loading={isLoading}
+          color="text-white"
+        />
+      )}
+
+      {/* Live indicator */}
+      {(data || isLoading) && (
+        <div className="ml-auto flex items-center gap-1.5 text-[10px] text-pot-muted shrink-0">
+          {isLoading ? (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-pot-muted" />
+              <span>Loading…</span>
+            </>
+          ) : (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-pot-green animate-pulse" />
+              <span className="text-pot-green">Live</span>
+              {lastUpdated && <span>· {lastUpdated}</span>}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useAIAgent.ts
+++ b/apps/web/src/hooks/useAIAgent.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/ai-agent'
 import { useCreateProposal, useVote, useProposals } from '@/hooks/usePots'
 import { fetchPricesRaw } from '@/lib/useAIAgent-helpers'
+import { agentApi, type AgentRule as BackendAgentRule } from '@/lib/api-client'
 
 /* ── Per-pot config store (localStorage) ── */
 
@@ -46,6 +47,32 @@ function saveLog(potPubkey: string, log: AgentLogEntry[]) {
   } catch {}
 }
 
+/**
+ * Convert frontend AgentRule → backend BackendAgentRule for API storage.
+ * The backend cron evaluates the subset of trigger types it supports.
+ */
+function toBackendRules(frontendConfig: AgentConfig): BackendAgentRule[] {
+  return frontendConfig.rules.map((r) => ({
+    id:    r.id,
+    name:  r.name,
+    enabled: r.enabled,
+    trigger: {
+      type:      r.trigger.type as BackendAgentRule['trigger']['type'],
+      threshold: r.trigger.threshold,
+      interval:  r.trigger.type === 'time_interval' ? r.trigger.threshold : undefined,
+      token:     r.trigger.tokenSymbol,
+    },
+    action: {
+      type:    r.action.type as BackendAgentRule['action']['type'],
+      amount:  r.action.amountPct,
+      token:   (r.action as any).fromSymbol,
+      toToken: (r.action as any).toSymbol,
+    },
+    cooldownMinutes:  r.cooldownMinutes,
+    lastTriggeredAt:  r.lastFiredAt,
+  }))
+}
+
 /* ── Hook ── */
 
 export interface UseAIAgentReturn {
@@ -59,7 +86,6 @@ export interface UseAIAgentReturn {
   triggerManualCheck: () => Promise<void>
 }
 
-// Mints to watch for price updates
 const WATCH_MINTS = [
   'So11111111111111111111111111111111111111112',    // SOL
   'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
@@ -82,11 +108,45 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
   const prevPricesRef = useRef<Record<string, number>>({})
   const proposalSeenRef = useRef<Set<string>>(new Set())
 
-  /* ── Persist ── */
+  /* ── Persist + API sync ── */
   const setConfig = useCallback((newConfig: AgentConfig) => {
     setConfigState(newConfig)
     saveConfig(newConfig)
-  }, [])
+
+    // Sync rules to backend (fire-and-forget) so the server cron can evaluate them
+    agentApi
+      .updateRules(potPubkey, toBackendRules(newConfig))
+      .catch(() => {})  // silently ignore if API is offline
+  }, [potPubkey])
+
+  /* ── Load from API on mount ── */
+  useEffect(() => {
+    // Merge server logs with local logs
+    agentApi
+      .getLogs(potPubkey, 50)
+      .then(({ logs: apiLogs }) => {
+        if (apiLogs.length === 0) return
+        const converted: AgentLogEntry[] = apiLogs.map((l) => ({
+          id:        l.id,
+          timestamp: l.ts,
+          level:     l.error ? 'error' : l.proposalCreated ? 'success' : 'info',
+          message:   [
+            l.actionDesc,
+            l.triggerDesc ? `(trigger: ${l.triggerDesc})` : '',
+            l.proposalCreated ? '\u2705 Proposal created' : '',
+            l.error ? `❌ ${l.error}` : '',
+          ].filter(Boolean).join(' — '),
+          ruleId:   l.ruleId,
+          ruleName: l.ruleName,
+        }))
+        setLog((prev) => {
+          const existingIds = new Set(prev.map((e) => e.id))
+          const fresh = converted.filter((e) => !existingIds.has(e.id))
+          return [...fresh, ...prev].sort((a, b) => b.timestamp - a.timestamp).slice(0, MAX_LOG)
+        })
+      })
+      .catch(() => {})
+  }, [potPubkey])
 
   /* ── Logging ── */
   const addLog = useCallback((entry: Omit<AgentLogEntry, 'id' | 'timestamp'>) => {
@@ -102,25 +162,23 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
     })
   }, [potPubkey])
 
-  /* ── Main evaluation loop ── */
+  /* ── Main evaluation loop (local, runs in-browser) ── */
   const runCheck = useCallback(async () => {
     if (!config?.enabled || !publicKey) return
     setIsRunning(true)
 
     try {
-      // 1. Fetch current prices
       const mints = [
         ...new Set([
           ...WATCH_MINTS,
           ...config.rules.flatMap((r) => r.trigger.tokenMint ? [r.trigger.tokenMint] : []),
-          ...config.rules.flatMap((r) => [r.action.fromMint, r.action.toMint].filter(Boolean) as string[]),
+          ...config.rules.flatMap((r) => [(r.action as any).fromMint, (r.action as any).toMint].filter(Boolean) as string[]),
         ])
       ]
 
       const prices = await fetchPricesRaw(mints)
       const prevPrices = prevPricesRef.current
 
-      // Compute % changes
       const priceChangePct: Record<string, number> = {}
       for (const [mint, price] of Object.entries(prices)) {
         const prev = prevPrices[mint]
@@ -128,157 +186,68 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
       }
       prevPricesRef.current = prices
 
-      const snapshot: MarketSnapshot = {
-        prices,
-        priceChangePct,
-        timestamp: Date.now(),
-      }
+      const snapshot: MarketSnapshot = { prices, priceChangePct, timestamp: Date.now() }
 
-      // 2. Handle proposal_created rules separately
+      // Proposal-created rules
       if (proposals) {
         const newProposals = proposals.filter(
           (p) => p.status === 'active' && !proposalSeenRef.current.has(p.pubkey)
         )
         for (const proposal of newProposals) {
           proposalSeenRef.current.add(proposal.pubkey)
-
           for (const rule of config.rules) {
             if (!rule.enabled || rule.trigger.type !== 'proposal_created') continue
             if (config.proposeOnly) continue
-
-            const maxImpact = rule.action.maxPriceImpactPct ?? 100
-            // In production: check Jupiter quote for impact
-            // Here we simulate: approve if description doesn't contain "high risk"
-            const shouldVote = rule.action.type === 'vote_yes'
-
-            if (shouldVote) {
-              addLog({
-                level: 'info',
-                message: `🗳️ Auto-voting YES on proposal #${proposal.proposalId}: "${proposal.description}"`,
-                ruleId: rule.id,
-                ruleName: rule.name,
-              })
+            if (rule.action.type === 'vote_yes') {
+              addLog({ level: 'info', message: `🗳️ Auto-voting YES on proposal #${(proposal as any).proposalId}: "${proposal.description}"`, ruleId: rule.id, ruleName: rule.name })
               try {
-                await vote.mutateAsync({
-                  potAddress: potPubkey,
-                  proposalAddress: proposal.pubkey,
-                  approve: true,
-                })
-                addLog({
-                  level: 'success',
-                  message: `✅ Voted YES on proposal #${proposal.proposalId}`,
-                  ruleId: rule.id,
-                  ruleName: rule.name,
-                })
-
-                // Update rule fire count
-                setConfig({
-                  ...config,
-                  rules: config.rules.map((r) =>
-                    r.id === rule.id
-                      ? { ...r, fireCount: r.fireCount + 1, lastFiredAt: Date.now() }
-                      : r
-                  ),
-                })
+                await vote.mutateAsync({ potAddress: potPubkey, proposalAddress: proposal.pubkey, approve: true })
+                addLog({ level: 'success', message: `✅ Voted YES on proposal #${(proposal as any).proposalId}`, ruleId: rule.id, ruleName: rule.name })
+                setConfig({ ...config, rules: config.rules.map((r) => r.id === rule.id ? { ...r, fireCount: r.fireCount + 1, lastFiredAt: Date.now() } : r) })
               } catch (err) {
-                addLog({
-                  level: 'error',
-                  message: `❌ Vote failed: ${err instanceof Error ? err.message : String(err)}`,
-                  ruleId: rule.id,
-                  ruleName: rule.name,
-                })
+                addLog({ level: 'error', message: `❌ Vote failed: ${err instanceof Error ? err.message : String(err)}`, ruleId: rule.id, ruleName: rule.name })
               }
             }
           }
         }
       }
 
-      // 3. Evaluate market-driven rules
+      // Market-driven rules
       for (const rule of config.rules) {
         if (rule.trigger.type === 'proposal_created') continue
-
         const result: EvalResult = evaluateRule(rule, snapshot)
+        if (!result.triggered) continue
 
-        if (!result.triggered) {
-          // Only log if something changed meaningfully
-          continue
-        }
+        addLog({ level: 'info', message: `🔔 Rule triggered: "${rule.name}" — ${result.reason}`, ruleId: rule.id, ruleName: rule.name })
 
-        addLog({
-          level: 'info',
-          message: `🔔 Rule triggered: "${rule.name}" — ${result.reason}`,
-          ruleId: rule.id,
-          ruleName: rule.name,
-        })
-
-        // Execute action
         if (rule.action.type === 'alert') {
-          addLog({
-            level: 'warn',
-            message: `⚠️ Alert: ${rule.action.label}`,
-            ruleId: rule.id,
-            ruleName: rule.name,
-          })
+          addLog({ level: 'warn', message: `⚠️ Alert: ${(rule.action as any).label}`, ruleId: rule.id, ruleName: rule.name })
         } else if (rule.action.type === 'propose_swap') {
-          const amountSol = ((rule.action.amountPct ?? 10) / 100) * (pot?.balance ?? 0)
+          const amountSol = (((rule.action as any).amountPct ?? 10) / 100) * (pot?.balance ?? 0)
           if (amountSol < 0.01) {
-            addLog({
-              level: 'warn',
-              message: `⚠️ Skipped: vault balance too low for proposal`,
-              ruleId: rule.id,
-              ruleName: rule.name,
-            })
+            addLog({ level: 'warn', message: `⚠️ Skipped: vault balance too low for proposal`, ruleId: rule.id, ruleName: rule.name })
             continue
           }
-
-          addLog({
-            level: 'info',
-            message: `📝 Creating proposal: ${rule.action.label} (${amountSol.toFixed(3)} SOL)`,
-            ruleId: rule.id,
-            ruleName: rule.name,
-          })
-
+          addLog({ level: 'info', message: `📝 Creating proposal: ${(rule.action as any).label} (${amountSol.toFixed(3)} SOL)`, ruleId: rule.id, ruleName: rule.name })
           try {
             await createProposal.mutateAsync({
               potAddress: potPubkey,
               nextProposalId: pot?.nextProposalId ?? 0,
               proposalType: {
                 swap: {
-                  fromMint: rule.action.fromMint!,
-                  toMint: rule.action.toMint!,
-                  amountIn: amountSol,
+                  fromMint:     (rule.action as any).fromMint!,
+                  toMint:       (rule.action as any).toMint!,
+                  amountIn:     amountSol,
                   minAmountOut: 0,
                 }
               },
-              description: `[AI] ${rule.action.label} — ${amountSol.toFixed(3)} ${rule.action.fromSymbol}`,
+              description: `[AI] ${(rule.action as any).label} — ${amountSol.toFixed(3)} ${(rule.action as any).fromSymbol}`,
             })
-
-            addLog({
-              level: 'success',
-              message: `✅ Proposal created: "${rule.action.label}"`,
-              ruleId: rule.id,
-              ruleName: rule.name,
-            })
-
-            // Update rule state
-            setConfig({
-              ...config,
-              rules: config.rules.map((r) =>
-                r.id === rule.id
-                  ? { ...r, fireCount: r.fireCount + 1, lastFiredAt: Date.now() }
-                  : r
-              ),
-            })
-
-            // Invalidate proposals cache
+            addLog({ level: 'success', message: `✅ Proposal created: "${(rule.action as any).label}"`, ruleId: rule.id, ruleName: rule.name })
+            setConfig({ ...config, rules: config.rules.map((r) => r.id === rule.id ? { ...r, fireCount: r.fireCount + 1, lastFiredAt: Date.now() } : r) })
             qc.invalidateQueries({ queryKey: ['proposals', potPubkey] })
           } catch (err) {
-            addLog({
-              level: 'error',
-              message: `❌ Proposal failed: ${err instanceof Error ? err.message : String(err)}`,
-              ruleId: rule.id,
-              ruleName: rule.name,
-            })
+            addLog({ level: 'error', message: `❌ Proposal failed: ${err instanceof Error ? err.message : String(err)}`, ruleId: rule.id, ruleName: rule.name })
           }
         }
       }
@@ -291,11 +260,10 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
     }
   }, [config, publicKey, proposals, potPubkey, pot, addLog, setConfig, createProposal, vote, qc])
 
-  /* ── Auto-run every 60 seconds ── */
+  /* ── Auto-run locally every 60s ── */
   useEffect(() => {
     if (!config?.enabled) return
     const interval = setInterval(runCheck, 60_000)
-    // Run immediately on enable
     runCheck()
     return () => clearInterval(interval)
   }, [config?.enabled, runCheck])
@@ -309,10 +277,7 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
     } else {
       const updated = { ...config, enabled: !config.enabled }
       setConfig(updated)
-      addLog({
-        level: 'info',
-        message: updated.enabled ? '🤖 AI Agent started' : '⏹️ AI Agent stopped',
-      })
+      addLog({ level: 'info', message: updated.enabled ? '🤖 AI Agent started' : '⏹️ AI Agent stopped' })
     }
   }, [config, potPubkey, setConfig, addLog])
 
@@ -320,6 +285,22 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
     setLog([])
     saveLog(potPubkey, [])
   }, [potPubkey])
+
+  /**
+   * Manual trigger: first call the backend API to run server-side evaluation,
+   * then also run the local in-browser evaluation as a fallback/supplement.
+   */
+  const triggerManualCheck = useCallback(async () => {
+    // Try server-side trigger first
+    try {
+      const result = await agentApi.trigger(potPubkey)
+      addLog({ level: 'info', message: `🖥️ Server trigger: ${result.message}` })
+    } catch {
+      // API offline — continue to local evaluation
+    }
+    // Always also run local evaluation (proposals require wallet signature)
+    await runCheck()
+  }, [potPubkey, runCheck, addLog])
 
   return {
     config,
@@ -329,6 +310,6 @@ export function useAIAgent(potPubkey: string, pot: any): UseAIAgentReturn {
     setConfig,
     toggleEnabled,
     clearLog,
-    triggerManualCheck: runCheck,
+    triggerManualCheck,
   }
 }

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -1,0 +1,38 @@
+/**
+ * useAnalytics — real-time vault analytics hook
+ * Polls the API every 10 seconds for fresh NAV/PnL/APY data
+ */
+import { useQuery } from '@tanstack/react-query'
+import { analyticsApi, type VaultAnalytics } from '../lib/api-client'
+
+export function useVaultAnalytics(
+  pubkey: string | null | undefined,
+  options?: { enabled?: boolean; refetchInterval?: number }
+) {
+  return useQuery<VaultAnalytics, Error>({
+    queryKey: ['analytics', pubkey],
+    queryFn: () => analyticsApi.getVault(pubkey!),
+    enabled:  Boolean(pubkey) && (options?.enabled !== false),
+    refetchInterval: options?.refetchInterval ?? 10_000,  // 10s
+    staleTime: 8_000,
+    retry: 2,
+    retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 10_000),
+  })
+}
+
+export function usePrices(
+  mints: string[],
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: ['prices', mints.join(',')],
+    queryFn: async () => {
+      const { pricesApi } = await import('../lib/api-client')
+      return pricesApi.get(mints)
+    },
+    enabled:  mints.length > 0 && (options?.enabled !== false),
+    refetchInterval: 5_000,  // 5s — matches price oracle cache TTL
+    staleTime: 4_000,
+    retry: 1,
+  })
+}

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -1,10 +1,14 @@
 /**
- * useAnalytics — real-time vault analytics hook
- * Polls the API every 10 seconds for fresh NAV/PnL/APY data
+ * useAnalytics — real-time vault analytics hooks
+ * Polls the API for fresh NAV/PnL/APY data.
  */
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueries } from '@tanstack/react-query'
 import { analyticsApi, type VaultAnalytics } from '../lib/api-client'
 
+/**
+ * Fetch analytics for a single vault.
+ * Refetches every 10 seconds so the UI stays live.
+ */
 export function useVaultAnalytics(
   pubkey: string | null | undefined,
   options?: { enabled?: boolean; refetchInterval?: number }
@@ -20,6 +24,40 @@ export function useVaultAnalytics(
   })
 }
 
+/**
+ * Fetch analytics for multiple vaults in parallel.
+ * React Query deduplicates and caches each query independently.
+ * Returns a map of pubkey → VaultAnalytics (undefined while loading).
+ */
+export function useVaultAnalyticsBatch(pubkeys: string[]) {
+  const results = useQueries({
+    queries: pubkeys.map((pubkey) => ({
+      queryKey: ['analytics', pubkey] as const,
+      queryFn:  () => analyticsApi.getVault(pubkey),
+      enabled:  Boolean(pubkey),
+      staleTime: 8_000,
+      retry: 1,
+      // Stagger fetches slightly to avoid rate-limit bursts
+      // React Query handles concurrency, but retryDelay adds back-pressure
+      retryDelay: 2_000,
+    })),
+  })
+
+  const dataMap: Record<string, VaultAnalytics | undefined> = {}
+  const isLoading = results.some((r) => r.isLoading)
+  const isAllSettled = results.every((r) => !r.isLoading)
+
+  pubkeys.forEach((pk, i) => {
+    dataMap[pk] = results[i]?.data
+  })
+
+  return { dataMap, isLoading, isAllSettled, results }
+}
+
+/**
+ * Fetch live token prices via the API price oracle.
+ * Refetches every 5 seconds — matches the API cache TTL.
+ */
 export function usePrices(
   mints: string[],
   options?: { enabled?: boolean }

--- a/apps/web/src/hooks/useYield.ts
+++ b/apps/web/src/hooks/useYield.ts
@@ -1,0 +1,34 @@
+/**
+ * useYield — DeFi yield opportunities hook
+ */
+import { useQuery } from '@tanstack/react-query'
+import { yieldApi, type YieldOpportunity } from '../lib/api-client'
+
+export function useYieldOpportunities(params?: {
+  risk?: 'low' | 'medium' | 'high'
+  token?: string
+  protocol?: string
+  minApy?: number
+}) {
+  return useQuery({
+    queryKey: ['yield', 'opportunities', params],
+    queryFn: () => yieldApi.getOpportunities(params),
+    refetchInterval: 5 * 60_000,  // 5 minutes
+    staleTime: 4 * 60_000,
+  })
+}
+
+export function useBestYield(token: string | null | undefined) {
+  return useQuery({
+    queryKey: ['yield', 'best', token],
+    queryFn: () => yieldApi.getBest(token!),
+    enabled: Boolean(token),
+    refetchInterval: 5 * 60_000,
+    staleTime: 4 * 60_000,
+    select: (data) => ({
+      bestApy: data.bestApy,
+      best: data.opportunities[0] ?? null,
+      all: data.opportunities,
+    }),
+  })
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,175 @@
+/**
+ * PotBot API Client — typed interface to the backend
+ * Centralizes all API calls so the frontend never calls Jupiter/Solana directly
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error((err as { error?: string }).error ?? `API error ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface PricesResponse {
+  prices: Record<string, number>
+  count: number
+  ts: number
+}
+
+export interface VaultAnalytics {
+  pubkey: string
+  navUsd: number
+  navPerShareUsd: number
+  totalShares: number
+  pnlUsd: number
+  pnlPct: number
+  apy30d: number
+  apy7d: number
+  positions: PositionWithPnl[]
+  solBalanceLamports: number
+  solBalanceUsd: number
+  updatedAt: number
+  cached?: boolean
+}
+
+export interface PositionWithPnl {
+  mint: string
+  symbol: string
+  amount: number
+  entryPrice: number
+  entryValue: number
+  currentPrice: number
+  currentValue: number
+  unrealizedPnlUsd: number
+  unrealizedPnlPct: number
+}
+
+export interface YieldOpportunity {
+  protocol: string
+  name: string
+  token: string
+  mint: string
+  apy: number
+  tvlUsd: number
+  risk: 'low' | 'medium' | 'high'
+  url: string
+  tags: string[]
+}
+
+export interface YieldResponse {
+  opportunities: YieldOpportunity[]
+  count: number
+  ts: number
+}
+
+export interface AgentRule {
+  id: string
+  name: string
+  enabled: boolean
+  trigger: {
+    type: string
+    threshold?: number
+    interval?: number
+    token?: string
+  }
+  action: {
+    type: string
+    amount?: number
+    token?: string
+    toToken?: string
+  }
+  cooldownMinutes: number
+  lastTriggeredAt?: number
+}
+
+export interface AgentLog {
+  id: string
+  potPubkey: string
+  ruleId: string
+  ruleName: string
+  triggerDesc: string
+  actionDesc: string
+  proposalCreated: boolean
+  proposalId?: string
+  error?: string
+  ts: number
+}
+
+// ── Prices ───────────────────────────────────────────────────────────────────
+
+export const pricesApi = {
+  get: (mints: string[]) =>
+    apiFetch<PricesResponse>(`/prices?ids=${mints.join(',')}`),
+
+  getOne: (mint: string) =>
+    apiFetch<{ mint: string; price: number; ts: number }>(`/prices/${mint}`),
+}
+
+// ── Analytics ────────────────────────────────────────────────────────────────
+
+export const analyticsApi = {
+  getVault: (pubkey: string) =>
+    apiFetch<VaultAnalytics>(`/analytics/${pubkey}`),
+
+  updatePositions: (pubkey: string, positions: Omit<PositionWithPnl, 'currentPrice' | 'currentValue' | 'unrealizedPnlUsd' | 'unrealizedPnlPct'>[]) =>
+    apiFetch<{ ok: boolean }>(`/analytics/${pubkey}/positions`, {
+      method: 'POST',
+      body: JSON.stringify({ positions }),
+    }),
+}
+
+// ── Yield ────────────────────────────────────────────────────────────────────
+
+export const yieldApi = {
+  getOpportunities: (params?: { risk?: string; token?: string; protocol?: string }) => {
+    const qs = new URLSearchParams()
+    if (params?.risk)     qs.set('risk', params.risk)
+    if (params?.token)    qs.set('token', params.token)
+    if (params?.protocol) qs.set('protocol', params.protocol)
+    const q = qs.toString()
+    return apiFetch<YieldResponse>(`/yield/opportunities${q ? `?${q}` : ''}`)
+  },
+
+  getBest: (token: string) =>
+    apiFetch<{ token: string; opportunities: YieldOpportunity[]; bestApy: number }>(
+      `/yield/best/${token}`
+    ),
+}
+
+// ── Agent ────────────────────────────────────────────────────────────────────
+
+export const agentApi = {
+  getRules: (pubkey: string) =>
+    apiFetch<{ rules: AgentRule[]; potPubkey: string }>(`/agent/${pubkey}/rules`),
+
+  updateRules: (pubkey: string, rules: AgentRule[]) =>
+    apiFetch<{ ok: boolean; count: number }>(`/agent/${pubkey}/rules`, {
+      method: 'POST',
+      body: JSON.stringify({ rules }),
+    }),
+
+  getLogs: (pubkey: string, limit = 50) =>
+    apiFetch<{ logs: AgentLog[]; count: number }>(`/agent/${pubkey}/logs?limit=${limit}`),
+
+  trigger: (pubkey: string) =>
+    apiFetch<{ ok: boolean; message: string }>(`/agent/${pubkey}/trigger`, { method: 'POST' }),
+}
+
+// ── Health ───────────────────────────────────────────────────────────────────
+
+export const healthApi = {
+  check: () =>
+    apiFetch<{ status: string; version: string; ts: number }>('/health'),
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,25 @@
-{\n  "framework": "nextjs",\n  "buildCommand": "npm run build --workspace=apps/web",\n  "outputDirectory": "apps/web/.next",\n  "installCommand": "npm install --legacy-peer-deps",\n  "ignoreCommand": "git diff HEAD^ HEAD --quiet apps/web packages/sdk packages/ui"\n}\n
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd apps/web && npm run build",
+  "outputDirectory": "apps/web/.next",
+  "installCommand": "npm install",
+  "framework": "nextjs",
+  "rewrites": [
+    {
+      "source": "/api/potbot/:path*",
+      "destination": "https://potbot-api.fly.dev/:path*"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options",   "value": "nosniff" },
+        { "key": "X-Frame-Options",           "value": "DENY" },
+        { "key": "X-XSS-Protection",          "value": "1; mode=block" },
+        { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ],
+  "regions": ["ams1", "fra1"]
+}


### PR DESCRIPTION
## Summary

This PR brings PotBot v2 to full production-quality state ahead of the Solana Frontier 2026 hackathon deadline (May 11, 2026).

### What's included

**Backend / Infrastructure**
- `apps/api` — Hono.js backend with price oracle, PnL engine, analytics API, and AI agent cron (60s rule evaluation)
- `apps/potbot-mcp` — MCP server on solana-agent-kit with 15+ vault management tools
- Production deploy configs for Fly.io (API) and Vercel (frontend)
- Supabase schema, Helius webhook setup, Upstash Redis cache

**Frontend data layer**
- `useVaultAnalyticsBatch` — parallel TanStack Query batch fetching for N vaults
- `VaultAnalyticsStrip` — compact live bar (NAV, PnL%, APY30d, positions)
- `PnLDashboard` — real positions from API with demo fallback
- `vaults/page.tsx` — live data from `usePots()` + analytics + USD prices
- `my-pots/page.tsx` — USD portfolio value, per-pot analytics
- `Navbar` — live SOL price ticker + API health indicator
- `leaderboard/page.tsx` — USD TVL, PnL%, APY30d per vault, multi-sort
- `useAIAgent.ts` — backend API sync for rules persistence + server-side evaluation

**Submission materials**
- 11-slide pitch deck (`potbot-v2-pitch-deck.pptx`)
- Updated README status table

### Commits
- `d2d66fa` — analytics batch + VaultAnalyticsStrip + PnLDashboard + vaults page
- `2566b94` — pot detail page with VaultAnalyticsStrip
- `56bbc34` — Navbar live prices + landing USD + my-pots USD + agent API sync
- `a69012a` — leaderboard USD TVL, PnL%, APY, batch analytics

🤖 Built with Claude Cowork