### PR TITLE
security: role-based access control + audit doc

### DIFF
--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -11,6 +11,7 @@ import {
   useProposals,
   useVote,
 } from '@/hooks/usePots'
+import { usePotRole } from '@/hooks/usePotRole'
 import { calculateTamaStats } from '@/lib/tamagotchi/stats'
 import { PnLDashboard } from '@/components/PnLDashboard'
 import { SharesPanel } from '@/components/SharesPanel'
@@ -315,6 +316,7 @@ export default function PotPage() {
   const { data: pot, isLoading: isPotLoading } = usePot(pubkey)
   const { data: members = [] } = useMembers(pubkey)
   const { data: proposals = [] } = useProposals(pubkey)
+  const { role } = usePotRole(pubkey)
 
   // Default landing tab is deposit — first thing user can do.
   const [activeTab, setActiveTab] = useState<Tab>('deposit')
@@ -363,11 +365,12 @@ export default function PotPage() {
   }
 
   const potAny = pot as any
-  const ownerAddress: string = potAny.authority ?? potAny.owner ?? ''
-  const isOwner = userPubkey?.toString() === ownerAddress
-  const canManage = isOwner || isMember
+  const ownerAddress: string = potAny.authority ?? potAny.creator ?? potAny.owner ?? ''
+  const isOwner = role === 'creator'
+  const canManage = role === 'creator' || role === 'member'
   const canVote = canManage
   const canExecute = isOwner
+  const canWithdraw = canManage
 
   const tamaStats = calculateTamaStats({
     tradeVolume: potAny.totalVolume ?? 0,
@@ -392,6 +395,11 @@ export default function PotPage() {
                 <h1 className="text-3xl font-bold text-white mb-1 break-words">{pot.name}</h1>
                 {snsName && <p className="text-sm font-mono text-pot-green">{snsName}</p>}
                 <p className="text-xs text-pot-muted font-mono mt-1 break-all">{pubkey}</p>
+                <div className="mt-2">
+                  <span className="px-3 py-1 bg-pot-card border border-pot-border text-xs rounded-full text-pot-muted">
+                    You: {role === 'creator' ? 'Creator' : role === 'member' ? 'Member' : 'Viewer'}
+                  </span>
+                </div>
               </div>
             </div>
             <div className="flex flex-col items-end gap-2 shrink-0">
@@ -644,7 +652,20 @@ export default function PotPage() {
         {activeTab === 'tamagotchi' && <TamagotchiTab stats={tamaStats} />}
 
         {/* ── Shares ── */}
-        {activeTab === 'shares' && <SharesTab potPubkey={pubkey} />}
+        {activeTab === 'shares' && (
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <button
+                disabled={!canWithdraw}
+                title={!canWithdraw ? 'Members only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Withdraw
+              </button>
+            </div>
+            <SharesTab potPubkey={pubkey} canWithdraw={canWithdraw} />
+          </div>
+        )}
 
         {/* ── Positions / P&L — powered by Dune SIM ── */}
         {activeTab === 'positions' && (
@@ -659,10 +680,50 @@ export default function PotPage() {
         )}
 
         {/* ── Strategy ── */}
-        {activeTab === 'strategy' && <StrategyPanel potPubkey={pubkey} />}
+        {activeTab === 'strategy' && (
+          <div className="space-y-4">
+            <div className="flex gap-2 justify-end">
+              <button
+                disabled={!isOwner}
+                title={!isOwner ? 'Creator only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Edit Strategy
+              </button>
+              <button
+                disabled={!isOwner}
+                title={!isOwner ? 'Creator only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Pause
+              </button>
+            </div>
+            <StrategyPanel potPubkey={pubkey} />
+          </div>
+        )}
 
         {/* ── Governance Settings ── */}
-        {activeTab === 'governance' && <GovernanceSettings isAdmin={isOwner} potPubkey={pubkey} />}
+        {activeTab === 'governance' && (
+          <div className="space-y-4">
+            <div className="flex gap-2 justify-end">
+              <button
+                disabled={!isOwner}
+                title={!isOwner ? 'Creator only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Add Member
+              </button>
+              <button
+                disabled={!isOwner}
+                title={!isOwner ? 'Creator only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Remove Member
+              </button>
+            </div>
+            <GovernanceSettings isAdmin={isOwner} potPubkey={pubkey} />
+          </div>
+        )}
 
         {/* ── AI Agent ── */}
         {activeTab === 'agent' && <AIAgentPanel potPubkey={pubkey} pot={pot} />}
@@ -670,6 +731,15 @@ export default function PotPage() {
         {/* ── Members ── */}
         {activeTab === 'members' && (
           <div className="space-y-4 w-full">
+            <div className="flex justify-end">
+              <button
+                disabled={!isOwner}
+                title={!isOwner ? 'Creator only' : undefined}
+                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Manage
+              </button>
+            </div>
             {members.length === 0 ? (
               <div className="text-center py-12 bg-pot-card border border-pot-border rounded-2xl">
                 <p className="text-pot-muted">No members yet</p>

--- a/apps/web/src/components/SharesTab.tsx
+++ b/apps/web/src/components/SharesTab.tsx
@@ -5,6 +5,7 @@ import { useMockStore } from '@/lib/mock-store'
 
 interface Props {
   potPubkey: string
+  canWithdraw?: boolean
 }
 
 interface ShareData {
@@ -28,7 +29,7 @@ function deriveTokenSymbol(potName: string): string {
   )
 }
 
-export default function SharesTab({ potPubkey }: Props) {
+export default function SharesTab({ potPubkey, canWithdraw = true }: Props) {
   const { pots, members } = useMockStore()
 
   const pot = useMemo(() => pots.find((p) => p.pubkey === potPubkey), [pots, potPubkey])
@@ -130,7 +131,13 @@ export default function SharesTab({ potPubkey }: Props) {
               <div className="text-xs text-pot-muted">SOL</div>
             </div>
           </div>
-          <button className="btn-secondary w-full mt-4 py-3 text-sm">🔥 Redeem Shares</button>
+          <button
+            disabled={!canWithdraw}
+            title={!canWithdraw ? 'Members only' : undefined}
+            className="btn-secondary w-full mt-4 py-3 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            🔥 Redeem Shares
+          </button>
         </div>
       ) : (
         <div className="card p-5 border border-pot-border text-center">

--- a/apps/web/src/hooks/usePotRole.test.ts
+++ b/apps/web/src/hooks/usePotRole.test.ts
@@ -1,0 +1,19 @@
+// TODO: No vitest/jest dependency is currently configured in apps/web/package.json.
+// Add a test runner, then convert these documented cases into executable tests.
+//
+// Required cases:
+// 1) creator -> wallet matches pot.creator/pot.authority => role === 'creator'
+// 2) member  -> wallet appears in members[] but is not creator => role === 'member'
+// 3) viewer  -> wallet is connected but not creator/member OR wallet missing => role === 'viewer'
+//
+// Suggested test skeleton (vitest):
+// import { describe, expect, it } from 'vitest'
+// import { derivePotRole } from './usePotRole'
+//
+// describe('derivePotRole', () => {
+//   it('returns creator for creator wallet', () => { ... })
+//   it('returns member for member wallet', () => { ... })
+//   it('returns viewer for non-member wallet', () => { ... })
+// })
+
+export {}

--- a/apps/web/src/hooks/usePotRole.ts
+++ b/apps/web/src/hooks/usePotRole.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useWallet } from '@solana/wallet-adapter-react'
+import { useMembers, usePot } from '@/hooks/usePots'
+
+export type PotRole = 'creator' | 'member' | 'viewer'
+
+export function derivePotRole(params: {
+  walletPubkey?: string
+  creator?: string
+  members?: Array<{ wallet?: string; pubkey?: string }>
+}): PotRole {
+  const { walletPubkey, creator, members = [] } = params
+  if (!walletPubkey) return 'viewer'
+  if (creator && walletPubkey === creator) return 'creator'
+
+  const isMember = members.some((member) => {
+    const memberAddress = member.wallet ?? member.pubkey
+    return memberAddress === walletPubkey
+  })
+
+  return isMember ? 'member' : 'viewer'
+}
+
+export function usePotRole(potPubkey?: string): { role: PotRole; isLoading: boolean } {
+  const { publicKey } = useWallet()
+  const { data: pot, isLoading: isPotLoading } = usePot(potPubkey)
+  const { data: members = [], isLoading: isMembersLoading } = useMembers(potPubkey)
+
+  const role = useMemo(
+    () =>
+      derivePotRole({
+        walletPubkey: publicKey?.toBase58(),
+        creator: (pot as any)?.creator ?? (pot as any)?.authority,
+        members: members as Array<{ wallet?: string; pubkey?: string }>,
+      }),
+    [publicKey, pot, members]
+  )
+
+  return {
+    role,
+    isLoading: isPotLoading || isMembersLoading,
+  }
+}

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,156 @@
+# PotBot Security Audit (On-chain RBAC + Supabase RLS)
+
+Date: 2026-04-26  
+Scope: `packages/program/programs/pot_vault/src/instructions/*`, `apps/web`, Supabase policy expectations.
+
+## 1) On-chain access control checklist (mutating handlers)
+
+### `deposit` (`deposit.rs`)
+- [x] Caller signer is checked against pot auth model (`depositor: Signer` and private pot check requires `depositor == pot.authority`).
+- [ ] Withdraw-like share burn from caller ATA is required (N/A to deposit).
+- [x] CPI program ID validation exists for System Program (`system_program: Program<System>`).
+- [ ] `#[account(has_one = creator)]` / `has_one = pot` used where appropriate.
+  - TODO **HIGH:** `member` account does not enforce `has_one = pot`; seeds include `pot` but explicit `has_one` hardening is missing.
+
+### `withdraw` (`withdraw.rs`)
+- [x] Caller signer is checked against membership (`withdrawer: Signer`, `member.wallet == withdrawer`).
+- [ ] Withdraw requires share burn from caller ATA.
+  - TODO **CRITICAL:** withdraw burns internal `MemberAccount.shares` only; no SPL share-token ATA burn requirement is enforced.
+- [x] CPI program ID validation is effectively not needed (direct lamport transfer; System Program account is typed).
+- [ ] `#[account(has_one = creator)]` / `has_one = pot` used where appropriate.
+  - TODO **HIGH:** `member` lacks explicit `has_one = pot` constraint.
+
+### `create_proposal` (`create_proposal.rs`)
+- [x] Caller signer is checked against members (`member` PDA seeded by `proposer`, `member.shares > 0`).
+- [ ] Withdraw share burn from ATA (N/A).
+- [x] CPI program ID validation (no external CPI in handler).
+- [ ] `#[account(has_one = creator)]` / `has_one = pot` used where appropriate.
+  - TODO **HIGH:** `member` account is not annotated with `has_one = pot`.
+
+### `vote` (`vote.rs`)
+- [x] Caller signer is checked against members (`member` PDA seeded by `voter`, `member.shares > 0`).
+- [ ] Withdraw share burn from ATA (N/A).
+- [x] CPI program ID validation (no external CPI in handler).
+- [x] `has_one = pot` applied on `proposal`.
+- [ ] `has_one = pot` missing on `member`.
+  - TODO **HIGH:** add `has_one = pot` on `member` for defense-in-depth.
+
+### `execute_swap` (executeTrade equivalent) (`execute_swap.rs`)
+- [x] Caller signer is role-checked by mode:
+  - AdminDirect: signer must equal `pot.authority`.
+  - Proposal: currently signer must equal `pot.authority`.
+  - StrategyTrigger: signer must equal `pot.agent_authority`.
+- [ ] Member-based caller validation against `PotAccount.members`/member PDA for proposal execution.
+  - TODO **HIGH:** proposal execution path is admin-only today; no member-signer path yet (commented as future Phase 2).
+- [x] CPI target program is pinned (`jupiter_program.key() == JUPITER_V6_PROGRAM_ID`).
+- [x] Additional remaining-account owner filtering exists (token/ATA/system/sysvar/Jupiter/exec).
+- [x] `has_one = pot` is present for `strategy` and optional `proposal_swap_spec`.
+
+### `create_strategy` (setStrategy equivalent) (`create_strategy.rs`)
+- [x] AdminDirect signer path validates `authority == admin == pot.authority`.
+- [ ] Non-admin strategy paths have incomplete auth.
+  - TODO **CRITICAL:** `StrategySource::Agent` path has explicit TODO and currently does **not** enforce `authority == pot.agent_authority`.
+- [ ] CPI program ID validation (N/A in this handler).
+- [ ] `#[account(has_one = creator)]` / `has_one = pot` used where appropriate.
+  - TODO **HIGH:** `pot` account is mutable but not constrained via `has_one` linkage to an explicit creator authority account in the context.
+
+---
+
+## 2) Supabase RLS audit and expected policies
+
+Expected model:
+- `SELECT` public read-only for: `pots`, `strategies`, `leaderboard_cache`.
+- `SELECT` members-only for private-pot `trade_log` rows (join through `members`).
+- `INSERT/UPDATE/DELETE`: `service_role` only (keeper/backend); web app should not write directly.
+
+> Notes:
+> - Snippets are intentionally commented so they can be pasted and edited safely in Supabase SQL Editor.
+> - Replace `is_pot_private(...)` / auth mapping with your project’s exact schema if names differ.
+
+### `pots`
+```sql
+-- alter table public.pots enable row level security;
+-- create policy "pots_select_public"
+--   on public.pots for select
+--   using (true);
+-- create policy "pots_write_service_role_only"
+--   on public.pots for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```
+
+### `strategies`
+```sql
+-- alter table public.strategies enable row level security;
+-- create policy "strategies_select_public"
+--   on public.strategies for select
+--   using (true);
+-- create policy "strategies_write_service_role_only"
+--   on public.strategies for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```
+
+### `members`
+```sql
+-- alter table public.members enable row level security;
+-- create policy "members_select_public_or_restricted"
+--   on public.members for select
+--   using (true); -- tighten if member list should be private
+-- create policy "members_write_service_role_only"
+--   on public.members for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```
+
+### `trade_log`
+```sql
+-- alter table public.trade_log enable row level security;
+-- create policy "trade_log_select_public_or_member_private"
+--   on public.trade_log for select
+--   using (
+--     -- public pots are readable by all
+--     exists (
+--       select 1
+--       from public.pots p
+--       where p.pubkey = trade_log.pot_pubkey
+--         and coalesce(p.is_private, false) = false
+--     )
+--     OR
+--     -- private pots readable only by authenticated pot members
+--     exists (
+--       select 1
+--       from public.members m
+--       where m.pot_pubkey = trade_log.pot_pubkey
+--         and m.wallet = auth.jwt()->>'sub'
+--     )
+--   );
+-- create policy "trade_log_write_service_role_only"
+--   on public.trade_log for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```
+
+### `leaderboard_cache`
+```sql
+-- alter table public.leaderboard_cache enable row level security;
+-- create policy "leaderboard_cache_select_public"
+--   on public.leaderboard_cache for select
+--   using (true);
+-- create policy "leaderboard_cache_write_service_role_only"
+--   on public.leaderboard_cache for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```
+
+### `worker_metrics`
+```sql
+-- alter table public.worker_metrics enable row level security;
+-- create policy "worker_metrics_select_restricted"
+--   on public.worker_metrics for select
+--   using (auth.role() = 'service_role'); -- or admin-only user claim if needed
+-- create policy "worker_metrics_write_service_role_only"
+--   on public.worker_metrics for all
+--   using (auth.role() = 'service_role')
+--   with check (auth.role() = 'service_role');
+```


### PR DESCRIPTION
### Motivation
- Harden frontend role-based access control for pot pages so creator/member/viewer semantics are enforced in the UI.
- Produce a focused on-chain access-control audit for mutating instructions in `pot_vault` and document Supabase RLS expectations. 
- Add minimal test scaffolding for the new role logic and ensure the web app type-check step is exercised.

### Description
- Added a reusable hook `usePotRole` that derives `{ role: 'creator' | 'member' | 'viewer', isLoading }` from `usePot`, `useMembers` and the connected wallet; exported `derivePotRole` for unit testing. (`apps/web/src/hooks/usePotRole.ts`).
- Wired role gating into the pot detail page (`apps/web/src/app/pots/[pubkey]/page.tsx`): role badge in header, deposit behavior unchanged, withdraw UI disabled for viewers, `+ Create Proposal` limited to member/creator, `Edit Strategy`/`Pause` restricted to creator, `Add Member`/`Remove Member` creator-only, and `Manage` on Members tab creator-only. 
- Updated `SharesTab` to accept a `canWithdraw` prop and disable the redeem button for unauthorized roles. (`apps/web/src/components/SharesTab.tsx`).
- Added `docs/security-audit.md` with a per-instruction checklist (deposit, withdraw, create_proposal, vote, execute_swap, create_strategy), flagged missing hardening with TODOs (CRITICAL/HIGH), and included commented Supabase RLS policy snippets for `pots`, `strategies`, `members`, `trade_log`, `leaderboard_cache`, and `worker_metrics`.
- Added a test scaffold `apps/web/src/hooks/usePotRole.test.ts` describing the three required cases (creator/member/viewer) but left as TODO because no test runner is configured.
- Did not modify any Rust instruction source code (audit-only) and did not change `supabase-sync.ts` signatures or `leaderboard/page.tsx` as requested.

Key audit findings documented
- CRITICAL: `withdraw` handler adjusts `MemberAccount.shares` but does not enforce burning an SPL share-token ATA (no ATA-burn requirement found).
- CRITICAL: `create_strategy` has an unimplemented `StrategySource::Agent` auth path (TODO) and does not enforce `authority == pot.agent_authority`.
- HIGH: several member-linked PDAs rely on seeds but are missing `has_one = pot` account constraints for defense-in-depth.
- HIGH: `execute_swap` Proposal mode is currently admin-only; member-executor path is noted as future Phase 2.

### Testing
- Added a test file scaffold for `derivePotRole` with the three required cases (creator, member, viewer) but did not run unit tests because no test runner (Vitest/Jest) is configured in `apps/web` (left as a TODO in `usePotRole.test.ts`).
- Ran type-check: executed `cd apps/web && npx tsc --noEmit` to validate TypeScript changes; the command failed due to pre-existing type errors elsewhere in the web app (unrelated to the role hook and page changes), so zero-errors was not achieved in this run.
- Manual code review / audit: inspected the relevant Anchor instruction handlers under `packages/program/programs/pot_vault/src/instructions/*` to create the on-chain checklist and mark missing constraints and auth checks.

If you want, I can (1) convert the test scaffold into runnable Vitest tests and add the dependency, (2) follow up with PR(s) that propose minimal Anchor account-constraint hardenings (non-breaking) and ATA burn enforcement options, or (3) help produce the exact Supabase SQL policies to paste into your project console.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee378d44f8832f86aebcb93ae6266a)