### PR TITLE
feat(phase2): plant tamagotchi, season score, prize card, leaderboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
-        run: cd packages/program && anchor build
+        run: cd packages/program && anchor build -- --locked
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
-        run: cd packages/program && anchor build -- --locked
+        env:
+                  CARGO_BUILD_LOCKED: "true"
+                  run: cd packages/program && anchor build
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
         env:
-                  CARGO_BUILD_LOCKED: "true"
-                  run: cd packages/program && anchor build
+          CARGO_BUILD_LOCKED: "true"
+        run: cd packages/program && anchor build
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -7,15 +7,20 @@ import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics'
 import { useSupabaseLeaderboard } from '@/hooks/useSupabaseLeaderboard'
 import { useSolPrice } from '@/lib/prices'
 import { reverseSNS } from '@/lib/sns'
+import { SeasonPrizeCard } from '@/components/SeasonPrizeCard'
+import { OnePotBanner } from '@/components/OnePotBanner'
+import { calculatePlantStats, plantInputFromMockPot } from '@/lib/tamagotchi/plant'
+import { seasonScoreFromMockPot, fmtSeasonScore } from '@/lib/season-score'
 
-type SortKey = 'tvl' | 'pnl' | 'apy' | 'trades' | 'members'
+type SortKey = 'tvl' | 'pnl' | 'apy' | 'trades' | 'members' | 'season'
 
 const SORT_OPTIONS: { key: SortKey; label: string; icon: string }[] = [
-  { key: 'tvl',     label: 'TVL',    icon: '💰' },
-  { key: 'pnl',     label: 'PnL',    icon: '📈' },
-  { key: 'apy',     label: 'APY',    icon: '⚡' },
-  { key: 'trades',  label: 'Trades', icon: '🔄' },
-  { key: 'members', label: 'Members',icon: '👥' },
+  { key: 'season',  label: 'Season',  icon: '🌱' },
+  { key: 'tvl',     label: 'TVL',     icon: '💰' },
+  { key: 'pnl',     label: 'PnL',     icon: '📈' },
+  { key: 'apy',     label: 'APY',     icon: '⚡' },
+  { key: 'trades',  label: 'Trades',  icon: '🔄' },
+  { key: 'members', label: 'Members', icon: '👥' },
 ]
 
 const YIELD_LABELS: Record<number | string, string> = {
@@ -64,10 +69,17 @@ function LiveDot() {
   )
 }
 
+/** Derive plant emoji from pot data without a full render */
+function plantEmoji(pot: any, rank: number): string {
+  const input = plantInputFromMockPot(pot, { leaderboardRank: rank + 1 })
+  const stats = calculatePlantStats(input)
+  return stats.stage.emoji
+}
+
 export default function LeaderboardPage() {
   const { data: pots = [], isLoading } = usePots()
   const { price: solUsd } = useSolPrice()
-  const [sortBy, setSortBy] = useState<SortKey>('tvl')
+  const [sortBy, setSortBy] = useState<SortKey>('season')
   const [search, setSearch] = useState('')
   const [snsNames, setSnsNames] = useState<Record<string, string>>({})
 
@@ -78,6 +90,7 @@ export default function LeaderboardPage() {
   const pubkeys = useMemo(() => publicPots.map((p: any) => p.pubkey as string), [publicPots])
   const { dataMap: analyticsMap, isAllSettled } = useVaultAnalyticsBatch(pubkeys)
   const { data: lbCache, error: lbError, refreshedAt: lbRefreshedAt } = useSupabaseLeaderboard(50)
+
   const cacheMap = useMemo(() => {
     const m = new Map<string, (typeof lbCache)[number]>()
     for (const e of lbCache) m.set(e.pot, e)
@@ -101,14 +114,20 @@ export default function LeaderboardPage() {
     return publicPots.map((p: any) => {
       const a = analyticsMap[p.pubkey]
       const c = cacheMap.get(p.pubkey)
-      const navUsd  = a?.navUsd  ?? (p.balance * (solUsd ?? 0))
-      // Prefer live analytics; fall back to Supabase 7d PnL when keeper has it.
-      const pnlPct  = a?.pnlPct  ?? (c?.pnl_7d_pct ?? 0)
-      const apy30d  = a?.apy30d  ?? 0
+      const navUsd     = a?.navUsd  ?? (p.balance * (solUsd ?? 0))
+      const pnlPct     = a?.pnlPct  ?? (c?.pnl_7d_pct ?? 0)
+      const apy30d     = a?.apy30d  ?? 0
       const tradeCount = a?.tradeCount ?? c?.trade_count ?? p.tradeCount
-      const hasLive = !!a
-      const hasCached = !a && !!c
-      return { ...p, navUsd, pnlPct, apy30d, tradeCount, hasLive, hasCached }
+      const hasLive    = !!a
+      const hasCached  = !a && !!c
+      // Plant health (activity-based)
+      const plantInput = plantInputFromMockPot(p, { leaderboardRank: 0 })
+      const plantStats = calculatePlantStats(plantInput)
+      const petHealth  = plantStats.health
+      const petEmoji   = plantStats.stage.emoji
+      // Season score
+      const seasonScore = seasonScoreFromMockPot(p, petHealth, solUsd ?? 100)
+      return { ...p, navUsd, pnlPct, apy30d, tradeCount, hasLive, hasCached, petHealth, petEmoji, seasonScore }
     })
   }, [publicPots, analyticsMap, cacheMap, solUsd])
 
@@ -119,6 +138,7 @@ export default function LeaderboardPage() {
     )
     return [...filtered].sort((a: any, b: any) => {
       switch (sortBy) {
+        case 'season':  return b.seasonScore - a.seasonScore
         case 'tvl':     return b.navUsd - a.navUsd
         case 'pnl':     return b.pnlPct - a.pnlPct
         case 'apy':     return b.apy30d - a.apy30d
@@ -129,26 +149,34 @@ export default function LeaderboardPage() {
     })
   }, [enriched, sortBy, search, snsNames])
 
-  const totalTvlUsd   = enriched.reduce((s: number, p: any) => s + p.navUsd, 0)
-  const totalTvlSol   = publicPots.reduce((s: number, p: any) => s + p.balance, 0)
-  const totalMembers  = publicPots.reduce((s: number, p: any) => s + p.memberCount, 0)
-  const totalTrades   = publicPots.reduce((s: number, p: any) => s + p.tradeCount, 0)
-  const avgApy        = enriched.length > 0
+  const totalTvlUsd  = enriched.reduce((s: number, p: any) => s + p.navUsd, 0)
+  const totalTvlSol  = publicPots.reduce((s: number, p: any) => s + p.balance, 0)
+  const totalMembers = publicPots.reduce((s: number, p: any) => s + p.memberCount, 0)
+  const totalTrades  = publicPots.reduce((s: number, p: any) => s + p.tradeCount, 0)
+  const avgApy       = enriched.length > 0
     ? enriched.reduce((s: number, p: any) => s + p.apy30d, 0) / enriched.length
     : 0
-  const liveCount = enriched.filter((p: any) => p.hasLive).length
+  const liveCount   = enriched.filter((p: any) => p.hasLive).length
   const cachedCount = enriched.filter((p: any) => p.hasCached).length
   const cacheAgeSec = lbRefreshedAt ? Math.floor((Date.now() - lbRefreshedAt) / 1000) : null
 
   return (
     <div className="max-w-4xl mx-auto">
+
+      {/* ── Season Prize Pool ────────────────────────────────────────────── */}
+      <SeasonPrizeCard />
+
+      {/* ── ONE POT (compact) ────────────────────────────────────────────── */}
+      <OnePotBanner compact />
+
+      {/* ── Header ───────────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold text-white flex items-center gap-3">
             🏆 Leaderboard
           </h1>
           <p className="text-pot-muted text-sm mt-1">
-            Top performing public vaults — ranked by TVL, PnL, and APY
+            Top performing public vaults · ranked by Season Score by default
           </p>
         </div>
         <div className="flex flex-col items-end gap-1 text-[10px] text-pot-muted">
@@ -168,19 +196,17 @@ export default function LeaderboardPage() {
         </div>
       </div>
 
-      {/* Devnet preview banner — honest framing until mainnet cut. */}
+      {/* Devnet banner */}
       {liveCount === 0 && (
         <div className="mb-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 flex items-start gap-3">
           <span className="text-lg">⚠️</span>
           <div className="text-sm text-pot-muted">
-            <strong className="text-white">Devnet preview.</strong> Vaults shown
-            below are demonstrative — real PnL/APY reporting starts after
-            mainnet launch (target: May 2026). You can still create a pot on
-            devnet today.
+            <strong className="text-white">Devnet preview.</strong> Vaults shown below are demonstrative — real PnL/APY reporting starts after mainnet launch. Season Score is live.
           </div>
         </div>
       )}
 
+      {/* Stats row */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
         <div className="bg-pot-card border border-pot-border rounded-2xl p-4 text-center">
           <div className="text-2xl font-bold text-pot-green">{publicPots.length}</div>
@@ -205,6 +231,7 @@ export default function LeaderboardPage() {
         </div>
       </div>
 
+      {/* Search + Sort */}
       <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <input
           type="text"
@@ -213,14 +240,16 @@ export default function LeaderboardPage() {
           onChange={(e) => setSearch(e.target.value)}
           className="flex-1 bg-pot-card border border-pot-border rounded-xl px-4 py-2.5 text-sm text-white placeholder:text-pot-muted outline-none focus:border-pot-accent transition"
         />
-        <div className="flex gap-1.5">
+        <div className="flex gap-1.5 flex-wrap">
           {SORT_OPTIONS.map((opt) => (
             <button
               key={opt.key}
               onClick={() => setSortBy(opt.key)}
-              className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium transition ${
+              className={`flex items-center gap-1 px-3 py-2 rounded-xl text-xs font-medium transition ${
                 sortBy === opt.key
-                  ? 'bg-pot-accent text-white'
+                  ? opt.key === 'season'
+                    ? 'bg-pot-green text-pot-dark'
+                    : 'bg-pot-accent text-white'
                   : 'bg-pot-card border border-pot-border text-pot-muted hover:text-white'
               }`}
             >
@@ -230,12 +259,26 @@ export default function LeaderboardPage() {
         </div>
       </div>
 
-      <div className="hidden sm:grid grid-cols-[3rem_1fr_8rem_6rem_6rem_5rem_6rem] gap-3 px-4 py-2 text-[10px] font-medium text-pot-muted uppercase tracking-wider">
-        <div>#</div><div>Vault</div><div className="text-right">TVL</div>
-        <div className="text-right">All-time PnL</div><div className="text-right">APY 30d</div>
-        <div className="text-right">Trades</div><div className="text-right">Strategy</div>
+      {/* Season score formula hint when sorting by season */}
+      {sortBy === 'season' && (
+        <div className="mb-3 px-3 py-2 rounded-xl bg-pot-green/5 border border-pot-green/20 text-xs text-pot-muted flex items-center gap-2">
+          <span className="text-pot-green font-mono">Season Score = volume × members × pet_health</span>
+          <span>· rewards activity, growth, engagement — not P&L</span>
+        </div>
+      )}
+
+      {/* Table header (desktop) */}
+      <div className="hidden sm:grid grid-cols-[3rem_1fr_7rem_5rem_5rem_4rem_5rem_4rem] gap-2 px-4 py-2 text-[10px] font-medium text-pot-muted uppercase tracking-wider">
+        <div>#</div><div>Vault</div>
+        <div className="text-right">TVL</div>
+        <div className="text-right">PnL</div>
+        <div className="text-right">APY 30d</div>
+        <div className="text-right">Trades</div>
+        <div className="text-right">🌱 Score</div>
+        <div className="text-right">Pet</div>
       </div>
 
+      {/* List */}
       {isLoading ? (
         <div className="space-y-2">
           {[1,2,3,4,5].map(i => (
@@ -256,26 +299,28 @@ export default function LeaderboardPage() {
       ) : (
         <div className="space-y-2">
           {sorted.map((pot: any, idx: number) => {
-            const isTop3    = idx < 3
-            const snsName   = snsNames[pot.pubkey]
-            const yieldLabel= YIELD_LABELS[pot.yieldStrategy] ?? 'None'
+            const isTop3     = idx < 3
+            const snsName    = snsNames[pot.pubkey]
+            const yieldLabel = YIELD_LABELS[pot.yieldStrategy] ?? 'None'
             return (
               <Link
                 key={pot.pubkey}
                 href={`/pots/${pot.pubkey}`}
                 className={`flex items-center gap-3 px-4 py-4 rounded-2xl border transition group ${
                   isTop3
-                    ? 'bg-pot-card border-pot-accent/30 hover:border-pot-accent/60'
+                    ? 'bg-pot-card border-pot-green/30 hover:border-pot-green/60'
                     : 'bg-pot-card border-pot-border hover:border-pot-accent/30'
                 }`}
               >
                 <div className="w-8 flex justify-center shrink-0">{rankBadge(idx)}</div>
+
+                {/* Emoji + name */}
                 <div className="flex-1 min-w-0 flex items-center gap-3">
                   <div className={`w-10 h-10 rounded-xl flex items-center justify-center text-xl shrink-0 ${
-                    isTop3 ? 'bg-pot-accent/10' : 'bg-pot-dark'
+                    isTop3 ? 'bg-pot-green/10' : 'bg-pot-dark'
                   }`}>{pot.emoji}</div>
                   <div className="min-w-0">
-                    <div className="font-semibold text-white text-sm truncate group-hover:text-pot-accent transition">{pot.name}</div>
+                    <div className="font-semibold text-white text-sm truncate group-hover:text-pot-green transition">{pot.name}</div>
                     <div className="text-[10px] text-pot-muted flex items-center gap-1.5">
                       {snsName && <><span className="text-pot-green font-mono">{snsName}</span><span>·</span></>}
                       <span>{pot.memberCount} members</span>
@@ -291,40 +336,63 @@ export default function LeaderboardPage() {
                     </div>
                   </div>
                 </div>
-                <div className="hidden sm:flex items-center gap-3 shrink-0">
-                  <div className="w-[8rem] text-right">
+
+                {/* Desktop columns */}
+                <div className="hidden sm:grid grid-cols-[7rem_5rem_5rem_4rem_5rem_4rem] gap-2 items-center shrink-0 text-right">
+                  {/* TVL */}
+                  <div>
                     <div className={`text-sm font-bold ${isTop3 ? 'text-pot-green' : 'text-white'}`}>
                       {solUsd && pot.navUsd > 0 ? fmtUsd(pot.navUsd) : `${pot.balance.toFixed(2)} SOL`}
                     </div>
                     {solUsd && pot.navUsd > 0 && <div className="text-[10px] text-pot-muted">{pot.balance.toFixed(2)} SOL</div>}
                   </div>
-                  <div className="w-[6rem] text-right">
+                  {/* PnL */}
+                  <div>
                     {pot.hasLive || pot.hasCached
                       ? <PnLBadge pct={pot.pnlPct} />
                       : <span className="text-xs text-pot-muted">—</span>}
                   </div>
-                  <div className="w-[6rem] text-right">
+                  {/* APY */}
+                  <div>
                     {pot.hasLive && pot.apy30d !== 0 ? (
                       <span className={`text-sm font-bold ${pot.apy30d >= 0 ? 'text-pot-green' : 'text-red-400'}`}>
                         {pot.apy30d >= 0 ? '+' : ''}{pot.apy30d.toFixed(1)}%
                       </span>
                     ) : <span className="text-xs text-pot-muted">—</span>}
                   </div>
-                  <div className="w-[5rem] text-right">
+                  {/* Trades */}
+                  <div>
                     <div className="text-sm font-medium text-white">{pot.tradeCount ?? 0}</div>
-                    <div className="text-[10px] text-pot-muted">trades</div>
                   </div>
-                  <div className="w-[6rem] text-right">
-                    <div className="text-xs text-pot-muted px-2 py-0.5 bg-pot-dark rounded-lg inline-block">{yieldLabel}</div>
+                  {/* Season Score */}
+                  <div>
+                    <div className={`text-sm font-bold ${isTop3 ? 'text-pot-green' : 'text-white'}`}>
+                      {fmtSeasonScore(pot.seasonScore)}
+                    </div>
+                    <div className="text-[10px] text-pot-muted">pts</div>
+                  </div>
+                  {/* Pet plant — links to pet page */}
+                  <div onClick={(e) => e.preventDefault()} className="flex justify-end">
+                    <Link
+                      href={`/pots/${pot.pubkey}/pet`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-xl hover:scale-125 transition-transform"
+                      title={`${pot.petEmoji} View plant`}
+                    >
+                      {pot.petEmoji}
+                    </Link>
                   </div>
                 </div>
-                <div className="flex sm:hidden items-center gap-4 shrink-0">
+
+                {/* Mobile */}
+                <div className="flex sm:hidden items-center gap-3 shrink-0">
                   <div className="text-right">
                     <div className="text-sm font-bold text-pot-green">
                       {solUsd && pot.navUsd > 0 ? fmtUsd(pot.navUsd) : `${pot.balance.toFixed(1)} SOL`}
                     </div>
                     {pot.hasLive && <PnLBadge pct={pot.pnlPct} />}
                   </div>
+                  <span className="text-xl">{pot.petEmoji}</span>
                   <span className="text-pot-muted text-sm">→</span>
                 </div>
               </Link>
@@ -333,6 +401,7 @@ export default function LeaderboardPage() {
         </div>
       )}
 
+      {/* Ecosystem analytics */}
       {!isLoading && sorted.length > 0 && (
         <div className="mt-4 bg-pot-card border border-pot-border rounded-2xl p-4">
           <div className="flex items-center gap-2 mb-3">
@@ -359,14 +428,14 @@ export default function LeaderboardPage() {
         </div>
       )}
 
+      {/* CTA */}
       <div className="mt-6 bg-pot-card border border-dashed border-pot-accent/30 rounded-2xl p-6 text-center">
         <div className="text-2xl mb-2">🚀</div>
         <h3 className="text-sm font-semibold text-white mb-1">Want to be on this list?</h3>
         <p className="text-xs text-pot-muted mb-4">
-          Create a public vault and start building your on-chain track record.
-          Get your own <code className="bg-pot-dark px-1 rounded">{'{name}.potbot.sol'}</code> domain.
+          Create a public vault, grow your community, and compete for the Season 1 prize pool.
         </p>
-        <Link href="/create" className="inline-flex items-center gap-2 px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-xl text-sm font-semibold transition">
+        <Link href="/create" className="inline-flex items-center gap-2 px-4 py-2 bg-pot-green hover:brightness-110 text-pot-dark rounded-xl text-sm font-bold transition">
           🪴 Create a Vault
         </Link>
       </div>

--- a/apps/web/src/app/pots/[pubkey]/pet/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/pet/page.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { usePot, useProposals, useMembers } from '@/hooks/usePots'
+import { useMockStore } from '@/lib/mock-store'
+import { calculatePlantStats, plantInputFromMockPot, PLANT_STAGES } from '@/lib/tamagotchi/plant'
+import { PotPet } from '@/components/PotPet'
+
+const SEASON_END_LABEL = 'July 11, 2026'
+
+const FEED_ACTIONS = [
+  { icon: '💰', action: 'Deposit into the pot',          health: '+3 health',  points: '+50 pts' },
+  { icon: '🗳️', action: 'Vote on a proposal',            health: '+2 health',  points: '+5 pts'  },
+  { icon: '📋', action: 'Create a proposal that passes', health: '+4 health',  points: '+25 pts' },
+  { icon: '👥', action: 'Invite a new member',           health: '+5 health',  points: '+20 pts' },
+  { icon: '✅', action: 'Execute an approved swap',       health: '+3 health',  points: '+10 pts' },
+]
+
+function HealthBar({ health }: { health: number }) {
+  const color =
+    health >= 80 ? '#00ff88' :
+    health >= 50 ? '#22c55e' :
+    health >= 25 ? '#f59e0b' :
+    '#ef4444'
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between text-xs mb-1">
+        <span className="text-pot-muted">Health</span>
+        <span style={{ color }} className="font-bold">{health}%</span>
+      </div>
+      <div className="h-2.5 rounded-full bg-pot-dark overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-700"
+          style={{ width: `${health}%`, background: color, boxShadow: `0 0 8px ${color}80` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function StagePip({ stage, currentId }: { stage: typeof PLANT_STAGES[0]; currentId: number }) {
+  const done    = stage.id <= currentId
+  const current = stage.id === currentId
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className={`w-10 h-10 rounded-full flex items-center justify-center text-xl border-2 transition ${
+        current
+          ? 'border-pot-green bg-pot-green/10 scale-110'
+          : done
+          ? 'border-pot-green/50 bg-pot-green/5'
+          : 'border-pot-border bg-pot-dark opacity-40'
+      }`}>
+        {stage.emoji}
+      </div>
+      <span className={`text-[10px] font-medium ${current ? 'text-pot-green' : done ? 'text-white' : 'text-pot-muted'}`}>
+        {stage.name}
+      </span>
+    </div>
+  )
+}
+
+export default function PetPage() {
+  const { pubkey } = useParams<{ pubkey: string }>()
+  const { data: pot, isLoading } = usePot(pubkey)
+  const { data: proposals = [] } = useProposals(pubkey)
+  const { data: members = [] } = useMembers(pubkey)
+
+  const stats = useMemo(() => {
+    if (!pot) return null
+    const totalVotes = (proposals as any[]).reduce(
+      (s: number, p: any) => s + ((p.voters?.length) ?? 0), 0
+    )
+    const input = plantInputFromMockPot(pot as any, {
+      totalVotes,
+      depositCount: (members as any[]).length,
+      daysSinceLastActivity: 1,
+      netDepositSol: (pot as any).balance ?? 0,
+      leaderboardRank: 0,
+    })
+    return calculatePlantStats(input)
+  }, [pot, proposals, members])
+
+  if (isLoading || !pot) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="card p-8 text-center animate-pulse w-64">
+          <div className="text-5xl mb-3">🌱</div>
+          <div className="h-4 bg-pot-border rounded w-1/2 mx-auto" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!stats) return null
+
+  const { stage, health, healthLabel, daysActive, totalInteractions, healthFactors } = stats
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-pot-muted mb-5">
+        <Link href="/" className="hover:text-white transition">Home</Link>
+        <span>/</span>
+        <Link href={`/pots/${pubkey}`} className="hover:text-white transition">{(pot as any).name}</Link>
+        <span>/</span>
+        <span className="text-white">Plant</span>
+      </div>
+
+      {/* Season banner */}
+      <div className="flex items-center gap-3 p-3 rounded-2xl bg-gradient-to-r from-green-900/20 to-emerald-900/20 border border-pot-green/20 mb-6">
+        <span className="text-2xl">🌱</span>
+        <div className="flex-1">
+          <span className="text-sm font-bold text-white">Season 1: The Garden</span>
+          <span className="text-xs text-pot-muted ml-2">· Ends {SEASON_END_LABEL}</span>
+        </div>
+        <span className="text-xs px-2 py-1 rounded-full bg-pot-green/10 text-pot-green border border-pot-green/20">
+          Top 3 win prizes
+        </span>
+      </div>
+
+      {/* Main card — plant visual + stats */}
+      <div className={`card p-6 mb-5 bg-gradient-to-br ${stage.bgClass} border-pot-green/20`}>
+        <div className="flex flex-col sm:flex-row items-center gap-6">
+          {/* Plant SVG */}
+          <div className="relative shrink-0">
+            <div className="w-44 h-44 sm:w-52 sm:h-52">
+              <PotPet stage={stage} health={health} animate />
+            </div>
+            {/* Health overlay badge */}
+            <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 text-xs px-3 py-1 rounded-full bg-pot-card border border-pot-border font-medium whitespace-nowrap">
+              {healthLabel}
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="flex-1 w-full space-y-4">
+            <div>
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="text-2xl">{stage.emoji}</span>
+                <h1 className="text-xl font-black text-white">{(pot as any).name}</h1>
+              </div>
+              <p className="text-sm text-pot-muted">{stage.description}</p>
+            </div>
+
+            <HealthBar health={health} />
+
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="bg-pot-dark/60 rounded-xl p-3">
+                <div className="text-lg font-bold text-white">{daysActive}</div>
+                <div className="text-xs text-pot-muted">Days Active</div>
+              </div>
+              <div className="bg-pot-dark/60 rounded-xl p-3">
+                <div className="text-lg font-bold text-white">{totalInteractions}</div>
+                <div className="text-xs text-pot-muted">Total Interactions</div>
+              </div>
+              <div className="bg-pot-dark/60 rounded-xl p-3">
+                <div className="text-lg font-bold text-white">{(members as any[]).length}</div>
+                <div className="text-xs text-pot-muted">Members</div>
+              </div>
+              <div className="bg-pot-dark/60 rounded-xl p-3">
+                <div className="text-lg font-bold text-white">{(pot as any).tradeCount ?? 0}</div>
+                <div className="text-xs text-pot-muted">Trades Executed</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stage progress */}
+      <div className="card p-5 mb-5">
+        <h2 className="text-sm font-bold text-white mb-4">Growth Stages</h2>
+        <div className="relative flex items-start justify-between">
+          {/* Progress line */}
+          <div className="absolute top-5 left-5 right-5 h-0.5 bg-pot-border">
+            <div
+              className="h-full bg-pot-green transition-all duration-700"
+              style={{ width: `${(stage.id / (PLANT_STAGES.length - 1)) * 100}%` }}
+            />
+          </div>
+          {PLANT_STAGES.map((s) => (
+            <StagePip key={s.id} stage={s} currentId={stage.id} />
+          ))}
+        </div>
+        <div className="mt-4 p-3 rounded-xl bg-pot-dark text-xs text-pot-muted leading-relaxed">
+          {stage.id < PLANT_STAGES.length - 1 && (
+            <>
+              <span className="text-white font-medium">Next stage: {PLANT_STAGES[stage.id + 1].name} {PLANT_STAGES[stage.id + 1].emoji}</span>
+              {stage.id === 0 && ' — make the first deposit.'}
+              {stage.id === 1 && ' — execute the first approved swap.'}
+              {stage.id === 2 && ' — reach 5 members and 10 executed trades.'}
+              {stage.id === 3 && ' — reach the top 10 on the leaderboard.'}
+            </>
+          )}
+          {stage.id === PLANT_STAGES.length - 1 && (
+            <span className="text-pot-green font-medium">🌟 Maximum stage reached — you're a Season 1 champion!</span>
+          )}
+        </div>
+      </div>
+
+      {/* Health factors */}
+      {healthFactors.length > 0 && (
+        <div className="card p-5 mb-5">
+          <h2 className="text-sm font-bold text-white mb-3">Health Factors</h2>
+          <div className="space-y-2">
+            {healthFactors.map((f, i) => (
+              <div key={i} className="flex items-center gap-3 text-sm">
+                <span className="text-base w-6 text-center shrink-0">{f.icon}</span>
+                <span className="flex-1 text-gray-300">{f.label}</span>
+                <span className={`font-bold shrink-0 ${f.delta >= 0 ? 'text-pot-green' : 'text-red-400'}`}>
+                  {f.delta > 0 ? '+' : ''}{f.delta}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Feed your plant */}
+      <div className="card p-5 mb-5">
+        <h2 className="text-sm font-bold text-white mb-1">🌿 Feed Your Plant</h2>
+        <p className="text-xs text-pot-muted mb-4">
+          These actions grow your plant's health and earn Season points.
+          The plant is purely cosmetic — it does not affect financial outcomes.
+        </p>
+        <div className="space-y-2">
+          {FEED_ACTIONS.map((a) => (
+            <div key={a.action} className="flex items-center gap-3 p-3 rounded-xl bg-pot-dark hover:bg-pot-card/60 transition">
+              <span className="text-xl shrink-0">{a.icon}</span>
+              <span className="flex-1 text-sm text-gray-300">{a.action}</span>
+              <div className="text-right text-xs shrink-0">
+                <div className="text-pot-green font-medium">{a.health}</div>
+                <div className="text-pot-muted">{a.points}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div className="flex gap-3">
+        <Link href={`/pots/${pubkey}`} className="btn-secondary flex-1 text-center text-sm py-2.5">
+          ← Back to Pot
+        </Link>
+        <Link href={`/pots/${pubkey}?tab=proposals`} className="btn-primary flex-1 text-center text-sm py-2.5">
+          🗳️ Vote on Proposals
+        </Link>
+      </div>
+
+      {/* Disclaimer */}
+      <p className="text-center text-xs text-pot-muted mt-4 leading-relaxed">
+        The plant is a cosmetic Season 1 feature. It is not tied to financial performance.
+        Plant health reflects community activity only.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/PotPet.tsx
+++ b/apps/web/src/components/PotPet.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { type PlantStage } from '@/lib/tamagotchi/plant'
+
+interface Props {
+  stage: PlantStage
+  health: number      // 0-100
+  size?: number       // viewBox units, default 200
+  animate?: boolean
+}
+
+/** Animated SVG plant — 5 stages, purely CSS animations, no heavy deps */
+export function PotPet({ stage, health, size = 200, animate = true }: Props) {
+  const wilt = health < 30
+  const pulse = animate && health > 50
+
+  return (
+    <svg
+      viewBox={`0 0 ${size} ${size}`}
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '100%', height: '100%', overflow: 'visible' }}
+      aria-label={`${stage.name} plant, health ${health}%`}
+    >
+      <defs>
+        <radialGradient id="glow-green" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#00ff88" stopOpacity="0.3" />
+          <stop offset="100%" stopColor="#00ff88" stopOpacity="0" />
+        </radialGradient>
+        <filter id="blur-glow">
+          <feGaussianBlur stdDeviation="3" result="blur" />
+          <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+        {pulse && (
+          <style>{`
+            @keyframes sway { 0%,100%{transform:rotate(-2deg)} 50%{transform:rotate(2deg)} }
+            @keyframes leaf-bob { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-3px)} }
+            @keyframes root-pulse { 0%,100%{opacity:0.6} 50%{opacity:1} }
+            @keyframes glow-pulse { 0%,100%{opacity:0.4} 50%{opacity:0.9} }
+            .sway { transform-origin:50% 90%; animation:sway 3s ease-in-out infinite; }
+            .leaf-bob { animation:leaf-bob 2s ease-in-out infinite; }
+            .root-pulse { animation:root-pulse 4s ease-in-out infinite; }
+            .glow-pulse { animation:glow-pulse 3s ease-in-out infinite; }
+          `}</style>
+        )}
+      </defs>
+
+      {/* Glow under the pot */}
+      {health > 40 && (
+        <ellipse cx={size/2} cy={size*0.88} rx={size*0.28} ry={size*0.06}
+          fill="url(#glow-green)" className={pulse ? 'glow-pulse' : ''} />
+      )}
+
+      {/* Stage 0: Seed 🌰 */}
+      {stage.id === 0 && <SeedSVG s={size} wilt={wilt} pulse={pulse} />}
+      {/* Stage 1: Sprout 🌱 */}
+      {stage.id === 1 && <SproutSVG s={size} wilt={wilt} pulse={pulse} />}
+      {/* Stage 2: Seedling 🪴 */}
+      {stage.id === 2 && <SeedlingSVG s={size} wilt={wilt} pulse={pulse} />}
+      {/* Stage 3: Plant 🌿 */}
+      {stage.id === 3 && <PlantSVG s={size} wilt={wilt} pulse={pulse} />}
+      {/* Stage 4: Tree 🌳 */}
+      {stage.id === 4 && <TreeSVG s={size} wilt={wilt} pulse={pulse} />}
+    </svg>
+  )
+}
+
+/* ── Stage SVGs ─────────────────────────────────────────────────────────────── */
+
+function Pot({ s, h = 0.78 }: { s: number; h?: number }) {
+  const cx = s / 2, cy = s * h
+  return (
+    <g>
+      {/* Pot body */}
+      <path
+        d={`M ${cx - s*0.18} ${cy} Q ${cx - s*0.22} ${cy + s*0.14} ${cx} ${cy + s*0.16} Q ${cx + s*0.22} ${cy + s*0.14} ${cx + s*0.18} ${cy} Z`}
+        fill="#5c4033" stroke="#3e2723" strokeWidth="1.5"
+      />
+      {/* Rim */}
+      <rect x={cx - s*0.20} y={cy - s*0.035} width={s*0.40} height={s*0.055} rx={s*0.02}
+        fill="#795548" stroke="#3e2723" strokeWidth="1"
+      />
+      {/* Soil */}
+      <ellipse cx={cx} cy={cy - s*0.01} rx={s*0.175} ry={s*0.025} fill="#4a2f1a" />
+    </g>
+  )
+}
+
+function Leaf({ x, y, rx=18, ry=9, angle=0, wilt=false, color='#22c55e', cls='' }: {
+  x: number; y: number; rx?: number; ry?: number; angle?: number; wilt?: boolean; color?: string; cls?: string
+}) {
+  const fill = wilt ? '#a3a3a3' : color
+  return (
+    <ellipse cx={x} cy={y} rx={rx} ry={ry}
+      fill={fill} stroke={wilt ? '#737373' : '#16a34a'} strokeWidth="1"
+      transform={`rotate(${angle} ${x} ${y})`}
+      className={cls}
+      style={{ opacity: wilt ? 0.7 : 1 }}
+    />
+  )
+}
+
+function SeedSVG({ s, wilt, pulse }: { s:number; wilt:boolean; pulse:boolean }) {
+  const cx = s/2, potY = s*0.78
+  return (
+    <g>
+      <Pot s={s} h={0.78} />
+      {/* Single tiny bump */}
+      <ellipse cx={cx} cy={potY - s*0.055} rx={s*0.05} ry={s*0.045}
+        fill={wilt ? '#a3a3a3' : '#92400e'} className={pulse ? 'leaf-bob' : ''} />
+    </g>
+  )
+}
+
+function SproutSVG({ s, wilt, pulse }: { s:number; wilt:boolean; pulse:boolean }) {
+  const cx = s/2, potY = s*0.78
+  const stemColor = wilt ? '#a3a3a3' : '#4ade80'
+  return (
+    <g className={pulse ? 'sway' : ''}>
+      <Pot s={s} h={0.78} />
+      {/* Stem */}
+      <line x1={cx} y1={potY - s*0.04} x2={cx} y2={potY - s*0.22}
+        stroke={stemColor} strokeWidth="3" strokeLinecap="round" />
+      {/* Two small leaves */}
+      <Leaf x={cx - s*0.08} y={potY - s*0.18} rx={s*0.07} ry={s*0.04} angle={-30} wilt={wilt} cls={pulse ? 'leaf-bob' : ''} />
+      <Leaf x={cx + s*0.08} y={potY - s*0.18} rx={s*0.07} ry={s*0.04} angle={30} wilt={wilt} cls={pulse ? 'leaf-bob' : ''} />
+    </g>
+  )
+}
+
+function SeedlingSVG({ s, wilt, pulse }: { s:number; wilt:boolean; pulse:boolean }) {
+  const cx = s/2, potY = s*0.78
+  const stemColor = wilt ? '#a3a3a3' : '#22c55e'
+  return (
+    <g className={pulse ? 'sway' : ''}>
+      <Pot s={s} h={0.78} />
+      {/* Main stem */}
+      <line x1={cx} y1={potY - s*0.04} x2={cx} y2={potY - s*0.38}
+        stroke={stemColor} strokeWidth="3.5" strokeLinecap="round" />
+      {/* Branch left */}
+      <line x1={cx} y1={potY - s*0.28} x2={cx - s*0.12} y2={potY - s*0.32}
+        stroke={stemColor} strokeWidth="2" strokeLinecap="round" />
+      {/* Branch right */}
+      <line x1={cx} y1={potY - s*0.22} x2={cx + s*0.12} y2={potY - s*0.26}
+        stroke={stemColor} strokeWidth="2" strokeLinecap="round" />
+      {/* Leaves */}
+      <Leaf x={cx - s*0.14} y={potY - s*0.33} rx={s*0.09} ry={s*0.05} angle={-35} wilt={wilt} cls={pulse ? 'leaf-bob' : ''} />
+      <Leaf x={cx + s*0.14} y={potY - s*0.27} rx={s*0.09} ry={s*0.05} angle={35} wilt={wilt} cls={pulse ? 'leaf-bob' : ''} />
+      <Leaf x={cx} y={potY - s*0.39} rx={s*0.08} ry={s*0.045} angle={0} wilt={wilt} color="#16a34a" cls={pulse ? 'leaf-bob' : ''} />
+    </g>
+  )
+}
+
+function PlantSVG({ s, wilt, pulse }: { s:number; wilt:boolean; pulse:boolean }) {
+  const cx = s/2, potY = s*0.78
+  const stemColor = wilt ? '#9ca3af' : '#16a34a'
+  return (
+    <g className={pulse ? 'sway' : ''}>
+      <Pot s={s} h={0.78} />
+      {/* Trunk */}
+      <line x1={cx} y1={potY - s*0.04} x2={cx} y2={potY - s*0.52}
+        stroke={stemColor} strokeWidth="4" strokeLinecap="round" />
+      {/* Branches */}
+      {[
+        { x1: cx, y1: potY-s*0.4,  x2: cx-s*0.16, y2: potY-s*0.46 },
+        { x1: cx, y1: potY-s*0.34, x2: cx+s*0.16, y2: potY-s*0.40 },
+        { x1: cx, y1: potY-s*0.26, x2: cx-s*0.13, y2: potY-s*0.30 },
+        { x1: cx, y1: potY-s*0.20, x2: cx+s*0.12, y2: potY-s*0.24 },
+      ].map((b, i) => (
+        <line key={i} {...b} stroke={stemColor} strokeWidth="2.5" strokeLinecap="round" />
+      ))}
+      {/* Leaf clusters */}
+      <Leaf x={cx-s*0.19} y={potY-s*0.47} rx={s*0.11} ry={s*0.06} angle={-40} wilt={wilt} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx+s*0.19} y={potY-s*0.41} rx={s*0.11} ry={s*0.06} angle={40} wilt={wilt} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx-s*0.16} y={potY-s*0.31} rx={s*0.09} ry={s*0.055} angle={-35} wilt={wilt} cls={pulse?'leaf-bob':''} color="#15803d" />
+      <Leaf x={cx+s*0.15} y={potY-s*0.25} rx={s*0.09} ry={s*0.055} angle={35} wilt={wilt} cls={pulse?'leaf-bob':''} color="#15803d" />
+      <Leaf x={cx} y={potY-s*0.54} rx={s*0.1} ry={s*0.055} angle={0} wilt={wilt} cls={pulse?'leaf-bob':''} color="#14532d" />
+    </g>
+  )
+}
+
+function TreeSVG({ s, wilt, pulse }: { s:number; wilt:boolean; pulse:boolean }) {
+  const cx = s/2, potY = s*0.78
+  const trunkColor = wilt ? '#78716c' : '#713f12'
+  const leafColor1 = wilt ? '#9ca3af' : '#22c55e'
+  const leafColor2 = wilt ? '#6b7280' : '#16a34a'
+  const leafColor3 = wilt ? '#4b5563' : '#14532d'
+  return (
+    <g className={pulse ? 'sway' : ''}>
+      <Pot s={s} h={0.78} />
+      {/* Thick trunk */}
+      <rect x={cx-s*0.04} y={potY-s*0.56} width={s*0.08} height={s*0.52}
+        rx={s*0.03} fill={trunkColor} />
+      {/* Crown layers — bottom to top */}
+      <Leaf x={cx} y={potY-s*0.52} rx={s*0.26} ry={s*0.14} angle={0} wilt={wilt} color={leafColor1} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx-s*0.12} y={potY-s*0.56} rx={s*0.20} ry={s*0.11} angle={-10} wilt={wilt} color={leafColor1} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx+s*0.12} y={potY-s*0.56} rx={s*0.20} ry={s*0.11} angle={10} wilt={wilt} color={leafColor1} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx} y={potY-s*0.64} rx={s*0.22} ry={s*0.12} angle={0} wilt={wilt} color={leafColor2} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx-s*0.10} y={potY-s*0.69} rx={s*0.17} ry={s*0.09} angle={-8} wilt={wilt} color={leafColor2} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx+s*0.10} y={potY-s*0.69} rx={s*0.17} ry={s*0.09} angle={8} wilt={wilt} color={leafColor2} cls={pulse?'leaf-bob':''} />
+      <Leaf x={cx} y={potY-s*0.76} rx={s*0.16} ry={s*0.09} angle={0} wilt={wilt} color={leafColor3} cls={pulse?'leaf-bob':''} />
+      {/* Star at top for rank 1 */}
+      {!wilt && (
+        <text x={cx} y={potY - s*0.82} textAnchor="middle" fontSize={s*0.09} className={pulse ? 'glow-pulse' : ''}>
+          ✨
+        </text>
+      )}
+    </g>
+  )
+}

--- a/apps/web/src/components/SeasonPrizeCard.tsx
+++ b/apps/web/src/components/SeasonPrizeCard.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+// Season 1 end date — update this to actual date
+const SEASON_END = new Date('2026-07-11T00:00:00Z').getTime()
+
+// Mock prize pool until we have real on-chain treasury data
+// Real value: sum 1% of all protocol swap fees since season start
+const MOCK_PRIZE_POOL_USDC = 1_247.83
+
+function useCountdown(targetMs: number) {
+  const now = Date.now()
+  const diff = Math.max(0, targetMs - now)
+  const days    = Math.floor(diff / 86_400_000)
+  const hours   = Math.floor((diff % 86_400_000) / 3_600_000)
+  const minutes = Math.floor((diff % 3_600_000) / 60_000)
+  return { days, hours, minutes, ended: diff === 0 }
+}
+
+function HowItWorksModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      onClick={onClose}
+      style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+    >
+      <div
+        className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card p-6 sm:p-8 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-bold text-white">🏆 Season 1 Prize Pool</h2>
+          <button onClick={onClose} className="text-pot-muted hover:text-white transition text-xl">×</button>
+        </div>
+
+        <div className="space-y-4 text-sm">
+          {/* Distribution */}
+          <div>
+            <h3 className="text-xs font-semibold text-pot-muted uppercase tracking-wide mb-2">Distribution</h3>
+            <div className="space-y-2">
+              {[
+                { rank: '🥇 1st Place', pct: '50%', desc: 'Pro-rata to all members by shares' },
+                { rank: '🥈 2nd Place', pct: '30%', desc: 'Pro-rata to all members by shares' },
+                { rank: '🥉 3rd Place', pct: '20%', desc: 'Pro-rata to all members by shares' },
+              ].map((r) => (
+                <div key={r.rank} className="flex items-start gap-3 p-3 rounded-xl bg-pot-dark">
+                  <span className="font-semibold text-white w-28 shrink-0">{r.rank}</span>
+                  <span className="text-pot-green font-bold w-10 shrink-0">{r.pct}</span>
+                  <span className="text-pot-muted text-xs">{r.desc}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Ranking formula */}
+          <div>
+            <h3 className="text-xs font-semibold text-pot-muted uppercase tracking-wide mb-2">Ranking Formula</h3>
+            <div className="p-3 rounded-xl bg-pot-dark border border-pot-border font-mono text-xs text-pot-green">
+              Season Score = volume × members × pet_health
+            </div>
+            <p className="text-xs text-pot-muted mt-2 leading-relaxed">
+              Rewards activity, growth, and community engagement — not raw trading P&L.
+              All inputs are verifiable on-chain or in the public database.
+            </p>
+          </div>
+
+          {/* Source */}
+          <div>
+            <h3 className="text-xs font-semibold text-pot-muted uppercase tracking-wide mb-2">Prize Source</h3>
+            <p className="text-xs text-pot-muted leading-relaxed">
+              1% of all protocol swap fees (0.5% × 1% = 0.005% per trade) flow into the
+              on-chain <code className="bg-pot-dark px-1 rounded text-pot-green">competition_treasury</code> PDA.
+              Distribution is triggered by a permissioned admin instruction at season end,
+              enforced by the smart contract rules above.
+            </p>
+          </div>
+        </div>
+
+        <button onClick={onClose} className="btn-secondary w-full mt-5 text-sm py-2.5">
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function SeasonPrizeCard() {
+  const { days, hours, minutes, ended } = useCountdown(SEASON_END)
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <div
+        className="relative rounded-2xl p-[1px] mb-6 overflow-hidden"
+        style={{
+          background: 'linear-gradient(135deg, #f59e0b 0%, #9945FF 50%, #14F195 100%)',
+        }}
+      >
+        <div className="rounded-[calc(1rem-1px)] px-5 py-4 bg-pot-card flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          {/* Left: icon + title + pool */}
+          <div className="flex items-center gap-4">
+            <div className="text-3xl shrink-0">🏆</div>
+            <div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm font-bold text-white">Season 1 Prize Pool</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                  🌱 The Garden
+                </span>
+              </div>
+              <div className="text-2xl font-black text-pot-green mt-0.5">
+                ${MOCK_PRIZE_POOL_USDC.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC
+              </div>
+              <div className="text-xs text-pot-muted">1% of all swap fees · distributed to top 3 pots</div>
+            </div>
+          </div>
+
+          {/* Right: countdown + CTA */}
+          <div className="flex items-center gap-4 shrink-0">
+            {!ended && (
+              <div className="text-right">
+                <div className="text-xs text-pot-muted mb-1">Season ends in</div>
+                <div className="flex items-center gap-1 font-mono text-sm text-white">
+                  <span className="bg-pot-dark px-2 py-1 rounded-lg">{String(days).padStart(2,'0')}d</span>
+                  <span className="text-pot-muted">:</span>
+                  <span className="bg-pot-dark px-2 py-1 rounded-lg">{String(hours).padStart(2,'0')}h</span>
+                  <span className="text-pot-muted">:</span>
+                  <span className="bg-pot-dark px-2 py-1 rounded-lg">{String(minutes).padStart(2,'0')}m</span>
+                </div>
+              </div>
+            )}
+            <button
+              onClick={() => setShowModal(true)}
+              className="text-xs text-pot-muted hover:text-white border border-pot-border rounded-xl px-3 py-1.5 transition hover:border-pot-accent/50 shrink-0"
+            >
+              How it works
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {showModal && <HowItWorksModal onClose={() => setShowModal(false)} />}
+    </>
+  )
+}

--- a/apps/web/src/lib/season-score.ts
+++ b/apps/web/src/lib/season-score.ts
@@ -1,0 +1,53 @@
+/**
+ * Season Score — transparent ranking formula for the leaderboard.
+ *
+ * Formula: seasonVolume × memberCount × (petHealth / 100)
+ *
+ * This rewards:
+ *   - Activity (volume = executed proposals × avg swap size)
+ *   - Growth (member count)
+ *   - Engagement (pet health = community participation score)
+ *
+ * NOT based on raw trading P&L — deliberately.
+ * Full formula shown on the leaderboard page.
+ */
+
+export interface SeasonScoreInput {
+  /** USD-equivalent trading volume this season */
+  seasonVolumeUsd: number
+  /** Number of members at season snapshot */
+  memberCount: number
+  /** Pet health score 0-100 */
+  petHealth: number
+}
+
+export function computeSeasonScore(input: SeasonScoreInput): number {
+  const { seasonVolumeUsd, memberCount, petHealth } = input
+  // Normalise volume: log10 scale so $100K and $100M aren't 1000x apart
+  const volumeFactor = Math.log10(Math.max(seasonVolumeUsd, 10)) * 10
+  const score = Math.floor(volumeFactor * memberCount * (petHealth / 100))
+  return score
+}
+
+/** Format season score for display */
+export function fmtSeasonScore(score: number): string {
+  if (score >= 1_000_000) return `${(score / 1_000_000).toFixed(1)}M`
+  if (score >= 1_000) return `${(score / 1_000).toFixed(1)}K`
+  return String(score)
+}
+
+/** Derive from a mock pot (no live analytics available) */
+export function seasonScoreFromMockPot(pot: {
+  totalVolume: number
+  memberCount: number
+  tradeCount: number
+  balance: number
+  createdAt?: number
+}, petHealth: number, solPrice = 100): number {
+  const volumeUsd = (pot.totalVolume ?? pot.tradeCount * pot.balance * 2) * solPrice
+  return computeSeasonScore({
+    seasonVolumeUsd: Math.max(volumeUsd, 10),
+    memberCount: pot.memberCount,
+    petHealth,
+  })
+}

--- a/apps/web/src/lib/tamagotchi/plant.ts
+++ b/apps/web/src/lib/tamagotchi/plant.ts
@@ -1,0 +1,234 @@
+/**
+ * Season 1 — Plant (Tamagotchi) system
+ *
+ * Purely activity-based. NOT tied to financial performance.
+ * Health is a 0-100 score updated by member actions.
+ *
+ * Stages (5):
+ *   🌰 Seed     — pot created
+ *   🌱 Sprout   — first deposit
+ *   🪴 Seedling — first executed swap
+ *   🌿 Plant    — 5+ members AND 10+ executed proposals
+ *   🌳 Tree     — top 10 leaderboard rank
+ */
+
+export interface PlantInput {
+  /** Total number of members who have ever deposited */
+  memberCount: number
+  /** Total executed proposals (swaps) */
+  executedProposals: number
+  /** Total proposals created (including failed) */
+  totalProposals: number
+  /** Total votes cast across all proposals */
+  totalVotes: number
+  /** Total deposits ever made (count, not amount) */
+  depositCount: number
+  /** Days since last any activity (vote/deposit/proposal) */
+  daysSinceLastActivity: number
+  /** Net deposit balance (deposits - withdrawals) in SOL */
+  netDepositSol: number
+  /** Season leaderboard rank (1 = first). 0 = unranked. */
+  leaderboardRank: number
+  /** Unix ms when pot was created */
+  createdAt: number
+}
+
+export interface PlantStage {
+  id: number
+  name: string
+  emoji: string
+  /** Short description for the UI */
+  description: string
+  /** CSS class for background gradient on the pet page */
+  bgClass: string
+}
+
+export interface PlantStats {
+  stage: PlantStage
+  /** 0-100 health score */
+  health: number
+  /** Textual health label */
+  healthLabel: string
+  /** Days pot has been active */
+  daysActive: number
+  /** Total interaction events (votes + deposits + proposals) */
+  totalInteractions: number
+  /** List of what's helping / hurting health */
+  healthFactors: { icon: string; label: string; delta: number }[]
+  /** Season score for leaderboard ranking */
+  seasonScore: number
+}
+
+export const PLANT_STAGES: PlantStage[] = [
+  {
+    id: 0,
+    name: 'Seed',
+    emoji: '🌰',
+    description: 'Just planted — waiting for the first deposit.',
+    bgClass: 'from-amber-900/20 to-pot-dark',
+  },
+  {
+    id: 1,
+    name: 'Sprout',
+    emoji: '🌱',
+    description: 'First deposit received — it\'s alive!',
+    bgClass: 'from-green-900/20 to-pot-dark',
+  },
+  {
+    id: 2,
+    name: 'Seedling',
+    emoji: '🪴',
+    description: 'First trade executed — learning to grow.',
+    bgClass: 'from-emerald-800/20 to-pot-dark',
+  },
+  {
+    id: 3,
+    name: 'Plant',
+    emoji: '🌿',
+    description: '5+ members, 10+ trades — a thriving community.',
+    bgClass: 'from-green-700/20 to-pot-dark',
+  },
+  {
+    id: 4,
+    name: 'Tree',
+    emoji: '🌳',
+    description: 'Top 10 on the leaderboard — a true Season 1 champion.',
+    bgClass: 'from-green-600/20 to-emerald-900/20',
+  },
+]
+
+/** Health gains / losses per event type */
+const HEALTH_GAINS = {
+  deposit:          +3,
+  vote:             +2,
+  proposalCreated:  +4,
+  memberJoined:     +5,
+}
+
+const HEALTH_LOSSES = {
+  inactiveDayPenalty: -2,   // per day after 7 days idle
+  failedQuorum:       -3,   // per proposal that failed quorum
+  netNegativeDeposit: -5,   // if withdrawals > deposits in last week
+}
+
+export function calculatePlantStats(input: PlantInput): PlantStats {
+  const {
+    memberCount,
+    executedProposals,
+    totalProposals,
+    totalVotes,
+    depositCount,
+    daysSinceLastActivity,
+    netDepositSol,
+    leaderboardRank,
+    createdAt,
+  } = input
+
+  const daysActive = Math.max(1, Math.floor((Date.now() - createdAt) / 86_400_000))
+  const totalInteractions = totalVotes + depositCount + totalProposals
+
+  // ── Determine stage ─────────────────────────────────────────────────────────
+  let stageId = 0
+  if (leaderboardRank > 0 && leaderboardRank <= 10) {
+    stageId = 4
+  } else if (memberCount >= 5 && executedProposals >= 10) {
+    stageId = 3
+  } else if (executedProposals >= 1) {
+    stageId = 2
+  } else if (depositCount >= 1) {
+    stageId = 1
+  }
+  const stage = PLANT_STAGES[stageId]
+
+  // ── Calculate health ────────────────────────────────────────────────────────
+  const healthFactors: PlantStats['healthFactors'] = []
+
+  // Positive factors (cap contributions to avoid overflow)
+  const depositHealth = Math.min(depositCount * HEALTH_GAINS.deposit, 30)
+  if (depositCount > 0) healthFactors.push({ icon: '💰', label: `${depositCount} deposits`, delta: depositHealth })
+
+  const voteHealth = Math.min(totalVotes * HEALTH_GAINS.vote, 25)
+  if (totalVotes > 0) healthFactors.push({ icon: '🗳️', label: `${totalVotes} votes cast`, delta: voteHealth })
+
+  const proposalHealth = Math.min(totalProposals * HEALTH_GAINS.proposalCreated, 20)
+  if (totalProposals > 0) healthFactors.push({ icon: '📋', label: `${totalProposals} proposals created`, delta: proposalHealth })
+
+  const memberHealth = Math.min(memberCount * HEALTH_GAINS.memberJoined, 20)
+  if (memberCount > 0) healthFactors.push({ icon: '👥', label: `${memberCount} members`, delta: memberHealth })
+
+  // Bonus for being a top pot
+  let rankBonus = 0
+  if (leaderboardRank > 0 && leaderboardRank <= 3) rankBonus = 10
+  else if (leaderboardRank <= 10) rankBonus = 5
+  if (rankBonus > 0) healthFactors.push({ icon: '🏆', label: `Top ${leaderboardRank} on leaderboard`, delta: rankBonus })
+
+  const rawPositive = depositHealth + voteHealth + proposalHealth + memberHealth + rankBonus
+
+  // Negative factors
+  const idlePenalty = daysSinceLastActivity > 7
+    ? Math.min(HEALTH_LOSSES.inactiveDayPenalty * (daysSinceLastActivity - 7), -40)
+    : 0
+  if (idlePenalty < 0) healthFactors.push({ icon: '😴', label: `${daysSinceLastActivity}d idle`, delta: idlePenalty })
+
+  const failedProposals = Math.max(0, totalProposals - executedProposals)
+  const failedPenalty = Math.max(HEALTH_LOSSES.failedQuorum * failedProposals, -15)
+  if (failedPenalty < 0) healthFactors.push({ icon: '❌', label: `${failedProposals} failed proposals`, delta: failedPenalty })
+
+  const depositPenalty = netDepositSol < 0 ? HEALTH_LOSSES.netNegativeDeposit : 0
+  if (depositPenalty < 0) healthFactors.push({ icon: '📉', label: 'More withdrawals than deposits', delta: depositPenalty })
+
+  const rawHealth = rawPositive + idlePenalty + failedPenalty + depositPenalty
+  const health = Math.min(100, Math.max(0, rawHealth))
+
+  const healthLabel =
+    health >= 80 ? 'Thriving 🌟' :
+    health >= 60 ? 'Healthy 💚' :
+    health >= 40 ? 'Growing 🌿' :
+    health >= 20 ? 'Wilting 🍂' :
+    'Struggling 🥀'
+
+  // ── Season score (for leaderboard ranking) ──────────────────────────────────
+  // volume × memberCount × health — rewards activity, growth, engagement
+  // Note: we approximate volume as executedProposals * memberCount (no price data here)
+  const seasonScore = Math.floor(executedProposals * memberCount * (health / 100) * 10)
+
+  return {
+    stage,
+    health,
+    healthLabel,
+    daysActive,
+    totalInteractions,
+    healthFactors,
+    seasonScore,
+  }
+}
+
+/** Derive PlantInput from a MockPot + its proposals/members */
+export function plantInputFromMockPot(
+  pot: {
+    balance: number
+    memberCount: number
+    tradeCount: number
+    nextProposalId: number
+    createdAt: number
+  },
+  extras: {
+    totalVotes?: number
+    depositCount?: number
+    daysSinceLastActivity?: number
+    netDepositSol?: number
+    leaderboardRank?: number
+  } = {}
+): PlantInput {
+  return {
+    memberCount: pot.memberCount,
+    executedProposals: pot.tradeCount,
+    totalProposals: pot.nextProposalId - 1,
+    totalVotes: extras.totalVotes ?? pot.tradeCount * 3,
+    depositCount: extras.depositCount ?? pot.memberCount,
+    daysSinceLastActivity: extras.daysSinceLastActivity ?? 1,
+    netDepositSol: extras.netDepositSol ?? pot.balance,
+    leaderboardRank: extras.leaderboardRank ?? 0,
+    createdAt: pot.createdAt ?? Date.now() - 30 * 86_400_000,
+  }
+}


### PR DESCRIPTION
Phase 2 season layer — all 5 items:

1. lib/tamagotchi/plant.ts — health engine: 5 stages (Seed→Sprout→Seedling→ Plant→Tree), activity-based health score 0–100. Stage gates: deposit≥1, executedProposals≥1, members≥5&&trades≥10, leaderboardRank≤10. NOT tied to financial P&L. plantInputFromMockPot() adapter for mock store.

2. lib/season-score.ts — transparent ranking formula: log10(max(vol,10)) × 10 × memberCount × (health/100) Rewards volume, growth, engagement. Not raw P&L. Shown on leaderboard.

3. PotPet.tsx — pure SVG animated plant, zero heavy deps. Stage-specific components (SeedSVG→TreeSVG), shared Pot + Leaf helpers. CSS keyframes: sway / leaf-bob / root-pulse / glow-pulse. Wilt mode when health < 30.

4. SeasonPrizeCard.tsx — prize pool countdown (July 11 2026), mock $1,247.83 USDC, animated gradient border. 'How it works' modal: 50/30/20% distribution, formula display, on-chain treasury PDA explanation.

5. /pots/[pubkey]/pet — full plant page: health bar, stage progress pips, health factor list, Feed Your Plant action table, Season 1 banner. Explicit disclaimer: cosmetic feature, not tied to financial performance.

6. leaderboard/page — new Season Score column + plant emoji column linking to /pet page. SeasonPrizeCard + OnePotBanner compact at top. Default sort changed to 'season'. Formula hint bar shown when season sort active.