### PR TITLE
fix: fix mint constraints in execute_swap to support exit swaps

### DIFF
--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -110,7 +110,7 @@ pub struct ExecuteSwap<'info> {
         mut,
         constraint = source_ata.owner == vault.key()
             @ crate::errors::PotError::VaultOwnerMismatch,
-        constraint = source_ata.mint == strategy.input_mint
+        constraint = (args.is_entry && source_ata.mint == strategy.input_mint) || (!args.is_entry && source_ata.mint == strategy.output_mint)
             @ crate::errors::PotError::MintNotAllowlisted,
     )]
     pub source_ata: Account<'info, TokenAccount>,
@@ -119,7 +119,7 @@ pub struct ExecuteSwap<'info> {
         mut,
         constraint = destination_ata.owner == vault.key()
             @ crate::errors::PotError::VaultOwnerMismatch,
-        constraint = destination_ata.mint == strategy.output_mint
+        constraint = (args.is_entry && destination_ata.mint == strategy.output_mint) || (!args.is_entry && destination_ata.mint == strategy.input_mint)
             @ crate::errors::PotError::MintNotAllowlisted,
     )]
     pub destination_ata: Account<'info, TokenAccount>,


### PR DESCRIPTION
## Fixes Codex review findings

### Bug fixed: exit swap mint constraints (execute_swap.rs)

The account constraints hard-pinned `source_ata` to `strategy.input_mint` and `destination_ata` to `strategy.output_mint` regardless of `args.is_entry`. For exit swaps (`Active → Closed`), the vault needs to spend the output mint and receive back the input mint — the old constraints rejected this valid setup before CPI.

**Fix:** constraints now switch based on `args.is_entry`:
- entry: `source = input_mint`, `destination = output_mint` (unchanged)
- - exit: `source = output_mint`, `destination = input_mint` (swapped)