### PR TITLE
feat(theme): port v3 light/dark slider

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -67,3 +67,88 @@
 .wallet-adapter-modal-title {
   @apply !text-white;
 }
+
+/* ──────────────────────────────────────────────────────────── */
+/*  LIGHT THEME OVERRIDES                                        */
+/*  Triggered by <html data-theme="light"> (set by ThemeToggle)  */
+/*  Covers the landing + all pot-* tokens used across the app.   */
+/* ──────────────────────────────────────────────────────────── */
+
+html[data-theme="light"] {
+  color-scheme: light;
+}
+
+html[data-theme="light"] body,
+html[data-theme="light"] .bg-pot-dark {
+  background-color: #f5f7fa !important;
+  color: #0d1117 !important;
+}
+
+html[data-theme="light"] .bg-pot-card {
+  background-color: #ffffff !important;
+}
+
+html[data-theme="light"] .border-pot-border,
+html[data-theme="light"] .border-pot-border\/40,
+html[data-theme="light"] .border-pot-border\/50 {
+  border-color: #e5e7eb !important;
+}
+
+html[data-theme="light"] .bg-pot-border {
+  background-color: #e5e7eb !important;
+}
+
+/* White text → near-black in light mode */
+html[data-theme="light"] .text-white {
+  color: #0d1117 !important;
+}
+
+/* Muted greys stay muted but shift warmer */
+html[data-theme="light"] .text-pot-muted {
+  color: #57606a !important;
+}
+html[data-theme="light"] .text-gray-400 {
+  color: #6b7280 !important;
+}
+
+/* Transparent / alpha backgrounds used by nav/hero glow */
+html[data-theme="light"] .bg-pot-dark\/60,
+html[data-theme="light"] .bg-pot-dark\/80,
+html[data-theme="light"] .bg-pot-dark\/95 {
+  background-color: rgba(245, 247, 250, 0.85) !important;
+}
+html[data-theme="light"] .bg-pot-card\/50 {
+  background-color: rgba(255, 255, 255, 0.6) !important;
+}
+
+/* Gradients on Waitlist section + For-builders */
+html[data-theme="light"] .from-pot-accent\/10 { --tw-gradient-from: rgba(139, 92, 246, 0.08) !important; }
+html[data-theme="light"] .via-pot-card        { --tw-gradient-via: #ffffff !important; }
+html[data-theme="light"] .to-pot-green\/10    { --tw-gradient-to: rgba(0, 255, 136, 0.08) !important; }
+html[data-theme="light"] .from-pot-card       { --tw-gradient-from: #ffffff !important; }
+html[data-theme="light"] .to-pot-dark         { --tw-gradient-to: #f5f7fa !important; }
+html[data-theme="light"] .from-pot-green\/5   { --tw-gradient-from: rgba(0, 255, 136, 0.05) !important; }
+html[data-theme="light"] .to-pot-accent\/5    { --tw-gradient-to: rgba(139, 92, 246, 0.05) !important; }
+
+/* btn-secondary: dark card → white card with dark text */
+html[data-theme="light"] .btn-secondary {
+  background-color: #ffffff !important;
+  color: #0d1117 !important;
+  border-color: #e5e7eb !important;
+}
+
+/* Input gets a soft background, not pot-dark */
+html[data-theme="light"] .input {
+  background-color: #ffffff !important;
+  color: #0d1117 !important;
+  border-color: #e5e7eb !important;
+}
+
+/* Scrollbar */
+html[data-theme="light"] ::-webkit-scrollbar-track { background: #f5f7fa; }
+html[data-theme="light"] ::-webkit-scrollbar-thumb { background: #d1d5db; }
+
+/* Smooth the theme swap */
+html, body, nav, section, footer, .card, .btn-secondary, .input {
+  transition: background-color .2s ease, color .2s ease, border-color .2s ease;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,13 +8,31 @@ export const metadata: Metadata = {
   description: 'Create group trading vaults, govern together, trade together, win together.',
 }
 
+// Runs before React hydrates — prevents light/dark flash on first paint.
+const THEME_BOOTSTRAP = `
+(function(){
+  try {
+    var stored = localStorage.getItem('pot-theme');
+    var theme = stored === 'light' || stored === 'dark'
+      ? stored
+      : (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    document.documentElement.setAttribute('data-theme', theme);
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+})();
+`.trim()
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }} />
+      </head>
       <body className="min-h-screen bg-pot-dark text-white antialiased">
         <AppProviders>
           <Navbar />

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { useWallet } from '@solana/wallet-adapter-react'
 import { useQuery } from '@tanstack/react-query'
 import { useSolPrice } from '@/lib/prices'
 import { healthApi } from '@/lib/api-client'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 const WalletMultiButtonDynamic = dynamic(
   async () =>
@@ -96,6 +97,9 @@ export function Navbar() {
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Theme slider (dark ↔ light) */}
+          <ThemeToggle />
+
           {/* Waitlist / Early-Access CTA — visible on every page */}
           {showWaitlistCta && (
             <Link

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Theme = 'dark' | 'light'
+
+/**
+ * Theme pill slider (58×30). Matches the v3 landing prototype.
+ * Stores choice in localStorage under `pot-theme`, falls back to prefers-color-scheme.
+ * Applies `data-theme` attribute on <html>.
+ */
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>('dark')
+  const [mounted, setMounted] = useState(false)
+
+  // Sync from DOM on mount (the pre-hydration script in layout.tsx already set it)
+  useEffect(() => {
+    const current = (document.documentElement.getAttribute('data-theme') as Theme) || 'dark'
+    setTheme(current)
+    setMounted(true)
+  }, [])
+
+  function toggle() {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.setAttribute('data-theme', next)
+    try {
+      localStorage.setItem('pot-theme', next)
+    } catch {}
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Toggle theme"
+      title={mounted ? `Switch to ${theme === 'dark' ? 'light' : 'dark'} mode` : 'Toggle theme'}
+      className="theme-slider relative h-[30px] w-[58px] shrink-0 rounded-full border border-pot-border bg-pot-card transition hover:border-pot-green"
+    >
+      <span
+        className={`theme-slider-knob absolute top-[2px] flex h-[24px] w-[24px] items-center justify-center rounded-full text-[13px] shadow-[0_2px_8px_rgba(20,241,149,0.35)] transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+          theme === 'light' ? 'left-[calc(100%-26px)]' : 'left-[2px]'
+        }`}
+        style={{ background: 'linear-gradient(135deg,#14F195 0%,#9945FF 100%)' }}
+      >
+        {theme === 'dark' ? '🌙' : '☀️'}
+      </span>
+      <span className="pointer-events-none absolute inset-0 flex items-center justify-between px-[8px] text-[11px] text-pot-muted">
+        <span aria-hidden>☀️</span>
+        <span aria-hidden>🌙</span>
+      </span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Changes

- New `ThemeToggle` component (58x30 pill slider) matching v3 prototype
- Mounted in Navbar right of logo, left of Waitlist CTA
- Persists choice in localStorage (`pot-theme`) with prefers-color-scheme fallback
- Inline bootstrap script in `layout.tsx` — no light/dark flash before hydration
- Light theme overrides in `globals.css` via `[data-theme="light"]` — background, card, border, text-white, gradients, input, btn-secondary
