### PR TITLE
Add waitlist rate-limiting/honeypot, site SEO/robots/sitemap, status page, and CORS origin fallback

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,7 @@ const app = new Hono()
 app.use('*', cors({
   origin: (origin) => {
     const allowed = (process.env.CORS_ORIGINS ?? 'http://localhost:3000').split(',')
+    if (!origin) return allowed[0]
     return allowed.includes(origin) || origin.endsWith('.vercel.app') ? origin : allowed[0]
   },
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     title: 'PotBot — Group Trading Vaults on Solana',
     description: 'Create shared on-chain vaults, vote on trades, and watch your Tamagotchi grow.',
     type: 'website',
-    url: 'https://potbot.xyz',
+    url: 'https://potbot.fun',
     images: [{ url: '/og-image.png', width: 1200, height: 630 }],
   },
   twitter: {

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -12,6 +12,7 @@ interface DevEntry {
   created_at: string
 }
 const devWaitlist = new Map<string, DevEntry>()
+const waitlistWindows = new Map<string, { count: number; windowStart: number }>()
 
 // Source values we expect from the front-end. Anything else is coerced to 'other'.
 const ALLOWED_SOURCES = new Set(['landing', 'signup', 'telegram', 'twitter', 'referral'])
@@ -40,9 +41,44 @@ function cleanWallet(raw: unknown): string | null {
   }
 }
 
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get('cf-connecting-ip') ??
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  )
+}
+
+function isRateLimited(req: NextRequest, maxPerMinute = 8): boolean {
+  const ip = getClientIp(req)
+  const key = `wl:${ip}`
+  const now = Date.now()
+  const windowMs = 60_000
+  const entry = waitlistWindows.get(key)
+
+  if (!entry || now - entry.windowStart > windowMs) {
+    waitlistWindows.set(key, { count: 1, windowStart: now })
+    return false
+  }
+
+  entry.count += 1
+  return entry.count > maxPerMinute
+}
+
 export async function POST(req: NextRequest) {
   try {
+    if (isRateLimited(req)) {
+      return NextResponse.json({ error: 'Too many requests. Try again in a minute.' }, { status: 429 })
+    }
+
     const body = await req.json().catch(() => ({}))
+
+    // Honeypot field for basic bot filtering. Real UI does not send it.
+    if (typeof body.website === 'string' && body.website.trim().length > 0) {
+      return NextResponse.json({ success: true })
+    }
+
     const email = (body.email ?? '').toString().trim().toLowerCase()
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,22 @@ import './globals.css'
 export const metadata: Metadata = {
   title: 'PotBot v2 — Group Trading Vaults on Solana',
   description: 'Create group trading vaults, govern together, trade together, win together.',
+  metadataBase: new URL('https://potbot.fun'),
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'PotBot v2 — Group Trading Vaults on Solana',
+    description: 'Create group trading vaults, govern together, trade together, win together.',
+    url: 'https://potbot.fun',
+    siteName: 'PotBot',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'PotBot v2 — Group Trading Vaults on Solana',
+    description: 'Create group trading vaults, govern together, trade together, win together.',
+  },
 }
 
 // Runs before React hydrates — prevents light/dark flash on first paint.

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: 'https://potbot.fun/sitemap.xml',
+    host: 'https://potbot.fun',
+  }
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+
+  return [
+    { url: 'https://potbot.fun', lastModified, changeFrequency: 'daily', priority: 1 },
+    { url: 'https://potbot.fun/vaults', lastModified, changeFrequency: 'daily', priority: 0.9 },
+    { url: 'https://potbot.fun/leaderboard', lastModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: 'https://potbot.fun/create', lastModified, changeFrequency: 'weekly', priority: 0.8 },
+    { url: 'https://potbot.fun/for-agents', lastModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: 'https://potbot.fun/signup', lastModified, changeFrequency: 'weekly', priority: 0.8 },
+    { url: 'https://potbot.fun/hackathon', lastModified, changeFrequency: 'monthly', priority: 0.6 },
+  ]
+}

--- a/apps/web/src/app/status/page.tsx
+++ b/apps/web/src/app/status/page.tsx
@@ -1,0 +1,32 @@
+export default function StatusPage() {
+  const checks = [
+    { name: 'Web API Health', href: '/api/health', note: 'Next.js route health check' },
+    { name: 'Prices API', href: '/api/prices', note: 'Live price feed endpoint' },
+    { name: 'Leaderboard API', href: '/api/leaderboard', note: 'Public rankings endpoint' },
+  ]
+
+  return (
+    <div className="max-w-3xl mx-auto py-12">
+      <h1 className="text-3xl font-black text-white mb-3">PotBot Status</h1>
+      <p className="text-pot-muted mb-8">
+        Quick operational checks for public endpoints.
+      </p>
+
+      <div className="space-y-3">
+        {checks.map((check) => (
+          <a
+            key={check.href}
+            href={check.href}
+            className="card p-4 flex items-center justify-between hover:border-pot-green/30 transition"
+          >
+            <div>
+              <div className="font-semibold text-white">{check.name}</div>
+              <div className="text-sm text-pot-muted">{check.note}</div>
+            </div>
+            <span className="text-pot-green text-sm">Open →</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -597,6 +597,32 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* ── Trust & Risk ── */}
+      <section className="max-w-6xl mx-auto px-4 pb-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          {[
+            { k: 'Network', v: 'Solana Devnet', sub: 'Mainnet rollout after hardening' },
+            { k: 'Custody', v: 'Program-controlled vaults', sub: 'No bot-held treasury keys' },
+            { k: 'Execution', v: 'Vote-gated actions', sub: 'AI proposes, members approve' },
+            { k: 'Status', v: 'Live API health', sub: 'Public endpoint: /api/health' },
+          ].map((item) => (
+            <div key={item.k} className="card p-4">
+              <div className="text-[11px] uppercase tracking-wider text-pot-muted">{item.k}</div>
+              <div className="text-white font-bold mt-1">{item.v}</div>
+              <div className="text-xs text-pot-muted mt-1">{item.sub}</div>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-pot-muted mt-4 text-center">
+          Risk disclosure: DeFi strategies can lose principal. Start with demo mode and small sizes.
+        </p>
+        <div className="text-center mt-2">
+          <Link href="/status" className="text-xs text-pot-green hover:underline">
+            View public status checks →
+          </Link>
+        </div>
+      </section>
+
       {/* ── Features grid ── */}
       <section className="max-w-6xl mx-auto px-4 py-16">
         <div className="text-center mb-12">


### PR DESCRIPTION
### Motivation

- Prevent automated spam and abuse on the public waitlist endpoint by adding lightweight rate-limiting and a honeypot.  
- Ensure predictable CORS behavior when requests have no `Origin` header.  
- Improve SEO and indexing by centralizing canonical site configuration to `https://potbot.fun` and exposing `sitemap.xml` and `robots.txt`.  
- Surface basic operational info and trust guidance on the landing site via a public status page and a trust/risk block.

### Description

- Implemented IP-based in-memory rate limiting for the waitlist route via `getClientIp` and `isRateLimited` with a per-minute cap, plus a `website` honeypot field that silently accepts bots.  
- Added `waitlistWindows` in-memory map for tracking request windows and return `429` when the limit is exceeded.  
- Adjusted global CORS middleware to return the default allowed origin when there is no `Origin` header.  
- Updated landing and web app metadata to use `https://potbot.fun` (added `metadataBase`, `alternates`, `openGraph`, and `twitter` entries) and changed the old landing open graph URL.  
- Added `robots.ts` and `sitemap.ts` Next metadata routes to publish sitemap and robots rules, and added a simple `/status` page to expose public health checks.  
- Added a trust & risk section to the landing `LandingPage.tsx` showing network/custody/execution/status notes and a link to the status page.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` and it completed successfully.  
- Built the Next.js app with `next build` and the production build succeeded.  
- Ran lint/type/CI checks (`eslint` / project build scripts) as part of CI and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6aff36f8832fa81a174ee4375a88)