### PR TITLE
CORS/Origin hardening, waitlist rate-limits & honeypot, SEO metadata, sitemap/robots and status page

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,11 +16,31 @@ import { analyticsGate } from './middleware/x402.js'
 
 const app = new Hono()
 
+function normalizeOrigins(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+function isAllowedOrigin(origin: string, allowedOrigins: string[]): boolean {
+  if (allowedOrigins.includes(origin)) return true
+
+  // Allow only Vercel preview URLs for this project naming convention.
+  return /^https:\/\/potbot(?:-[a-z0-9-]+)?\.vercel\.app$/i.test(origin)
+}
+
 // ── Global Middleware ────────────────────────────────────────────────────────
 app.use('*', cors({
   origin: (origin) => {
-    const allowed = (process.env.CORS_ORIGINS ?? 'http://localhost:3000').split(',')
-    return allowed.includes(origin) || origin.endsWith('.vercel.app') ? origin : allowed[0]
+    const allowed = normalizeOrigins(
+      process.env.CORS_ORIGINS ??
+      'http://localhost:3000,https://potbot.fun,https://www.potbot.fun',
+    )
+
+    // Non-browser callers may omit Origin. In that case return the primary configured origin.
+    if (!origin) return allowed[0] ?? 'http://localhost:3000'
+    return isAllowedOrigin(origin, allowed) ? origin : allowed[0] ?? origin
   },
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization', 'X-PAYMENT'],

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     title: 'PotBot — Group Trading Vaults on Solana',
     description: 'Create shared on-chain vaults, vote on trades, and watch your Tamagotchi grow.',
     type: 'website',
-    url: 'https://potbot.xyz',
+    url: 'https://potbot.fun',
     images: [{ url: '/og-image.png', width: 1200, height: 630 }],
   },
   twitter: {

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -12,6 +12,10 @@ interface DevEntry {
   created_at: string
 }
 const devWaitlist = new Map<string, DevEntry>()
+const waitlistWindows = new Map<string, { count: number; windowStart: number }>()
+const WAITLIST_WINDOW_MS = 60_000
+const WAITLIST_MAX_PER_MINUTE = 8
+const WAITLIST_SWEEP_FLAG = '__potbotWaitlistSweepStarted'
 
 // Source values we expect from the front-end. Anything else is coerced to 'other'.
 const ALLOWED_SOURCES = new Set(['landing', 'signup', 'telegram', 'twitter', 'referral'])
@@ -40,9 +44,92 @@ function cleanWallet(raw: unknown): string | null {
   }
 }
 
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get('cf-connecting-ip') ??
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  )
+}
+
+function isRateLimited(req: NextRequest, maxPerMinute = 8): boolean {
+  const ip = getClientIp(req)
+  const key = `wl:${ip}`
+  const now = Date.now()
+  const windowMs = WAITLIST_WINDOW_MS
+  const entry = waitlistWindows.get(key)
+
+  if (!entry || now - entry.windowStart > windowMs) {
+    waitlistWindows.set(key, { count: 1, windowStart: now })
+    return false
+  }
+
+  entry.count += 1
+  return entry.count > maxPerMinute
+}
+
+function isTrustedOrigin(req: NextRequest): boolean {
+  const origin = req.headers.get('origin')
+  const host = req.headers.get('host')
+  const referer = req.headers.get('referer')
+
+  const allowed = new Set<string>([
+    'http://localhost:3000',
+    'https://potbot.fun',
+    'https://www.potbot.fun',
+  ])
+
+  if (host) {
+    allowed.add(`https://${host}`)
+    allowed.add(`http://${host}`)
+  }
+
+  if (origin && allowed.has(origin)) return true
+  if (!origin && referer) {
+    try {
+      return allowed.has(new URL(referer).origin)
+    } catch {
+      return false
+    }
+  }
+
+  // Allow non-browser requests without origin/referer (server-to-server).
+  return !origin && !referer
+}
+
+function withRateHeaders(res: NextResponse, req: NextRequest): NextResponse {
+  const ip = getClientIp(req)
+  const key = `wl:${ip}`
+  const entry = waitlistWindows.get(key)
+  const remaining = entry ? Math.max(0, WAITLIST_MAX_PER_MINUTE - entry.count) : WAITLIST_MAX_PER_MINUTE
+  const resetAt = entry ? Math.ceil((entry.windowStart + WAITLIST_WINDOW_MS) / 1000) : Math.ceil((Date.now() + WAITLIST_WINDOW_MS) / 1000)
+  res.headers.set('X-RateLimit-Limit', String(WAITLIST_MAX_PER_MINUTE))
+  res.headers.set('X-RateLimit-Remaining', String(remaining))
+  res.headers.set('X-RateLimit-Reset', String(resetAt))
+  return res
+}
+
 export async function POST(req: NextRequest) {
   try {
+    if (!isTrustedOrigin(req)) {
+      return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 })
+    }
+
+    if (isRateLimited(req)) {
+      return withRateHeaders(
+        NextResponse.json({ error: 'Too many requests. Try again in a minute.' }, { status: 429 }),
+        req,
+      )
+    }
+
     const body = await req.json().catch(() => ({}))
+
+    // Honeypot field for basic bot filtering. Real UI does not send it.
+    if (typeof body.website === 'string' && body.website.trim().length > 0) {
+      return withRateHeaders(NextResponse.json({ success: true }), req)
+    }
+
     const email = (body.email ?? '').toString().trim().toLowerCase()
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
@@ -116,10 +203,10 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    return NextResponse.json({ success: true })
+    return withRateHeaders(NextResponse.json({ success: true }), req)
   } catch (e) {
     console.error('[waitlist] error:', e)
-    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+    return withRateHeaders(NextResponse.json({ error: 'Server error' }, { status: 500 }), req)
   }
 }
 
@@ -140,4 +227,17 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ count })
   }
   return NextResponse.json({ count: devWaitlist.size, mode: 'demo' })
+}
+
+const globalForWaitlist = globalThis as typeof globalThis & Record<string, unknown>
+if (!globalForWaitlist[WAITLIST_SWEEP_FLAG]) {
+  globalForWaitlist[WAITLIST_SWEEP_FLAG] = true
+  setInterval(() => {
+    const now = Date.now()
+    for (const [key, value] of waitlistWindows) {
+      if (now - value.windowStart > WAITLIST_WINDOW_MS * 2) {
+        waitlistWindows.delete(key)
+      }
+    }
+  }, 5 * 60_000)
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,22 @@ import './globals.css'
 export const metadata: Metadata = {
   title: 'PotBot v2 — Group Trading Vaults on Solana',
   description: 'Create group trading vaults, govern together, trade together, win together.',
+  metadataBase: new URL('https://potbot.fun'),
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'PotBot v2 — Group Trading Vaults on Solana',
+    description: 'Create group trading vaults, govern together, trade together, win together.',
+    url: 'https://potbot.fun',
+    siteName: 'PotBot',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'PotBot v2 — Group Trading Vaults on Solana',
+    description: 'Create group trading vaults, govern together, trade together, win together.',
+  },
 }
 
 // Runs before React hydrates — prevents light/dark flash on first paint.

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: 'https://potbot.fun/sitemap.xml',
+    host: 'https://potbot.fun',
+  }
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+
+  return [
+    { url: 'https://potbot.fun', lastModified, changeFrequency: 'daily', priority: 1 },
+    { url: 'https://potbot.fun/vaults', lastModified, changeFrequency: 'daily', priority: 0.9 },
+    { url: 'https://potbot.fun/leaderboard', lastModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: 'https://potbot.fun/create', lastModified, changeFrequency: 'weekly', priority: 0.8 },
+    { url: 'https://potbot.fun/for-agents', lastModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: 'https://potbot.fun/signup', lastModified, changeFrequency: 'weekly', priority: 0.8 },
+    { url: 'https://potbot.fun/status', lastModified, changeFrequency: 'daily', priority: 0.6 },
+    { url: 'https://potbot.fun/hackathon', lastModified, changeFrequency: 'monthly', priority: 0.6 },
+  ]
+}

--- a/apps/web/src/app/status/page.tsx
+++ b/apps/web/src/app/status/page.tsx
@@ -1,0 +1,78 @@
+type Check = {
+  name: string
+  href: string
+  note: string
+}
+
+type CheckResult = Check & {
+  ok: boolean
+  status: number
+  latencyMs: number
+}
+
+const checks: Check[] = [
+  { name: 'Web API Health', href: '/api/health', note: 'Core service heartbeat' },
+  {
+    name: 'Prices API',
+    href: '/api/prices?mints=So11111111111111111111111111111111111111112',
+    note: 'Token pricing endpoint',
+  },
+  { name: 'Leaderboard API', href: '/api/leaderboard', note: 'Public leaderboard endpoint' },
+]
+
+async function runCheck(check: Check): Promise<CheckResult> {
+  const started = Date.now()
+  try {
+    const res = await fetch(check.href, { cache: 'no-store' })
+    return {
+      ...check,
+      ok: res.ok,
+      status: res.status,
+      latencyMs: Date.now() - started,
+    }
+  } catch {
+    return {
+      ...check,
+      ok: false,
+      status: 0,
+      latencyMs: Date.now() - started,
+    }
+  }
+}
+
+export const dynamic = 'force-dynamic'
+
+export default async function StatusPage() {
+  const results = await Promise.all(checks.map(runCheck))
+  const healthy = results.filter((c) => c.ok).length
+
+  return (
+    <div className="max-w-3xl mx-auto py-12">
+      <h1 className="text-3xl font-black text-white mb-3">PotBot Status</h1>
+      <p className="text-pot-muted mb-2">Live checks for key public endpoints.</p>
+      <p className="text-xs text-pot-muted/80 mb-8">
+        {healthy}/{results.length} checks passing · Updated {new Date().toLocaleString()}
+      </p>
+
+      <div className="space-y-3">
+        {results.map((check) => (
+          <a
+            key={check.href}
+            href={check.href}
+            className="card p-4 flex items-center justify-between hover:border-pot-green/30 transition"
+          >
+            <div>
+              <div className="font-semibold text-white flex items-center gap-2">
+                {check.ok ? '🟢' : '🔴'} {check.name}
+              </div>
+              <div className="text-sm text-pot-muted">
+                {check.note} · HTTP {check.status || 'ERR'} · {check.latencyMs}ms
+              </div>
+            </div>
+            <span className="text-pot-green text-sm">Open →</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -597,6 +597,32 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* ── Trust & Risk ── */}
+      <section className="max-w-6xl mx-auto px-4 pb-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          {[
+            { k: 'Network', v: 'Solana Devnet', sub: 'Mainnet rollout after hardening' },
+            { k: 'Custody', v: 'Program-controlled vaults', sub: 'No bot-held treasury keys' },
+            { k: 'Execution', v: 'Vote-gated actions', sub: 'AI proposes, members approve' },
+            { k: 'Status', v: 'Live API health', sub: 'Public endpoint: /api/health' },
+          ].map((item) => (
+            <div key={item.k} className="card p-4">
+              <div className="text-[11px] uppercase tracking-wider text-pot-muted">{item.k}</div>
+              <div className="text-white font-bold mt-1">{item.v}</div>
+              <div className="text-xs text-pot-muted mt-1">{item.sub}</div>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-pot-muted mt-4 text-center">
+          Risk disclosure: DeFi strategies can lose principal. Start with demo mode and small sizes.
+        </p>
+        <div className="text-center mt-2">
+          <Link href="/status" className="text-xs text-pot-green hover:underline">
+            View public status checks →
+          </Link>
+        </div>
+      </section>
+
       {/* ── Features grid ── */}
       <section className="max-w-6xl mx-auto px-4 py-16">
         <div className="text-center mb-12">


### PR DESCRIPTION
### Motivation
- Harden API CORS/origin handling and provide sane defaults for vercel preview URLs and potbot domains.
- Protect the public waitlist endpoint from abuse via rate-limiting, origin checks, and a honeypot field.
- Improve site SEO and observability by standardizing site metadata, adding sitemap/robots, and exposing a public status page.

### Description
- Replace simple CORS split logic with `normalizeOrigins` and `isAllowedOrigin` in `apps/api/src/index.ts`, defaulting allowed origins and handling missing `Origin` headers more robustly.
- Add rate-limiting, origin validation, client IP extraction, honeypot handling, response rate-limit headers, and a periodic sweep for in-memory windows to `apps/web/src/app/api/waitlist/route.ts` to limit submissions per IP and reduce bot signups.
- Update landing and web metadata to use `https://potbot.fun`, add `metadataBase`, canonical alternates and richer OpenGraph/Twitter fields in layout files (`apps/landing/src/app/layout.tsx` and `apps/web/src/app/layout.tsx`).
- Add `robots.ts` and `sitemap.ts` under `apps/web/src/app` to publish robots rules and a sitemap pointing at `potbot.fun`.
- Add a public status page at `apps/web/src/app/status/page.tsx` that performs live checks against key endpoints.
- Add a small Trust & Risk card section and link to the new status page in the landing component (`apps/web/src/components/LandingPage.tsx`).

### Testing
- Performed TypeScript type-check and project build for the web and API bundles which completed successfully.
- Ran a local smoke check against the API health endpoint (`/api/health`) which returned a successful response.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6aff36f8832fa81a174ee4375a88)