### PR TITLE
feat: full referral signup + admin email blast

### DIFF
--- a/apps/web/src/app/api/admin/send-email/route.ts
+++ b/apps/web/src/app/api/admin/send-email/route.ts
@@ -1,0 +1,247 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabase, isSupabaseConfigured } from '@/lib/supabase'
+import { renderEmail, renderEmailPlainText } from '@/lib/email-template'
+
+/**
+ * Admin-triggered bulk-email endpoint.
+ *
+ * Auth:  Authorization: Bearer <ADMIN_SECRET>
+ *
+ * Body:
+ *   {
+ *     "subject":    "PotBot mainnet is live 🚀",
+ *     "preheader":  "Founding members, your early access has landed.",
+ *     "headline":   "Mainnet is live",
+ *     "body":       "<p>You asked to be first…</p>",
+ *     "ctaLabel":   "Open PotBot",
+ *     "ctaUrl":     "https://potbot.fun",
+ *
+ *     // Optional filters / dry-run
+ *     "sourceFilter":  "signup",        // only email rows with this source
+ *     "emailOverride": "me@example.com", // send only to this email (for testing)
+ *     "dryRun":        true              // render + fetch recipients, don't send
+ *   }
+ *
+ * Requires these env vars in production:
+ *   ADMIN_SECRET             — shared secret that gates this endpoint
+ *   RESEND_API_KEY           — from https://resend.com/api-keys
+ *   RESEND_FROM              — e.g. "PotBot <hello@potbot.fun>"  (must be verified in Resend)
+ *   NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
+ */
+
+export const runtime = 'nodejs' // force node runtime (we use fetch to Resend, big batches)
+
+// Resend per-batch limit is 100 recipients per call. Tune if you change providers.
+const BATCH_SIZE = 50
+const RESEND_BATCH_ENDPOINT = 'https://api.resend.com/emails/batch'
+
+interface SendBody {
+  subject: string
+  preheader?: string
+  headline: string
+  body: string
+  ctaLabel?: string
+  ctaUrl?: string
+  sourceFilter?: string
+  emailOverride?: string
+  dryRun?: boolean
+}
+
+function unauthorized(msg = 'Unauthorized') {
+  return NextResponse.json({ error: msg }, { status: 401 })
+}
+
+function bad(msg: string) {
+  return NextResponse.json({ error: msg }, { status: 400 })
+}
+
+function requireAdmin(req: NextRequest): string | null {
+  const secret = process.env.ADMIN_SECRET
+  if (!secret) return 'ADMIN_SECRET not set on the server'
+  const auth = req.headers.get('authorization') ?? ''
+  const provided = auth.startsWith('Bearer ') ? auth.slice(7) : ''
+  if (provided !== secret) return 'Invalid ADMIN_SECRET'
+  return null
+}
+
+async function fetchRecipients(opts: {
+  sourceFilter?: string
+  emailOverride?: string
+}): Promise<string[]> {
+  if (opts.emailOverride) return [opts.emailOverride.trim().toLowerCase()]
+
+  if (!isSupabaseConfigured) {
+    console.warn('[send-email] Supabase not configured — no recipients to send to.')
+    return []
+  }
+
+  const db = createServerSupabase()
+  let query = db.from('waitlist').select('email').not('email', 'is', null)
+  if (opts.sourceFilter) query = query.eq('source', opts.sourceFilter)
+
+  const { data, error } = await query
+  if (error) {
+    console.error('[send-email] failed to load recipients:', error)
+    throw new Error('Failed to load recipients from Supabase')
+  }
+  // Dedup + sanitise
+  return Array.from(
+    new Set((data ?? []).map((r) => (r.email ?? '').trim().toLowerCase()).filter(Boolean)),
+  )
+}
+
+interface BatchResult {
+  sent: number
+  failed: number
+  errors: Array<{ batch: number; error: string }>
+}
+
+async function sendBatches(
+  recipients: string[],
+  payload: SendBody,
+): Promise<BatchResult> {
+  const apiKey = process.env.RESEND_API_KEY
+  const from = process.env.RESEND_FROM ?? 'PotBot <onboarding@resend.dev>'
+
+  if (!apiKey) {
+    throw new Error(
+      'RESEND_API_KEY is not set. Create one at https://resend.com/api-keys and add to .env.local',
+    )
+  }
+
+  const html = renderEmail({
+    subject: payload.subject,
+    preheader: payload.preheader,
+    headline: payload.headline,
+    body: payload.body,
+    ctaLabel: payload.ctaLabel,
+    ctaUrl: payload.ctaUrl,
+  })
+  const text = renderEmailPlainText({
+    subject: payload.subject,
+    preheader: payload.preheader,
+    headline: payload.headline,
+    body: payload.body,
+    ctaLabel: payload.ctaLabel,
+    ctaUrl: payload.ctaUrl,
+  })
+
+  const result: BatchResult = { sent: 0, failed: 0, errors: [] }
+
+  for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
+    const chunk = recipients.slice(i, i + BATCH_SIZE)
+    // Resend's batch endpoint: each element is a full email payload.
+    const batchIdx = Math.floor(i / BATCH_SIZE) + 1
+    const items = chunk.map((to) => ({
+      from,
+      to,
+      subject: payload.subject,
+      html,
+      text,
+    }))
+
+    try {
+      const res = await fetch(RESEND_BATCH_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(items),
+      })
+      if (!res.ok) {
+        const errText = await res.text()
+        console.error(`[send-email] batch ${batchIdx} failed:`, res.status, errText)
+        result.failed += chunk.length
+        result.errors.push({ batch: batchIdx, error: `${res.status}: ${errText.slice(0, 300)}` })
+      } else {
+        result.sent += chunk.length
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      console.error(`[send-email] batch ${batchIdx} threw:`, msg)
+      result.failed += chunk.length
+      result.errors.push({ batch: batchIdx, error: msg })
+    }
+  }
+
+  return result
+}
+
+export async function POST(req: NextRequest) {
+  const authErr = requireAdmin(req)
+  if (authErr) return unauthorized(authErr)
+
+  let body: SendBody
+  try {
+    body = (await req.json()) as SendBody
+  } catch {
+    return bad('Invalid JSON body')
+  }
+
+  if (!body?.subject?.trim()) return bad('subject is required')
+  if (!body?.headline?.trim()) return bad('headline is required')
+  if (!body?.body?.trim()) return bad('body is required')
+
+  let recipients: string[]
+  try {
+    recipients = await fetchRecipients({
+      sourceFilter: body.sourceFilter,
+      emailOverride: body.emailOverride,
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to load recipients' },
+      { status: 500 },
+    )
+  }
+
+  if (recipients.length === 0) {
+    return NextResponse.json({
+      sent: 0,
+      failed: 0,
+      recipientsPreviewCount: 0,
+      note: 'No recipients matched the filter.',
+    })
+  }
+
+  // Dry run — return what we'd send without calling Resend.
+  if (body.dryRun) {
+    return NextResponse.json({
+      dryRun: true,
+      recipientsPreviewCount: recipients.length,
+      samplePreview: recipients.slice(0, 5),
+      renderedHtmlLength: renderEmail({
+        subject: body.subject,
+        preheader: body.preheader,
+        headline: body.headline,
+        body: body.body,
+        ctaLabel: body.ctaLabel,
+        ctaUrl: body.ctaUrl,
+      }).length,
+    })
+  }
+
+  try {
+    const result = await sendBatches(recipients, body)
+    return NextResponse.json({
+      ...result,
+      recipientsTotal: recipients.length,
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Send failed' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET() {
+  // Simple health-check: tells you whether the required env vars are present.
+  return NextResponse.json({
+    adminSecretConfigured: !!process.env.ADMIN_SECRET,
+    resendKeyConfigured: !!process.env.RESEND_API_KEY,
+    resendFrom: process.env.RESEND_FROM ?? null,
+    supabaseConfigured: isSupabaseConfigured,
+  })
+}

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -1,60 +1,143 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { PublicKey } from '@solana/web3.js'
 import { createServerSupabase, isSupabaseConfigured } from '@/lib/supabase'
 
 // In-memory fallback when Supabase isn't configured (dev/demo mode)
-const devWaitlist = new Set<string>()
+interface DevEntry {
+  email: string
+  twitter?: string | null
+  telegram?: string | null
+  solana_wallet?: string | null
+  source: string
+  created_at: string
+}
+const devWaitlist = new Map<string, DevEntry>()
+
+// Source values we expect from the front-end. Anything else is coerced to 'other'.
+const ALLOWED_SOURCES = new Set(['landing', 'signup', 'telegram', 'twitter', 'referral'])
+
+function cleanHandle(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim().replace(/^@+/, '')
+  if (!trimmed) return null
+  if (trimmed.length > 64) return null
+  // Basic sanity: alphanumeric + underscore for x/tg handles
+  if (!/^[a-zA-Z0-9_.\-]+$/.test(trimmed)) return null
+  return trimmed
+}
+
+function cleanWallet(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  try {
+    // Throws if not a valid base58 32-byte pubkey
+    // eslint-disable-next-line no-new
+    new PublicKey(trimmed)
+    return trimmed
+  } catch {
+    return null
+  }
+}
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json()
-    const email = (body.email ?? '').trim().toLowerCase()
+    const body = await req.json().catch(() => ({}))
+    const email = (body.email ?? '').toString().trim().toLowerCase()
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return NextResponse.json({ error: 'Invalid email address' }, { status: 400 })
     }
 
+    // All extra fields are OPTIONAL. Invalid input is silently nulled rather than
+    // failing the whole signup — email is the only hard requirement.
+    const twitter = cleanHandle(body.twitter)
+    const telegram = cleanHandle(body.telegram)
+    const solana_wallet = cleanWallet(body.solana_wallet ?? body.wallet)
+
+    const rawSource = (body.source ?? 'landing').toString().trim().toLowerCase()
+    const source = ALLOWED_SOURCES.has(rawSource) ? rawSource : 'other'
+
+    // Optional strict mode: when the request explicitly asks for the full form
+    // (source === 'signup'), validate that at least one extra contact is present.
+    if (source === 'signup' && !twitter && !telegram && !solana_wallet) {
+      return NextResponse.json(
+        { error: 'Provide at least one of: Twitter, Telegram, or Solana wallet.' },
+        { status: 400 },
+      )
+    }
+
     if (isSupabaseConfigured) {
       const db = createServerSupabase()
+
+      // Upsert on email so users can fill in extra fields later without errors.
       const { error } = await db
         .from('waitlist')
-        .insert({ email })
+        .upsert(
+          {
+            email,
+            twitter,
+            telegram,
+            solana_wallet,
+            source,
+          },
+          { onConflict: 'email' },
+        )
         .select()
         .single()
 
       if (error) {
-        // Unique violation = already registered
+        // Unique violation on upsert shouldn't happen, but just in case:
         if (error.code === '23505') {
           return NextResponse.json({ success: true, alreadyRegistered: true })
         }
-        console.error('Waitlist insert error:', error)
-        return NextResponse.json({ error: 'Failed to save email' }, { status: 500 })
+        console.error('[waitlist] insert error:', error)
+        return NextResponse.json({ error: 'Failed to save signup' }, { status: 500 })
       }
     } else {
       // Demo fallback
-      if (devWaitlist.has(email)) {
+      const alreadyRegistered = devWaitlist.has(email)
+      devWaitlist.set(email, {
+        email,
+        twitter,
+        telegram,
+        solana_wallet,
+        source,
+        created_at: new Date().toISOString(),
+      })
+      console.log(
+        '[waitlist demo] signup:',
+        { email, twitter, telegram, solana_wallet, source },
+        '| total:',
+        devWaitlist.size,
+      )
+      if (alreadyRegistered) {
         return NextResponse.json({ success: true, alreadyRegistered: true })
       }
-      devWaitlist.add(email)
-      console.log('[Waitlist demo] New signup:', email, '| Total:', devWaitlist.size)
     }
 
     return NextResponse.json({ success: true })
   } catch (e) {
-    console.error('Waitlist error:', e)
+    console.error('[waitlist] error:', e)
     return NextResponse.json({ error: 'Server error' }, { status: 500 })
   }
 }
 
-export async function GET() {
-  // Simple count endpoint for admin use
+export async function GET(req: NextRequest) {
+  // Admin count endpoint — requires ADMIN_SECRET bearer token
   const secret = process.env.ADMIN_SECRET
-  if (!secret) return NextResponse.json({ count: '?' })
+  const auth = req.headers.get('authorization') ?? ''
+  const provided = auth.startsWith('Bearer ') ? auth.slice(7) : ''
+
+  if (!secret) return NextResponse.json({ count: '?', note: 'ADMIN_SECRET not set' })
+  if (provided !== secret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   if (isSupabaseConfigured) {
     const db = createServerSupabase()
     const { count } = await db.from('waitlist').select('*', { count: 'exact', head: true })
     return NextResponse.json({ count })
   }
-
   return NextResponse.json({ count: devWaitlist.size, mode: 'demo' })
 }

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import SignupForm from '@/components/SignupForm'
+
+export const metadata = {
+  title: 'Early Access — PotBot',
+  description:
+    'Sign up for PotBot mainnet early access. Founding members get lower fees, NFT badge, and priority on Strategy Vaults.',
+}
+
+const PERKS = [
+  { icon: '🪴', title: 'Lower swap fees', desc: 'Founding members unlock the lowest tier fees for life.' },
+  { icon: '🐾', title: 'Tamagotchi NFT badge', desc: 'Claim the exclusive founding-member NFT once mainnet ships.' },
+  { icon: '⚡', title: 'Priority Strategy Vaults', desc: 'First access to creator-led Strategy Vaults before the public drop.' },
+]
+
+export default function SignupPage() {
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero */}
+      <section className="relative pt-16 pb-8 px-4 text-center overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute top-1/4 left-1/2 -translate-x-1/2 w-[500px] h-[300px] bg-pot-green/5 rounded-full blur-3xl" />
+          <div className="absolute top-1/3 left-1/3 w-[300px] h-[200px] bg-pot-accent/5 rounded-full blur-3xl" />
+        </div>
+
+        <div className="relative z-10 max-w-2xl mx-auto">
+          <Link
+            href="/"
+            className="text-xs text-pot-muted hover:text-white transition inline-flex items-center gap-1 mb-6"
+          >
+            ← Back to home
+          </Link>
+
+          <div className="inline-flex items-center gap-2 bg-pot-card border border-pot-border rounded-full px-4 py-1.5 text-xs text-pot-muted mb-6">
+            <span className="w-1.5 h-1.5 rounded-full bg-pot-accent animate-pulse inline-block" />
+            Mainnet launching soon
+          </div>
+
+          <div className="text-6xl mb-4 animate-float">🪴</div>
+
+          <h1 className="text-4xl sm:text-5xl font-black text-white leading-tight mb-3">
+            Get early access to <span className="text-pot-green">PotBot</span>
+          </h1>
+
+          <p className="text-lg text-pot-muted max-w-lg mx-auto">
+            Tell us how to reach you. We'll email updates as mainnet approaches, and founding members
+            unlock exclusive perks.
+          </p>
+        </div>
+      </section>
+
+      {/* Two-column layout: perks + form */}
+      <section className="max-w-5xl mx-auto px-4 mt-8 grid grid-cols-1 lg:grid-cols-5 gap-8">
+        {/* Perks */}
+        <aside className="lg:col-span-2 space-y-4 lg:pt-6">
+          <div className="text-xs font-bold tracking-wider text-pot-green uppercase mb-3">
+            What founding members get
+          </div>
+          {PERKS.map((p) => (
+            <div
+              key={p.title}
+              className="card p-5 hover:border-pot-green/30 transition-all"
+            >
+              <div className="flex items-start gap-3">
+                <div className="text-2xl shrink-0">{p.icon}</div>
+                <div>
+                  <h3 className="font-bold text-white mb-1">{p.title}</h3>
+                  <p className="text-sm text-pot-muted leading-relaxed">{p.desc}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <div className="text-xs text-pot-muted/70 pt-2">
+            Prefer Twitter? Follow{' '}
+            <a
+              href="https://x.com/PotBot_sol"
+              target="_blank"
+              rel="noreferrer"
+              className="text-pot-accent hover:underline"
+            >
+              @PotBot_sol
+            </a>{' '}
+            for launch news.
+          </div>
+        </aside>
+
+        {/* Form */}
+        <div className="lg:col-span-3">
+          <div className="card p-6 sm:p-8">
+            <SignupForm />
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -91,7 +91,7 @@ function WaitlistSection() {
       const res = await fetch('/api/waitlist', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.trim() }),
+        body: JSON.stringify({ email: email.trim(), source: 'landing' }),
       })
       const data = await res.json()
       if (!res.ok) { setStatus('error'); return }
@@ -120,39 +120,64 @@ function WaitlistSection() {
             <div className="text-4xl">🎉</div>
             <p className="text-pot-green font-bold text-lg">You're on the list!</p>
             <p className="text-pot-muted text-sm">We'll email you when mainnet goes live.</p>
+            <Link
+              href="/signup"
+              className="text-xs text-pot-accent hover:underline mt-2"
+            >
+              Want the founding-member NFT? Add your wallet →
+            </Link>
           </div>
         ) : status === 'duplicate' ? (
           <div className="flex flex-col items-center gap-3">
             <div className="text-4xl">✅</div>
             <p className="text-white font-bold text-lg">Already registered!</p>
             <p className="text-pot-muted text-sm">You're already on the waitlist. We'll reach out soon.</p>
+            <Link
+              href="/signup"
+              className="text-xs text-pot-accent hover:underline mt-2"
+            >
+              Update your profile (twitter / wallet) →
+            </Link>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="your@email.com"
-              required
-              className="input flex-1 py-3 px-4 text-base"
-              disabled={status === 'loading'}
-            />
-            <button
-              type="submit"
-              disabled={status === 'loading' || !email.trim()}
-              className="btn-primary px-6 py-3 text-base whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {status === 'loading' ? (
-                <span className="flex items-center gap-2">
-                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  Joining...
-                </span>
-              ) : (
-                '🚀 Join Waitlist'
-              )}
-            </button>
-          </form>
+          <>
+            <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="your@email.com"
+                required
+                className="input flex-1 py-3 px-4 text-base"
+                disabled={status === 'loading'}
+              />
+              <button
+                type="submit"
+                disabled={status === 'loading' || !email.trim()}
+                className="btn-primary px-6 py-3 text-base whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {status === 'loading' ? (
+                  <span className="flex items-center gap-2">
+                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    Joining...
+                  </span>
+                ) : (
+                  '🚀 Join Waitlist'
+                )}
+              </button>
+            </form>
+
+            {/* Fuller signup CTA */}
+            <div className="mt-6 text-sm text-pot-muted">
+              Want founding-member perks (NFT badge, lower fees)?{' '}
+              <Link
+                href="/signup"
+                className="text-pot-green font-semibold hover:underline inline-flex items-center gap-1"
+              >
+                Full sign-up →
+              </Link>
+            </div>
+          </>
         )}
 
         {status === 'error' && (
@@ -205,6 +230,13 @@ export default function LandingPage() {
 
           {/* CTA buttons */}
           <div className="flex flex-wrap gap-4 justify-center mb-12">
+            {/* Primary CTA — the new signup page */}
+            <Link
+              href="/signup"
+              className="btn-primary text-base px-6 py-3 glow-green flex items-center gap-2"
+            >
+              🚀 Get Early Access
+            </Link>
             <WalletMultiButton />
             <Link href="/vaults" className="btn-secondary text-base px-6 py-3">
               ⚡ Browse Strategy Vaults
@@ -384,8 +416,11 @@ export default function LandingPage() {
           Open source and free to use on Solana devnet.
         </p>
         <div className="flex flex-wrap gap-4 justify-center">
-          <Link href="/create" className="btn-primary text-lg px-8 py-4">
-            🚀 Create Your Vault
+          <Link href="/signup" className="btn-primary text-lg px-8 py-4 glow-green">
+            🚀 Get Early Access
+          </Link>
+          <Link href="/create" className="btn-secondary text-lg px-8 py-4">
+            🪴 Create Your Vault
           </Link>
           <a
             href="https://github.com/YD811/potbot-v2"
@@ -410,6 +445,7 @@ export default function LandingPage() {
             <span>· Group DeFi Vaults on Solana</span>
           </div>
           <div className="flex gap-6">
+            <Link href="/signup" className="hover:text-pot-green transition">Early Access</Link>
             <Link href="/leaderboard" className="hover:text-white transition">Leaderboard</Link>
             <Link href="/vaults" className="hover:text-white transition">Vaults</Link>
             <Link href="/for-agents" className="hover:text-white transition">For Agents</Link>

--- a/apps/web/src/components/SignupForm.tsx
+++ b/apps/web/src/components/SignupForm.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+type Status = 'idle' | 'loading' | 'success' | 'duplicate' | 'error'
+
+interface FormState {
+  email: string
+  twitter: string
+  telegram: string
+  solana_wallet: string
+}
+
+const EMPTY: FormState = { email: '', twitter: '', telegram: '', solana_wallet: '' }
+
+export default function SignupForm() {
+  const [form, setForm] = useState<FormState>(EMPTY)
+  const [status, setStatus] = useState<Status>('idle')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  function update<K extends keyof FormState>(key: K, value: string) {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (status === 'loading') return
+    setErrorMsg(null)
+
+    const email = form.email.trim()
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setErrorMsg('Please enter a valid email address.')
+      setStatus('error')
+      return
+    }
+
+    const payload = {
+      email,
+      twitter: form.twitter.trim() || undefined,
+      telegram: form.telegram.trim() || undefined,
+      solana_wallet: form.solana_wallet.trim() || undefined,
+      source: 'signup',
+    }
+
+    setStatus('loading')
+    try {
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setErrorMsg(data.error ?? 'Something went wrong.')
+        setStatus('error')
+        return
+      }
+      setStatus(data.alreadyRegistered ? 'duplicate' : 'success')
+    } catch {
+      setErrorMsg('Network error. Please try again.')
+      setStatus('error')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="card p-8 text-center max-w-lg mx-auto">
+        <div className="text-5xl mb-4">🎉</div>
+        <h2 className="text-2xl font-black text-pot-green mb-2">You're on the list!</h2>
+        <p className="text-pot-muted mb-6">
+          Thanks for signing up. We'll email you as soon as PotBot mainnet is live — plus
+          early-access perks for founding members.
+        </p>
+        <Link href="/" className="btn-secondary inline-block">
+          ← Back to home
+        </Link>
+      </div>
+    )
+  }
+
+  if (status === 'duplicate') {
+    return (
+      <div className="card p-8 text-center max-w-lg mx-auto">
+        <div className="text-5xl mb-4">✅</div>
+        <h2 className="text-2xl font-black text-white mb-2">Welcome back!</h2>
+        <p className="text-pot-muted mb-6">
+          You're already on the waitlist. We've saved any additional details you provided.
+        </p>
+        <Link href="/" className="btn-secondary inline-block">
+          ← Back to home
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* Email — required */}
+      <div>
+        <label className="block text-sm font-semibold text-white mb-2">
+          Email <span className="text-pot-green">*</span>
+        </label>
+        <input
+          type="email"
+          required
+          autoComplete="email"
+          value={form.email}
+          onChange={(e) => update('email', e.target.value)}
+          placeholder="your@email.com"
+          className="input w-full py-3 px-4"
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      {/* Twitter */}
+      <div>
+        <label className="block text-sm font-semibold text-white mb-2">
+          Twitter / X handle <span className="text-pot-muted font-normal">(optional)</span>
+        </label>
+        <div className="relative">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-pot-muted">@</span>
+          <input
+            type="text"
+            value={form.twitter}
+            onChange={(e) => update('twitter', e.target.value.replace(/^@+/, ''))}
+            placeholder="potbot_sol"
+            className="input w-full py-3 pl-8 pr-4"
+            disabled={status === 'loading'}
+          />
+        </div>
+      </div>
+
+      {/* Telegram */}
+      <div>
+        <label className="block text-sm font-semibold text-white mb-2">
+          Telegram username <span className="text-pot-muted font-normal">(optional)</span>
+        </label>
+        <div className="relative">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-pot-muted">@</span>
+          <input
+            type="text"
+            value={form.telegram}
+            onChange={(e) => update('telegram', e.target.value.replace(/^@+/, ''))}
+            placeholder="potbot_user"
+            className="input w-full py-3 pl-8 pr-4"
+            disabled={status === 'loading'}
+          />
+        </div>
+      </div>
+
+      {/* Solana wallet */}
+      <div>
+        <label className="block text-sm font-semibold text-white mb-2">
+          Solana wallet address <span className="text-pot-muted font-normal">(optional)</span>
+        </label>
+        <input
+          type="text"
+          value={form.solana_wallet}
+          onChange={(e) => update('solana_wallet', e.target.value)}
+          placeholder="e.g. 7Np41oeYqPef…D4nLa"
+          className="input w-full py-3 px-4 font-mono text-sm"
+          disabled={status === 'loading'}
+        />
+        <p className="text-xs text-pot-muted mt-1.5">
+          Providing a wallet makes you eligible for the founding-member NFT drop.
+        </p>
+      </div>
+
+      {errorMsg && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-2">
+          {errorMsg}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'loading' || !form.email.trim()}
+        className="btn-primary w-full py-3.5 text-base disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {status === 'loading' ? (
+          <span className="flex items-center justify-center gap-2">
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            Joining…
+          </span>
+        ) : (
+          '🚀 Get Early Access'
+        )}
+      </button>
+
+      <p className="text-xs text-pot-muted/70 text-center">
+        We'll only email you about PotBot. No spam, unsubscribe anytime.
+      </p>
+    </form>
+  )
+}

--- a/apps/web/src/lib/email-template.ts
+++ b/apps/web/src/lib/email-template.ts
@@ -1,0 +1,227 @@
+/**
+ * PotBot branded HTML email template — launch / product-update style.
+ *
+ * Inline styles only (email clients don't support external CSS / most classes).
+ * Dark theme matching the PotBot landing page, with a colour-blocked hero
+ * and a single CTA button.
+ *
+ * Usage:
+ *   renderEmail({
+ *     subject: "PotBot is live on mainnet",
+ *     preheader: "Founding members — your early access has landed.",
+ *     headline: "Mainnet is live 🚀",
+ *     body: "<p>You asked to be first. You are.</p>",
+ *     ctaLabel: "Open PotBot",
+ *     ctaUrl: "https://potbot.fun",
+ *   })
+ */
+
+export interface EmailTemplateInput {
+  /** Subject line — also used in <title>. */
+  subject: string
+  /** Preview text shown in inbox (1-line teaser after subject). Max ~90 chars. */
+  preheader?: string
+  /** Big headline inside the email body. */
+  headline: string
+  /** Body HTML. Can contain <p>, <ul>, <strong>, <a>, etc. */
+  body: string
+  /** Optional primary CTA button. If omitted, no button is rendered. */
+  ctaLabel?: string
+  /** URL for the CTA button. */
+  ctaUrl?: string
+  /** Recipient's email, rendered in the unsubscribe footer. */
+  recipientEmail?: string
+  /** Optional unsubscribe URL. */
+  unsubscribeUrl?: string
+}
+
+/* PotBot brand palette (from apps/web/src/app/globals.css + LandingPage.tsx) */
+const C = {
+  bgOuter: '#0D1117', // pot-dark
+  bgCard: '#111827', // pot-card
+  border: '#1A2332', // pot-border
+  green: '#14F195', // pot-green (Solana green)
+  accent: '#9945FF', // pot-accent (Solana purple)
+  text: '#FFFFFF',
+  muted: '#6B7280', // pot-muted
+  mutedSoft: '#9CA3AF',
+}
+
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+export function renderEmail(input: EmailTemplateInput): string {
+  const {
+    subject,
+    preheader = '',
+    headline,
+    body,
+    ctaLabel,
+    ctaUrl,
+    recipientEmail,
+    unsubscribeUrl,
+  } = input
+
+  const cta =
+    ctaLabel && ctaUrl
+      ? `
+      <tr>
+        <td align="center" style="padding: 16px 24px 8px;">
+          <a href="${escapeHtml(ctaUrl)}"
+             style="display:inline-block;background:${C.green};color:${C.bgOuter};
+                    font-weight:800;font-size:16px;text-decoration:none;
+                    padding:14px 32px;border-radius:9999px;
+                    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+            ${escapeHtml(ctaLabel)} →
+          </a>
+        </td>
+      </tr>`
+      : ''
+
+  const footerLinks =
+    unsubscribeUrl || recipientEmail
+      ? `
+        <div style="color:${C.muted};font-size:11px;margin-top:8px;">
+          ${recipientEmail ? `Sent to ${escapeHtml(recipientEmail)}. ` : ''}
+          ${
+            unsubscribeUrl
+              ? `<a href="${escapeHtml(unsubscribeUrl)}" style="color:${C.muted};text-decoration:underline;">Unsubscribe</a>`
+              : ''
+          }
+        </div>`
+      : ''
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:${C.bgOuter};
+               font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,sans-serif;
+               color:${C.text};-webkit-font-smoothing:antialiased;">
+
+    <!-- Preheader (hidden in body, shown in inbox preview) -->
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">
+      ${escapeHtml(preheader)}
+    </div>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${C.bgOuter};padding:32px 16px;">
+      <tr>
+        <td align="center">
+
+          <!-- Container -->
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0"
+                 style="max-width:600px;width:100%;background:${C.bgCard};
+                        border:1px solid ${C.border};border-radius:20px;overflow:hidden;">
+
+            <!-- Header / brand strip -->
+            <tr>
+              <td style="background:linear-gradient(135deg, ${C.green}14 0%, ${C.accent}14 100%);
+                         padding:24px 32px;border-bottom:1px solid ${C.border};">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="left">
+                      <span style="font-size:22px;font-weight:900;color:${C.text};letter-spacing:-0.5px;">
+                        <span style="font-size:24px;">🪴</span>
+                        &nbsp;PotBot
+                      </span>
+                    </td>
+                    <td align="right">
+                      <span style="font-size:11px;color:${C.muted};">Group DeFi on Solana</span>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Hero headline -->
+            <tr>
+              <td style="padding:40px 32px 16px;">
+                <h1 style="margin:0;font-size:30px;line-height:1.15;font-weight:900;color:${C.text};letter-spacing:-0.5px;">
+                  ${escapeHtml(headline)}
+                </h1>
+              </td>
+            </tr>
+
+            <!-- Body -->
+            <tr>
+              <td style="padding:8px 32px 16px;font-size:16px;line-height:1.6;color:${C.mutedSoft};">
+                ${body}
+              </td>
+            </tr>
+
+            <!-- CTA -->
+            ${cta}
+
+            <!-- Divider -->
+            <tr>
+              <td style="padding:24px 32px 0;">
+                <div style="height:1px;background:${C.border};"></div>
+              </td>
+            </tr>
+
+            <!-- Socials -->
+            <tr>
+              <td align="center" style="padding:20px 32px 24px;font-size:13px;color:${C.muted};">
+                <a href="https://potbot.fun" style="color:${C.green};text-decoration:none;margin:0 10px;">Website</a>
+                ·
+                <a href="https://x.com/PotBot_sol" style="color:${C.green};text-decoration:none;margin:0 10px;">Twitter</a>
+                ·
+                <a href="https://github.com/YD811/potbot-v2" style="color:${C.green};text-decoration:none;margin:0 10px;">GitHub</a>
+              </td>
+            </tr>
+          </table>
+
+          <!-- Footer -->
+          <div style="max-width:600px;margin:16px auto 0;text-align:center;color:${C.muted};font-size:12px;line-height:1.5;">
+            <div>Built for Solana Frontier 2026 · Group DeFi Vaults</div>
+            ${footerLinks}
+          </div>
+
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+}
+
+/**
+ * Plain-text fallback (for email clients / spam filters).
+ * Strips HTML and keeps the CTA as a trailing link.
+ */
+export function renderEmailPlainText(input: EmailTemplateInput): string {
+  const lines: string[] = []
+  lines.push('🪴 PotBot — Group DeFi on Solana')
+  lines.push('')
+  lines.push(input.headline)
+  lines.push('')
+  lines.push(
+    input.body
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+  )
+  if (input.ctaLabel && input.ctaUrl) {
+    lines.push('')
+    lines.push(`${input.ctaLabel}: ${input.ctaUrl}`)
+  }
+  lines.push('')
+  lines.push('—')
+  lines.push('potbot.fun · https://x.com/PotBot_sol')
+  if (input.unsubscribeUrl) {
+    lines.push(`Unsubscribe: ${input.unsubscribeUrl}`)
+  }
+  return lines.join('\n')
+}

--- a/supabase/migrations/004_waitlist_referral_fields.sql
+++ b/supabase/migrations/004_waitlist_referral_fields.sql
@@ -1,0 +1,35 @@
+-- Extend waitlist table with referral/profile fields for the full sign-up form.
+-- New columns are optional so existing email-only rows remain valid.
+--
+-- After this migration, /api/waitlist accepts { email, twitter?, telegram?, solana_wallet? }.
+
+ALTER TABLE waitlist
+  ADD COLUMN IF NOT EXISTS twitter        TEXT,
+  ADD COLUMN IF NOT EXISTS telegram       TEXT,
+  ADD COLUMN IF NOT EXISTS solana_wallet  TEXT,
+  ADD COLUMN IF NOT EXISTS referrer_code  TEXT,
+  ADD COLUMN IF NOT EXISTS updated_at     TIMESTAMPTZ DEFAULT NOW();
+
+-- Lookup index for wallet-based dedup / analytics
+CREATE INDEX IF NOT EXISTS waitlist_solana_wallet_idx ON waitlist (solana_wallet)
+  WHERE solana_wallet IS NOT NULL;
+
+-- Source values we use going forward
+COMMENT ON COLUMN waitlist.source        IS 'landing | signup | telegram | twitter | referral';
+COMMENT ON COLUMN waitlist.twitter       IS 'Twitter/X handle (leading @ stripped before store)';
+COMMENT ON COLUMN waitlist.telegram      IS 'Telegram username (leading @ stripped before store)';
+COMMENT ON COLUMN waitlist.solana_wallet IS 'Solana wallet address (base58, 32 bytes)';
+COMMENT ON COLUMN waitlist.referrer_code IS 'Optional invite code / referrer handle';
+
+-- Touch updated_at on UPDATE
+CREATE OR REPLACE FUNCTION waitlist_set_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS waitlist_updated_at ON waitlist;
+CREATE TRIGGER waitlist_updated_at
+  BEFORE UPDATE ON waitlist
+  FOR EACH ROW EXECUTE FUNCTION waitlist_set_updated_at();


### PR DESCRIPTION
## Summary

End-to-end email signup + admin broadcast feature for potbot.fun.

**New capabilities**
- Full signup form at `/signup` collecting email, Twitter, Telegram, Solana wallet
- Existing inline email capture on landing still works (now explicitly tagged `source: 'landing'`)
- Branded HTML + plain-text email template matching the PotBot dark theme
- Admin-only `/api/admin/send-email` endpoint — gated by `ADMIN_SECRET`, fans out via Resend's batch API (50 per call), supports `dryRun` and `emailOverride` for safe testing

## Changes

### Database
- **`supabase/migrations/004_waitlist_referral_fields.sql`** — adds `twitter`, `telegram`, `solana_wallet`, `referrer_code`, `updated_at` columns to `waitlist`; adds index on `solana_wallet`; adds `updated_at` trigger

### API
- **`apps/web/src/app/api/waitlist/route.ts`** — extended to accept `twitter` / `telegram` / `solana_wallet`. Validates wallet via `@solana/web3.js` `PublicKey`, strips leading `@` from handles. Uses `upsert({ onConflict: 'email' })` so users can revisit `/signup` and add a wallet without errors. `source === 'signup'` requires at least one extra contact field.
- **`apps/web/src/app/api/admin/send-email/route.ts`** — new. `POST` with `{ subject, headline, body, ctaLabel?, ctaUrl?, sourceFilter?, emailOverride?, dryRun? }`. Fetches recipients from Supabase, batches 50 per Resend call, returns `{ sent, failed, errors[], recipientsTotal }`. `GET` returns env-var health check.

### Frontend
- **`apps/web/src/app/signup/page.tsx`** — new `/signup` route with SEO metadata, two-column layout (perks sidebar + form card)
- **`apps/web/src/components/SignupForm.tsx`** — client form with idle / loading / success / duplicate / error states
- **`apps/web/src/components/LandingPage.tsx`** — primary "🚀 Get Early Access" CTA in hero, cross-links from inline form success/duplicate to `/signup`, "Full sign-up →" link under inline form, footer link, final-CTA button

### Email
- **`apps/web/src/lib/email-template.ts`** — `renderEmail()` + `renderEmailPlainText()`. Inline-styled, table-based HTML for cross-client compat; hidden preheader; CTA pill; PotBot brand colors.

## Required env vars (production)

```
ADMIN_SECRET=<long-random-string>      # gates the admin endpoints
RESEND_API_KEY=<from resend.com>       # https://resend.com/api-keys
RESEND_FROM="PotBot <hello@potbot.fun>" # must be a verified domain in Resend
NEXT_PUBLIC_SUPABASE_URL=...
SUPABASE_SERVICE_ROLE_KEY=...
```

## Test plan

- [ ] Run migration 004 against Supabase (adds columns without data loss)
- [ ] Visit `/signup` — submit email only → expect 400 asking for at least one extra field
- [ ] Submit full form with valid wallet → row lands in `waitlist` with `source = 'signup'`
- [ ] Submit again with same email + different wallet → row updated (upsert), `updated_at` advances
- [ ] Invalid wallet text → stored as `NULL`, not a 400
- [ ] Landing inline form still works (`source = 'landing'`) and the "Full sign-up →" link goes to `/signup`
- [ ] `GET /api/admin/send-email` with Bearer `ADMIN_SECRET` → env var health check
- [ ] `POST /api/admin/send-email` with `{ dryRun: true, emailOverride: "me@example.com", subject, headline, body }` → returns `recipientsPreviewCount: 1` without sending
- [ ] Send a real test email to one address via `emailOverride` → inbox delivery + branded rendering
- [ ] Blast to everyone with `source === 'signup'` filter → `{ sent: N, failed: 0 }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)