### PR TITLE
feat(phase1): ONE POT banner, FAQ, disclaimers, dashboard, footer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
-        run: cd packages/program && anchor build
+        run: cd packages/program && anchor build -- --locked
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
           cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
-        run: cd packages/program && anchor build -- --locked
+        env:
+                  CARGO_BUILD_LOCKED: "true"
+                  run: cd packages/program && anchor build
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           avm install 0.30.1 && avm use 0.30.1
       - name: anchor build
         env:
-                  CARGO_BUILD_LOCKED: "true"
-                  run: cd packages/program && anchor build
+          CARGO_BUILD_LOCKED: "true"
+        run: cd packages/program && anchor build
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4
         with:

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,415 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import Link from 'next/link'
+import { useWallet } from '@solana/wallet-adapter-react'
+import dynamic from 'next/dynamic'
+import { usePots } from '@/hooks/usePots'
+import { useMockStore } from '@/lib/mock-store'
+import { useSolPrice } from '@/lib/prices'
+import { calculateTamaStats } from '@/lib/tamagotchi/stats'
+
+const WalletMultiButton = dynamic(
+  async () => (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
+  { ssr: false }
+)
+
+const QUEST_PLACEHOLDER = [
+  {
+    id: 'q1',
+    icon: '🐦',
+    title: 'Share on Twitter',
+    desc: 'Tweet about your pot with #PotBotSeason1',
+    points: 100,
+    done: false,
+  },
+  {
+    id: 'q2',
+    icon: '👥',
+    title: 'Bring 3 Friends',
+    desc: 'Refer 3 users who each deposit ≥ 0.1 SOL',
+    points: 500,
+    done: false,
+  },
+  {
+    id: 'q3',
+    icon: '🗳️',
+    title: 'Active Voter',
+    desc: 'Vote on 10 proposals across different pots',
+    points: 150,
+    done: false,
+  },
+  {
+    id: 'q4',
+    icon: '🔒',
+    title: 'Private Pot Creator',
+    desc: 'Create your first private pot',
+    points: 300,
+    done: false,
+  },
+]
+
+const POINTS_ACTIONS = [
+  { action: 'Create a pot',                    points: 100 },
+  { action: 'First deposit (any pot)',          points: 50  },
+  { action: 'Vote on a proposal',              points: 5   },
+  { action: 'Create a passing proposal',       points: 25  },
+  { action: 'Refer a user who deposits ≥0.1 SOL', points: 200 },
+  { action: 'Member joins a pot you created',  points: 20  },
+  { action: 'Pot reaches 10 members',          points: 500 },
+  { action: 'Daily check-in',                  points: 1   },
+]
+
+function SkeletonCard() {
+  return (
+    <div className="card p-5 animate-pulse">
+      <div className="h-5 bg-pot-border rounded w-1/2 mb-3" />
+      <div className="h-4 bg-pot-border rounded w-3/4 mb-2" />
+      <div className="h-4 bg-pot-border rounded w-1/3" />
+    </div>
+  )
+}
+
+function StatCard({ label, value, sub, accent }: { label: string; value: string; sub?: string; accent?: boolean }) {
+  return (
+    <div className={`card p-4 text-center ${accent ? 'glow-green border-pot-green/20' : ''}`}>
+      <div className={`text-2xl font-bold ${accent ? 'text-pot-green' : 'text-white'}`}>{value}</div>
+      {sub && <div className="text-[10px] text-pot-muted font-mono">{sub}</div>}
+      <div className="text-xs text-pot-muted mt-1">{label}</div>
+    </div>
+  )
+}
+
+export default function DashboardPage() {
+  const { publicKey, connected } = useWallet()
+  const { data: allPots, isLoading } = usePots()
+  const { price: solPrice } = useSolPrice()
+  const walletStr = publicKey?.toBase58() ?? ''
+  const [questTab, setQuestTab] = useState<'active' | 'points'>('active')
+
+  /* ── My pots ── */
+  const allMembers = useMockStore.getState().members
+  const myMemberships = useMemo(
+    () => allMembers.filter((m) => m.wallet === walletStr),
+    [allMembers, walletStr]
+  )
+  const myPotPubkeys = useMemo(
+    () => new Set(myMemberships.map((m) => m.potPubkey)),
+    [myMemberships]
+  )
+  const myPots = useMemo(
+    () => (allPots ?? []).filter((p: any) => myPotPubkeys.has(p.pubkey) || p.authority === walletStr),
+    [allPots, myPotPubkeys, walletStr]
+  )
+
+  /* ── Portfolio totals ── */
+  const totalSol = myPots.reduce((s: number, p: any) => s + (p.balance ?? 0), 0)
+  const totalUsd = solPrice ? totalSol * solPrice : 0
+
+  /* ── Referrals ── */
+  const referrals = useMockStore.getState().referrals ?? []
+  const myReferrals = referrals.filter((r: any) => r.referrer === walletStr)
+  const referralFees = myReferrals.reduce((s: number, r: any) => s + (r.level1Earning ?? 0), 0)
+
+  /* ── Pending proposals ── */
+  const allProposals = useMockStore.getState().proposals ?? []
+  const pending = allProposals.filter(
+    (p: any) =>
+      p.status === 'active' &&
+      myPotPubkeys.has(p.potPubkey) &&
+      !(p.voters ?? []).includes(walletStr)
+  )
+
+  /* ── Tamagotchi emoji for each pot ── */
+  function potTama(pot: any) {
+    const stats = calculateTamaStats({
+      tradeVolume: (pot.totalVolume ?? 0) * (solPrice ?? 100),
+      memberCount: pot.memberCount ?? 1,
+      winRate: 0.5,
+      yieldApy: 0,
+      ageSeconds: (Date.now() - (pot.createdAt ?? Date.now())) / 1000,
+    })
+    return stats.emoji
+  }
+
+  /* ── Not connected ── */
+  if (!connected) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <div className="text-5xl mb-4">🪴</div>
+        <h1 className="text-2xl font-bold text-white mb-2">Your Personal Dashboard</h1>
+        <p className="text-pot-muted mb-6 max-w-sm">
+          Connect your wallet to see your pots, points, pending votes, and referral earnings.
+        </p>
+        <WalletMultiButton />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {/* ── Hero ─────────────────────────────────────────────────── */}
+      <div className="card p-6 mb-6 bg-gradient-to-br from-pot-card to-pot-dark border-pot-border">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <div className="text-xs text-pot-muted font-mono mb-1">
+              {walletStr.slice(0, 6)}…{walletStr.slice(-6)}
+            </div>
+            <h1 className="text-2xl font-black text-white">My Dashboard</h1>
+            <p className="text-pot-muted text-sm mt-0.5">
+              {myPots.length} pot{myPots.length !== 1 ? 's' : ''} · Season 1 🌱
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="text-right">
+              <div className="text-xl font-bold text-pot-green">
+                {totalUsd > 0
+                  ? `$${totalUsd >= 1000 ? (totalUsd / 1000).toFixed(1) + 'K' : totalUsd.toFixed(0)}`
+                  : `${totalSol.toFixed(2)} SOL`}
+              </div>
+              <div className="text-xs text-pot-muted">Portfolio Value</div>
+            </div>
+            {pending.length > 0 && (
+              <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-400 text-xs font-medium animate-pulse">
+                🗳️ {pending.length} vote{pending.length !== 1 ? 's' : ''} pending
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-5">
+          <StatCard
+            label="Total Value"
+            value={totalUsd > 0 ? `$${totalUsd.toFixed(0)}` : `${totalSol.toFixed(2)} SOL`}
+            accent
+          />
+          <StatCard label="Active POTs" value={String(myPots.length)} />
+          <StatCard label="Season Points" value="—" sub="coming soon" />
+          <StatCard label="Season Rank" value="—" sub="coming soon" />
+        </div>
+      </div>
+
+      {/* ── My POTs ──────────────────────────────────────────────── */}
+      <section className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-white">My POTs</h2>
+          <Link href="/my-pots" className="text-xs text-pot-muted hover:text-white transition">
+            Full view →
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => <SkeletonCard key={i} />)}
+          </div>
+        ) : myPots.length === 0 ? (
+          <div className="card p-8 text-center">
+            <div className="text-3xl mb-2">🌱</div>
+            <h3 className="text-base font-semibold text-white mb-1">No POTs yet</h3>
+            <p className="text-sm text-pot-muted mb-4">Join an existing vault or create your own.</p>
+            <div className="flex gap-3 justify-center">
+              <Link href="/leaderboard" className="btn-secondary text-sm py-2">Browse Pots</Link>
+              <Link href="/create" className="btn-primary text-sm py-2">Create POT</Link>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {myPots.map((pot: any) => {
+              const membership = myMemberships.find((m) => m.potPubkey === pot.pubkey)
+              const sharePct = pot.totalShares > 0 && membership
+                ? (membership.shares / pot.totalShares) * 100
+                : 0
+              const myValueSol = pot.balance * (sharePct / 100)
+              const myValueUsd = solPrice ? myValueSol * solPrice : 0
+              return (
+                <Link
+                  key={pot.pubkey}
+                  href={`/pots/${pot.pubkey}`}
+                  className="card p-4 hover:border-pot-green/30 transition group"
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xl group-hover:animate-float">{pot.emoji}</span>
+                      <div>
+                        <div className="text-sm font-semibold text-white">{pot.name}</div>
+                        <div className="text-[10px] text-pot-muted font-mono">
+                          {pot.pubkey.slice(0, 4)}…{pot.pubkey.slice(-4)}
+                        </div>
+                      </div>
+                    </div>
+                    <span className="text-lg">{potTama(pot)}</span>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-2 text-xs">
+                    <div className="bg-pot-dark rounded-lg p-2">
+                      <div className="text-pot-green font-bold">
+                        {myValueUsd > 0 ? `$${myValueUsd.toFixed(2)}` : `${myValueSol.toFixed(3)} SOL`}
+                      </div>
+                      <div className="text-pot-muted">My Value</div>
+                    </div>
+                    <div className="bg-pot-dark rounded-lg p-2">
+                      <div className="text-white font-bold">{sharePct.toFixed(1)}%</div>
+                      <div className="text-pot-muted">My Share</div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2 mt-2">
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+                      pot.isPublic ? 'bg-pot-green/10 text-pot-green' : 'bg-pot-accent/10 text-pot-accent'
+                    }`}>
+                      {pot.isPublic ? 'Public' : 'Private'}
+                    </span>
+                    <span className="text-[10px] text-pot-muted">{pot.memberCount} members</span>
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* ── Pending Votes ─────────────────────────────────────────── */}
+      {pending.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-lg font-bold text-white mb-4">⏳ Pending Votes</h2>
+          <div className="space-y-2">
+            {pending.map((p: any) => {
+              const pot = (allPots ?? []).find((pot: any) => pot.pubkey === p.potPubkey) as any
+              const hoursLeft = p.createdAt
+                ? Math.max(0, 24 - (Date.now() - p.createdAt) / 3_600_000)
+                : 24
+              return (
+                <Link
+                  key={p.pubkey}
+                  href={`/pots/${p.potPubkey}?tab=proposals`}
+                  className="card p-4 flex items-center justify-between gap-4 hover:border-amber-500/30 transition"
+                >
+                  <div>
+                    <div className="text-sm text-white font-medium">{p.description}</div>
+                    <div className="text-xs text-pot-muted mt-0.5">
+                      {pot?.name ?? p.potPubkey.slice(0, 8)} · {hoursLeft.toFixed(0)}h remaining
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-xs px-3 py-1.5 rounded-xl bg-amber-500/10 text-amber-400 border border-amber-500/20 font-medium">
+                    Vote →
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* ── Quests & Points ───────────────────────────────────────── */}
+      <section className="mb-8">
+        <div className="flex items-center gap-2 mb-4">
+          <button
+            onClick={() => setQuestTab('active')}
+            className={`px-4 py-2 rounded-xl text-sm font-medium transition ${
+              questTab === 'active' ? 'bg-pot-card border border-pot-border text-white' : 'text-pot-muted hover:text-white'
+            }`}
+          >
+            🎯 Active Quests
+          </button>
+          <button
+            onClick={() => setQuestTab('points')}
+            className={`px-4 py-2 rounded-xl text-sm font-medium transition ${
+              questTab === 'points' ? 'bg-pot-card border border-pot-border text-white' : 'text-pot-muted hover:text-white'
+            }`}
+          >
+            ⭐ Points Table
+          </button>
+        </div>
+
+        {questTab === 'active' && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {QUEST_PLACEHOLDER.map((q) => (
+              <div
+                key={q.id}
+                className="card p-4 flex items-start gap-3 opacity-90"
+              >
+                <div className="text-2xl shrink-0">{q.icon}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-semibold text-white">{q.title}</div>
+                  <div className="text-xs text-pot-muted mt-0.5">{q.desc}</div>
+                  <div className="text-xs text-pot-green font-bold mt-1.5">+{q.points} pts</div>
+                </div>
+                <span className="shrink-0 text-xs px-2.5 py-1 rounded-full bg-pot-card border border-pot-border text-pot-muted">
+                  Soon
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {questTab === 'points' && (
+          <div className="card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-pot-border">
+                  <th className="text-left px-4 py-3 text-pot-muted font-medium text-xs">Action</th>
+                  <th className="text-right px-4 py-3 text-pot-muted font-medium text-xs">Points</th>
+                </tr>
+              </thead>
+              <tbody>
+                {POINTS_ACTIONS.map((row, i) => (
+                  <tr key={i} className="border-b border-pot-border/50 last:border-0 hover:bg-pot-card/50">
+                    <td className="px-4 py-3 text-gray-300">{row.action}</td>
+                    <td className="px-4 py-3 text-right text-pot-green font-bold">+{row.points}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ── Referrals ─────────────────────────────────────────────── */}
+      <section className="mb-8">
+        <h2 className="text-lg font-bold text-white mb-4">🔗 Referrals</h2>
+        <div className="card p-5">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-5">
+            <div className="text-center">
+              <div className="text-xl font-bold text-white">{myReferrals.length}</div>
+              <div className="text-xs text-pot-muted">Referred Users</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-pot-green">
+                {referralFees.toFixed(3)} SOL
+              </div>
+              <div className="text-xs text-pot-muted">Fees Earned</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-white">20%</div>
+              <div className="text-xs text-pot-muted">Your Cut</div>
+            </div>
+          </div>
+
+          {walletStr && (
+            <div>
+              <div className="text-xs text-pot-muted mb-1.5">Your referral link</div>
+              <div className="flex gap-2">
+                <div className="flex-1 bg-pot-dark border border-pot-border rounded-xl px-3 py-2 text-xs font-mono text-pot-muted truncate">
+                  {typeof window !== 'undefined' ? window.location.origin : 'https://potbot.fun'}/pots/[pot]?ref={walletStr.slice(0, 8)}…
+                </div>
+                <button
+                  onClick={() => {
+                    const base = typeof window !== 'undefined' ? window.location.origin : 'https://potbot.fun'
+                    navigator.clipboard.writeText(`${base}?ref=${walletStr}`)
+                  }}
+                  className="btn-secondary text-xs py-2 px-4 shrink-0"
+                >
+                  Copy
+                </button>
+              </div>
+              <p className="text-xs text-pot-muted mt-2">
+                Earn 20% of all swap fees from users you refer, paid instantly to your wallet.
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+interface FAQItem {
+  q: string
+  a: string
+}
+
+interface FAQCategory {
+  id: string
+  label: string
+  icon: string
+  items: FAQItem[]
+}
+
+const FAQ_DATA: FAQCategory[] = [
+  {
+    id: 'basics',
+    label: 'Basics',
+    icon: '🪴',
+    items: [
+      {
+        q: 'What is PotBot?',
+        a: 'PotBot lets a group of people pool funds into a shared on-chain treasury and decide together which trades to make. Each member\'s deposit is recorded as "shares" in the vault. Members propose token swaps and vote on them. If a proposal passes, the smart contract executes the swap via Jupiter. Members can withdraw their proportional share at any time.',
+      },
+      {
+        q: 'What is a "Pot"?',
+        a: 'A Pot is a smart contract on Solana that holds the group\'s funds and enforces the voting rules. Nobody — not even the pot creator — can move funds out except through the rules everyone agreed to.',
+      },
+      {
+        q: 'What are Shares?',
+        a: 'Shares represent your proportion of the pot. If you deposit 1 SOL into a pot that holds 9 SOL after your deposit, you own 11.1% of it. If the pot\'s total value goes up or down, your shares move with it. Shares are tracked on-chain.',
+      },
+      {
+        q: 'What is a Proposal?',
+        a: 'A Proposal is a request to perform an action on behalf of the pot — most commonly, "swap X of token A into token B". Members vote yes or no, weighted by their shares. If the vote meets the pot\'s quorum and approval thresholds, the swap executes automatically.',
+      },
+      {
+        q: 'What is the AI Agent?',
+        a: 'The AI Agent is an optional feature that monitors price and balance conditions and creates proposals automatically based on rules the pot members configure. The agent can only propose — it cannot vote or execute. All trades still require member voting.',
+      },
+      {
+        q: 'What is ONE POT?',
+        a: 'ONE POT is a publicly available example vault that anyone can join. It runs a transparent, conservative SOL/USDC rotation strategy and exists so new users can experience the platform with a small deposit before creating their own pot. ONE POT is not a recommendation — it\'s a demo with real funds.',
+      },
+    ],
+  },
+  {
+    id: 'money',
+    label: 'Money',
+    icon: '💰',
+    items: [
+      {
+        q: 'How does PotBot make money?',
+        a: 'PotBot charges a 0.5% fee on every swap executed through a pot. There are no subscription fees, no fees on deposits or withdrawals, and no fees if your pot doesn\'t trade.',
+      },
+      {
+        q: 'Where do the fees go?',
+        a: 'Of the 0.5% swap fee: 39% to the protocol treasury, 20% to the referrer of the depositing user, 20% to $POT token buyback-and-burn, 20% to development and operations, and 1% to the Season Trading Competition Treasury.',
+      },
+      {
+        q: 'How do members earn?',
+        a: 'Members earn — or lose — based on the trading decisions the group makes. If voted-on swaps gain value, withdrawing members receive more than they deposited. If swaps lose value, withdrawing members receive less. Members may also earn through the referral program and Season prize distributions.',
+      },
+      {
+        q: 'How do referrals work?',
+        a: 'When you refer a new user who deposits at least 0.1 SOL, you earn 20% of all swap fees they generate, paid in real-time to your wallet, for as long as they use PotBot.',
+      },
+      {
+        q: 'Are returns guaranteed?',
+        a: 'No. PotBot is not a yield product. The vault is a coordination tool — outcomes depend entirely on the swap decisions members vote on, and on the volatile crypto markets those swaps occur in. You can lose part or all of your deposit.',
+      },
+    ],
+  },
+  {
+    id: 'token',
+    label: 'Token',
+    icon: '🪙',
+    items: [
+      {
+        q: 'What is $POT?',
+        a: '$POT is the protocol\'s utility token on Solana. It receives buyback-and-burn from 20% of all protocol swap fees. Holding $POT does not represent ownership in PotBot or guarantee any return.',
+      },
+      {
+        q: 'What is a Pot Token?',
+        a: 'Any pot creator can choose to issue a public token for their pot via our integration with bags.fm. The pot token is a community signal — a way for outsiders to express interest in a pot\'s strategy by buying its token on the open market. Pot tokens are bonded-curve tokens and trade independently of the underlying vault\'s NAV.',
+      },
+      {
+        q: 'What is liquidity providing?',
+        a: "If a pot has issued a token, members can add liquidity to its trading pair on a DEX. Liquidity providers earn a share of trading fees on that pair. This is a separate activity from the pot's internal voting and is subject to standard DEX risks including impermanent loss.",
+      },
+      {
+        q: 'What is buyback and burn?',
+        a: 'Buyback and burn means the protocol uses a portion of fee revenue to purchase $POT on the open market and permanently remove those tokens from circulation. The mechanism is automated and verifiable on-chain.',
+      },
+    ],
+  },
+  {
+    id: 'safety',
+    label: 'Safety',
+    icon: '🔒',
+    items: [
+      {
+        q: 'Who controls the funds in a pot?',
+        a: 'The smart contract does. No human — including the PotBot team and the pot creator — has the ability to move funds in ways the contract doesn\'t permit. Any movement requires a passing vote according to the pot\'s rules.',
+      },
+      {
+        q: 'Can the pot creator run away with my money?',
+        a: 'No. The smart contract does not give the creator unilateral withdrawal rights. Creators set up the pot\'s parameters (quorum, voting window, etc.) at creation, but the funds inside the vault are protected by code, not trust.',
+      },
+      {
+        q: 'What are the actual risks?',
+        a: 'Three main categories. (1) Market risk — token prices move and your pot can lose value. (2) Smart contract risk — although our code is open-source and audited, no smart contract is provably bug-free. (3) Group decision risk — you\'re trusting the collective judgment of pot members. Choose pots whose strategy and members you understand.',
+      },
+      {
+        q: 'Can I withdraw at any time?',
+        a: 'Yes. Withdrawals are pro-rata against your shares and execute immediately on-chain. There is no lock-up period, no admin approval, no waiting list.',
+      },
+      {
+        q: 'Is PotBot regulated?',
+        a: 'PotBot is a non-custodial software tool. We do not hold customer funds. Users are responsible for compliance with their local laws. Use of PotBot is restricted in certain jurisdictions — see our Terms of Service.',
+      },
+    ],
+  },
+  {
+    id: 'season',
+    label: 'Season',
+    icon: '🌱',
+    items: [
+      {
+        q: 'What is a Season?',
+        a: 'Seasons are quarterly community events that introduce themed activities, points, and a competition prize pool. Season 1 is "The Garden" — every pot gets a virtual plant that grows based on member activity.',
+      },
+      {
+        q: 'What is the Tamagotchi (plant)?',
+        a: "Each pot has a virtual plant that visualizes the pot's community health. The plant gains health from member actions like voting, depositing, and creating proposals — and loses health from inactivity. The plant is purely cosmetic and is not tied to financial performance.",
+      },
+      {
+        q: 'What is the Trading Competition Treasury?',
+        a: '1% of all protocol swap fees during the season accumulate in a transparent on-chain treasury. At season end, the top 3 pots on the leaderboard receive 50% / 30% / 20% of the treasury, distributed pro-rata to those pots\' members.',
+      },
+      {
+        q: 'How is the leaderboard ranked?',
+        a: 'Pots are ranked by Season Score, calculated as: season trading volume × member count × pet health score. This formula rewards activity, growth, and engagement — not raw trading P&L. The exact formula and inputs are visible on the leaderboard page.',
+      },
+      {
+        q: 'What are points?',
+        a: 'Points are rewards for taking actions on the platform — creating pots, voting, referring users, completing quests. Points contribute to a future $POT token distribution and unlock immediate quest rewards. Points are recorded off-chain in our database and are not transferable.',
+      },
+      {
+        q: 'What are quests?',
+        a: 'Quests are time-limited tasks (often marketing-related — sharing about PotBot, bringing friends, exploring new features) that award bonus points. New quests rotate weekly.',
+      },
+    ],
+  },
+]
+
+function FAQAccordion({ items }: { items: FAQItem[] }) {
+  const [open, setOpen] = useState<number | null>(null)
+  return (
+    <div className="space-y-2">
+      {items.map((item, i) => (
+        <div key={i} className="border border-pot-border rounded-xl overflow-hidden">
+          <button
+            onClick={() => setOpen(open === i ? null : i)}
+            className="w-full flex items-center justify-between gap-4 px-5 py-4 text-left hover:bg-pot-card/50 transition"
+          >
+            <span className="text-sm font-medium text-white">{item.q}</span>
+            <span
+              className="shrink-0 text-pot-muted transition-transform duration-200"
+              style={{ transform: open === i ? 'rotate(45deg)' : 'none' }}
+            >
+              +
+            </span>
+          </button>
+          {open === i && (
+            <div className="px-5 pb-5 bg-pot-card/30">
+              <p className="text-sm text-gray-300 leading-relaxed">{item.a}</p>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function FAQPage() {
+  const [activeCategory, setActiveCategory] = useState('basics')
+  const category = FAQ_DATA.find((c) => c.id === activeCategory) ?? FAQ_DATA[0]
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-pot-muted mb-3">
+          <Link href="/" className="hover:text-white transition">Home</Link>
+          <span>/</span>
+          <span className="text-white">FAQ</span>
+        </div>
+        <h1 className="text-3xl font-black text-white mb-2">Frequently Asked Questions</h1>
+        <p className="text-pot-muted">
+          Everything you need to know about PotBot — plain language, no hype.
+        </p>
+      </div>
+
+      {/* Category tabs */}
+      <div className="flex gap-2 flex-wrap mb-6">
+        {FAQ_DATA.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => setActiveCategory(cat.id)}
+            className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-medium transition ${
+              activeCategory === cat.id
+                ? 'bg-pot-green text-pot-dark font-bold'
+                : 'bg-pot-card border border-pot-border text-pot-muted hover:text-white'
+            }`}
+          >
+            <span>{cat.icon}</span>
+            <span>{cat.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* FAQ Items */}
+      <FAQAccordion items={category.items} />
+
+      {/* Footer links */}
+      <div className="mt-10 p-6 rounded-2xl border border-pot-border bg-pot-card/50 text-center">
+        <p className="text-sm text-pot-muted mb-3">Still have questions?</p>
+        <div className="flex flex-wrap gap-3 justify-center">
+          <a
+            href="https://t.me/Trade_pot_bot"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-secondary text-sm py-2 px-5"
+          >
+            💬 Telegram Bot
+          </a>
+          <a
+            href="https://x.com/PotBot_sol"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-secondary text-sm py-2 px-5"
+          >
+            𝕏 Twitter
+          </a>
+          <Link href="/create" className="btn-primary text-sm py-2 px-5">
+            🪴 Try PotBot
+          </Link>
+        </div>
+      </div>
+
+      {/* Disclaimers */}
+      <div className="mt-8 p-5 rounded-2xl bg-amber-500/5 border border-amber-500/20">
+        <p className="text-xs text-pot-muted leading-relaxed space-y-1">
+          <strong className="text-amber-400/80 block mb-2">Risk Disclosures</strong>
+          PotBot is non-custodial software. You retain full custody of your funds via the smart contract. Crypto assets are volatile — you may lose some or all of the funds you deposit. Past performance does not predict future results. PotBot is not investment advice. Members make their own decisions through on-chain voting. Use of PotBot may be restricted in certain jurisdictions; by using this app you confirm compliance with your local laws.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,30 +1,28 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { AppProviders } from './providers'
 import { Navbar } from '@/components/Navbar'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'PotBot v2 — Group Trading Vaults on Solana',
-  description: 'Create group trading vaults, govern together, trade together, win together.',
+  title: 'PotBot — Group Trading Vaults on Solana',
+  description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
   metadataBase: new URL('https://potbot.fun'),
-  alternates: {
-    canonical: '/',
-  },
+  alternates: { canonical: '/' },
   openGraph: {
-    title: 'PotBot v2 — Group Trading Vaults on Solana',
-    description: 'Create group trading vaults, govern together, trade together, win together.',
+    title: 'PotBot — Group Trading Vaults on Solana',
+    description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
     url: 'https://potbot.fun',
     siteName: 'PotBot',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'PotBot v2 — Group Trading Vaults on Solana',
-    description: 'Create group trading vaults, govern together, trade together, win together.',
+    title: 'PotBot — Group Trading Vaults on Solana',
+    description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
   },
 }
 
-// Runs before React hydrates — prevents light/dark flash on first paint.
 const THEME_BOOTSTRAP = `
 (function(){
   try {
@@ -39,22 +37,78 @@ const THEME_BOOTSTRAP = `
 })();
 `.trim()
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+const FOOTER_LINKS = [
+  { label: 'FAQ',         href: '/faq' },
+  { label: 'Leaderboard', href: '/leaderboard' },
+  { label: 'Hackathon',   href: '/hackathon' },
+  { label: 'For Agents',  href: '/for-agents' },
+  { label: 'GitHub',      href: 'https://github.com/YD811/potbot-v2', external: true },
+  { label: 'Twitter',     href: 'https://x.com/PotBot_sol', external: true },
+]
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }} />
       </head>
-      <body className="min-h-screen bg-pot-dark text-white antialiased">
+      <body className="min-h-screen bg-pot-dark text-white antialiased flex flex-col">
         <AppProviders>
           <Navbar />
-          <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
             {children}
           </main>
+
+          {/* ── Footer ─────────────────────────────────────────── */}
+          <footer className="border-t border-pot-border/40 bg-pot-dark/80 mt-16">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              {/* Links row */}
+              <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mb-6">
+                <Link href="/" className="flex items-center gap-2">
+                  <span className="text-xl">🪴</span>
+                  <span className="font-bold text-white">Pot<span className="text-pot-green">Bot</span></span>
+                  <span className="text-xs text-pot-muted">v2 · Solana Frontier 2026</span>
+                </Link>
+                <nav className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-pot-muted justify-center">
+                  {FOOTER_LINKS.map(({ label, href, external }) =>
+                    external ? (
+                      <a key={label} href={href} target="_blank" rel="noopener noreferrer"
+                        className="hover:text-white transition">{label}</a>
+                    ) : (
+                      <Link key={label} href={href} className="hover:text-white transition">{label}</Link>
+                    )
+                  )}
+                </nav>
+              </div>
+
+              {/* Disclaimers */}
+              <div className="border-t border-pot-border/30 pt-5 space-y-1.5 text-[11px] text-pot-muted leading-relaxed">
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Non-custodial:</span>{' '}
+                  PotBot is non-custodial software. You retain full custody of your funds via the smart contract.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Risk:</span>{' '}
+                  Crypto assets are volatile. You may lose some or all of the funds you deposit. Past performance does not predict future results.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Not advice:</span>{' '}
+                  PotBot is not investment advice. Members make their own decisions through on-chain voting.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Jurisdictions:</span>{' '}
+                  Use of PotBot is restricted in certain jurisdictions. By using this app you confirm compliance with your local laws.{' '}
+                  <Link href="/faq" className="underline hover:text-white">See FAQ</Link>
+                </p>
+                <p className="pt-1 text-pot-border">
+                  © 2026 PotBot · Built on Solana · Open source ·{' '}
+                  <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noopener noreferrer" className="underline hover:text-white">
+                    View code
+                  </a>
+                </p>
+              </div>
+            </div>
+          </footer>
         </AppProviders>
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useMockStore } from '@/lib/mock-store'
 import { useSolPrice } from '@/lib/prices'
 import LandingPage from '@/components/LandingPage'
 import { TrustBadge } from '@/components/TrustBadge'
+import { OnePotBanner } from '@/components/OnePotBanner'
 
 const WalletMultiButton = dynamic(
   async () => (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
@@ -46,8 +47,8 @@ export default function DashboardPage() {
   const { publicKey, connected } = useWallet()
   const { data: pots, isLoading } = usePots()
   const { price: solPrice } = useSolPrice()
-  const [search, setSearch]     = useState('')
-  const [tab, setTab]           = useState<'all' | 'mine'>('all')
+  const [search, setSearch] = useState('')
+  const [tab, setTab] = useState<'all' | 'mine'>('all')
 
   const walletStr = publicKey?.toBase58() ?? ''
 
@@ -94,6 +95,9 @@ export default function DashboardPage() {
     <div>
       <HackathonButton />
 
+      {/* ── ONE POT Featured Banner ── */}
+      <OnePotBanner />
+
       {/* Stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
         <div className="card p-4 text-center glow-green">
@@ -123,26 +127,42 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Leaderboard teaser */}
-      <Link
-        href="/leaderboard"
-        className="flex items-center justify-between p-4 mb-6 bg-gradient-to-r from-amber-500/10 to-violet-500/10 border border-amber-500/20 rounded-2xl hover:border-amber-500/40 transition group"
-      >
-        <div className="flex items-center gap-3">
-          <span className="text-2xl">🏆</span>
-          <div>
-            <div className="text-sm font-semibold text-white">Public Leaderboard</div>
-            <div className="text-xs text-pot-muted">
-              {pots?.filter((p) => p.isPublic).length ?? 0} public pots competing — see top performers
+      {/* Quick links row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+        <Link
+          href="/leaderboard"
+          className="flex items-center justify-between p-4 bg-gradient-to-r from-amber-500/10 to-violet-500/10 border border-amber-500/20 rounded-2xl hover:border-amber-500/40 transition group"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">🏆</span>
+            <div>
+              <div className="text-sm font-semibold text-white">Public Leaderboard</div>
+              <div className="text-xs text-pot-muted">
+                {pots?.filter((p) => p.isPublic).length ?? 0} public pots — see top performers
+              </div>
             </div>
           </div>
-        </div>
-        <span className="text-pot-muted text-sm group-hover:text-white transition">View →</span>
-      </Link>
+          <span className="text-pot-muted text-sm group-hover:text-white transition">View →</span>
+        </Link>
+
+        <Link
+          href="/dashboard"
+          className="flex items-center justify-between p-4 bg-gradient-to-r from-pot-green/5 to-pot-accent/5 border border-pot-green/20 rounded-2xl hover:border-pot-green/40 transition group"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">📊</span>
+            <div>
+              <div className="text-sm font-semibold text-white">My Dashboard</div>
+              <div className="text-xs text-pot-muted">Portfolio · Votes · Quests · Referrals</div>
+            </div>
+          </div>
+          <span className="text-pot-muted text-sm group-hover:text-white transition">Open →</span>
+        </Link>
+      </div>
 
       {/* Header + Search + Tabs */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
-        <h2 className="text-2xl font-bold">POTs</h2>
+        <h2 className="text-2xl font-bold">All POTs</h2>
         <div className="flex gap-3 w-full sm:w-auto">
           <input
             type="text"
@@ -186,7 +206,7 @@ export default function DashboardPage() {
           )}
         </button>
         {tab === 'mine' && (
-          <Link href="/my-pots" className="ml-auto text-xs text-pot-muted hover:text-white transition">
+          <Link href="/dashboard" className="ml-auto text-xs text-pot-muted hover:text-white transition">
             Full dashboard →
           </Link>
         )}
@@ -257,7 +277,6 @@ export default function DashboardPage() {
                   <span className="text-xl">{pot.tamagotchiEmoji}</span>
                 </div>
 
-                {/* Balance in SOL + USD */}
                 <div className="mb-3">
                   <div className="text-xl font-bold text-pot-green">
                     {pot.balance.toFixed(2)} SOL

--- a/apps/web/src/components/DisclaimerModal.tsx
+++ b/apps/web/src/components/DisclaimerModal.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+
+const STORAGE_KEY = 'potbot-disclaimer-v1'
+
+const DISCLAIMERS: { icon: string; text: string }[] = [
+  {
+    icon: '🔒',
+    text: 'PotBot is non-custodial software. You retain full custody of your funds via the smart contract.',
+  },
+  {
+    icon: '⚠️',
+    text: 'Crypto assets are volatile. You may lose some or all of the funds you deposit. Past performance does not predict future results.',
+  },
+  {
+    icon: '🗳️',
+    text: 'PotBot is not investment advice. Members make their own decisions through on-chain voting.',
+  },
+  {
+    icon: '🌍',
+    text: 'PotBot is not available in restricted jurisdictions. By using this app you confirm you are not a resident of such jurisdictions.',
+  },
+]
+
+interface Props {
+  /** Render this to trigger the modal (e.g. a Deposit button). */
+  trigger: (open: () => void) => ReactNode
+  /** Called when user accepts and wants to proceed. */
+  onAccept: () => void
+}
+
+/**
+ * Wraps any action (e.g. first deposit) behind a one-time disclaimer modal.
+ * Shows once per browser; subsequent clicks go straight to onAccept.
+ */
+export function DisclaimerModal({ trigger, onAccept }: Props) {
+  const [open, setOpen] = useState(false)
+  const [accepted, setAccepted] = useState(false)
+  const [checked, setChecked] = useState(false)
+
+  useEffect(() => {
+    try {
+      setAccepted(localStorage.getItem(STORAGE_KEY) === 'true')
+    } catch {
+      setAccepted(true) // privacy mode — skip modal
+    }
+  }, [])
+
+  function handleOpen() {
+    if (accepted) {
+      onAccept()
+    } else {
+      setOpen(true)
+    }
+  }
+
+  function handleAccept() {
+    try { localStorage.setItem(STORAGE_KEY, 'true') } catch {}
+    setAccepted(true)
+    setOpen(false)
+    onAccept()
+  }
+
+  return (
+    <>
+      {trigger(handleOpen)}
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center p-4"
+          onClick={(e) => e.target === e.currentTarget && setOpen(false)}
+          style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(8px)' }}
+        >
+          <div
+            className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card p-6 sm:p-8 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center gap-3 mb-5">
+              <div className="w-10 h-10 rounded-xl bg-amber-500/10 border border-amber-500/20 flex items-center justify-center text-xl">
+                ℹ️
+              </div>
+              <div>
+                <h2 className="text-base font-bold text-white">Before you deposit</h2>
+                <p className="text-xs text-pot-muted">Please read and accept to continue</p>
+              </div>
+            </div>
+
+            {/* Disclaimers */}
+            <div className="space-y-3 mb-5">
+              {DISCLAIMERS.map((d) => (
+                <div
+                  key={d.icon}
+                  className="flex items-start gap-3 p-3 rounded-xl bg-pot-dark border border-pot-border/50"
+                >
+                  <span className="shrink-0 text-base mt-0.5">{d.icon}</span>
+                  <p className="text-xs text-gray-300 leading-relaxed">{d.text}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* Checkbox */}
+            <label className="flex items-start gap-3 cursor-pointer mb-5 group">
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => setChecked(e.target.checked)}
+                className="mt-0.5 w-4 h-4 accent-[#00ff88] cursor-pointer"
+              />
+              <span className="text-xs text-pot-muted group-hover:text-white transition leading-relaxed">
+                I have read and understand the above disclosures. I accept full responsibility for my deposits and trading decisions.
+              </span>
+            </label>
+
+            {/* Actions */}
+            <div className="flex gap-3">
+              <button
+                onClick={() => setOpen(false)}
+                className="flex-1 btn-secondary text-sm py-2.5"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAccept}
+                disabled={!checked}
+                className="flex-1 btn-primary text-sm py-2.5 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Accept & Continue
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+/** Standalone disclaimer banner for footers / modals that just shows the text. */
+export function DisclaimerBanner() {
+  return (
+    <div className="border-t border-pot-border/30 bg-pot-dark/50 py-6">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-[11px] text-pot-muted space-y-1.5 leading-relaxed">
+          <p>
+            <strong className="text-pot-muted/80">Non-custodial:</strong> PotBot is non-custodial software. You retain full custody of your funds via the smart contract.
+          </p>
+          <p>
+            <strong className="text-pot-muted/80">Risk:</strong> Crypto assets are volatile. You may lose some or all of the funds you deposit. Past performance does not predict future results.
+          </p>
+          <p>
+            <strong className="text-pot-muted/80">Not advice:</strong> PotBot is not investment advice. Members make their own decisions through on-chain voting.
+          </p>
+          <p>
+            <strong className="text-pot-muted/80">Jurisdictions:</strong> Use of PotBot may be restricted in certain jurisdictions. By using this app you confirm compliance with your local laws.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -46,6 +46,11 @@ function LivePriceTicker() {
             {apiDown ? 'Demo Mode' : 'Live'}
           </span>
         </div>
+        {/* Season 1 ticker */}
+        <div className="hidden sm:flex items-center gap-1.5 text-[11px]">
+          <span className="text-pot-muted">|</span>
+          <span className="text-pot-accent">🌱 Season 1: The Garden</span>
+        </div>
         <div className="ml-auto flex items-center gap-3 text-[11px] text-pot-muted">
           <Link href="/for-agents" className="hover:text-pot-green transition hidden sm:block">
             🤖 For AI Agents
@@ -57,7 +62,7 @@ function LivePriceTicker() {
 }
 
 const NAV_LINKS = [
-  { href: '/',            label: 'Dashboard' },
+  { href: '/',            label: 'Home' },
   { href: '/leaderboard', label: '🏆 Leaderboard' },
   { href: '/vaults',      label: '⚡ Vaults' },
   { href: '/create',      label: '+ Create' },
@@ -71,7 +76,6 @@ export function Navbar() {
   const isActive = (href: string) =>
     href === '/' ? pathname === '/' : pathname.startsWith(href)
 
-  // Hide the Waitlist CTA on the signup page itself — no point linking to where we are.
   const showWaitlistCta = !pathname.startsWith('/signup')
 
   return (
@@ -90,17 +94,18 @@ export function Navbar() {
             }`}>{label}</Link>
           ))}
           {publicKey && (
-            <Link href="/my-pots" className={`px-3 py-1.5 rounded-lg transition ${
-              isActive('/my-pots') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
-            }`}>My POTs</Link>
+            <Link href="/dashboard" className={`px-3 py-1.5 rounded-lg transition ${
+              isActive('/dashboard') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
+            }`}>My Dashboard</Link>
           )}
+          <Link href="/faq" className={`px-3 py-1.5 rounded-lg transition ${
+            isActive('/faq') ? 'text-white bg-pot-card border border-pot-border' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
+          }`}>FAQ</Link>
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Theme slider (dark ↔ light) */}
           <ThemeToggle />
 
-          {/* Waitlist / Early-Access CTA — visible on every page */}
           {showWaitlistCta && (
             <Link
               href="/signup"
@@ -133,7 +138,6 @@ export function Navbar() {
 
       {menuOpen && (
         <div className="sm:hidden border-t border-pot-border bg-pot-dark/95 backdrop-blur-xl px-4 py-3 space-y-1">
-          {/* Mobile Waitlist CTA — top of the drawer so it's impossible to miss */}
           {showWaitlistCta && (
             <Link
               href="/signup"
@@ -151,11 +155,15 @@ export function Navbar() {
               }`}>{label}</Link>
           ))}
           {publicKey && (
-            <Link href="/my-pots" onClick={() => setMenuOpen(false)}
+            <Link href="/dashboard" onClick={() => setMenuOpen(false)}
               className={`block px-4 py-2.5 rounded-xl text-sm font-medium transition ${
-                isActive('/my-pots') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
-              }`}>My POTs</Link>
+                isActive('/dashboard') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
+              }`}>My Dashboard</Link>
           )}
+          <Link href="/faq" onClick={() => setMenuOpen(false)}
+            className={`block px-4 py-2.5 rounded-xl text-sm font-medium transition ${
+              isActive('/faq') ? 'text-white bg-pot-card border border-pot-border' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
+            }`}>FAQ</Link>
           <div className="pt-2 border-t border-pot-border/50">
             <Link href="/for-agents" onClick={() => setMenuOpen(false)}
               className="block px-4 py-2 text-sm text-pot-muted hover:text-pot-green transition">

--- a/apps/web/src/components/OnePotBanner.tsx
+++ b/apps/web/src/components/OnePotBanner.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import Link from 'next/link'
+import { useSolPrice } from '@/lib/prices'
+import { usePot } from '@/hooks/usePots'
+
+const ONE_POT_PUBKEY =
+  process.env.NEXT_PUBLIC_ONE_POT_PUBKEY ?? 'DEMO1111111111111111111111111111111111111111'
+
+const STRATEGY_RULES = [
+  { icon: '⚖️', label: '70% SOL / 30% USDC baseline allocation' },
+  { icon: '🤖', label: 'AI Agent proposes rebalances when SOL moves ±10% from 7-day MA' },
+  { icon: '⏱️', label: '24h voting window · 50% quorum · 60% approval threshold' },
+  { icon: '🔒', label: 'Max 20% of treasury per single swap — hard-coded in the contract' },
+  { icon: '📖', label: 'All rules visible on the pot page under the Strategy tab' },
+]
+
+export function OnePotBanner({ compact = false }: { compact?: boolean }) {
+  const { price: solPrice } = useSolPrice()
+  const { data: pot } = usePot(ONE_POT_PUBKEY)
+
+  const balanceUsd = pot && solPrice ? pot.balance * solPrice : null
+
+  if (compact) {
+    return (
+      <Link
+        href={`/pots/${ONE_POT_PUBKEY}`}
+        className="group flex items-center justify-between p-4 rounded-2xl border border-pot-green/30 bg-gradient-to-r from-pot-green/5 to-pot-accent/5 hover:border-pot-green/60 transition-all mb-6"
+        style={{
+          background: 'linear-gradient(135deg, rgba(0,255,136,0.05) 0%, rgba(139,92,246,0.05) 100%)',
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <span className="text-3xl">🌿</span>
+            <span className="absolute -top-1 -right-1 text-[10px] bg-pot-green text-pot-dark font-bold px-1 rounded-full">
+              S1
+            </span>
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-white">ONE POT</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-pot-green/20 text-pot-green border border-pot-green/30 font-bold">
+                FEATURED
+              </span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-pot-accent/20 text-pot-accent border border-pot-accent/30">
+                Season 1
+              </span>
+            </div>
+            <p className="text-xs text-pot-muted mt-0.5">
+              Conservative SOL/USDC rotation · Try the platform with a small deposit
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {balanceUsd != null && (
+            <div className="text-right hidden sm:block">
+              <div className="text-sm font-bold text-pot-green">
+                ${balanceUsd >= 1000 ? (balanceUsd / 1000).toFixed(1) + 'K' : balanceUsd.toFixed(0)}
+              </div>
+              <div className="text-[10px] text-pot-muted">TVL</div>
+            </div>
+          )}
+          <span className="text-pot-muted text-sm group-hover:text-pot-green transition">Join →</span>
+        </div>
+      </Link>
+    )
+  }
+
+  return (
+    <div
+      className="relative rounded-3xl p-[1px] mb-8 overflow-hidden"
+      style={{
+        background: 'linear-gradient(135deg, #00ff88 0%, #9945FF 50%, #00ff88 100%)',
+        backgroundSize: '200% 200%',
+        animation: 'gradientShift 6s ease infinite',
+      }}
+    >
+      <style>{`
+        @keyframes gradientShift {
+          0%   { background-position: 0% 50%; }
+          50%  { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+      `}</style>
+
+      <div
+        className="rounded-[calc(1.5rem-1px)] p-6 sm:p-8"
+        style={{ background: 'linear-gradient(135deg, #0a1220 0%, #0d1117 50%, #0a0e1a 100%)' }}
+      >
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+          <div className="flex items-center gap-3">
+            <div className="relative">
+              <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-pot-green/20 to-pot-accent/20 flex items-center justify-center text-3xl border border-pot-green/20">
+                🌿
+              </div>
+              <span className="absolute -top-1 -right-1 text-[10px] bg-pot-green text-pot-dark font-black px-1.5 py-0.5 rounded-full">
+                S1
+              </span>
+            </div>
+            <div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h2 className="text-xl font-black text-white tracking-tight">ONE POT</h2>
+                <span className="text-xs px-2 py-0.5 rounded-full bg-pot-green/20 text-pot-green border border-pot-green/30 font-bold uppercase tracking-wide">
+                  Featured
+                </span>
+                <span className="text-xs px-2 py-0.5 rounded-full bg-pot-accent/20 text-pot-accent border border-pot-accent/30">
+                  🌱 Season 1
+                </span>
+              </div>
+              <p className="text-pot-muted text-sm mt-1">
+                The canonical PotBot demo vault — transparent, conservative, open to everyone
+              </p>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="flex items-center gap-4 shrink-0">
+            {pot && (
+              <>
+                <div className="text-center">
+                  <div className="text-lg font-bold text-pot-green">
+                    {balanceUsd != null
+                      ? `$${balanceUsd >= 1000 ? (balanceUsd / 1000).toFixed(1) + 'K' : balanceUsd.toFixed(0)}`
+                      : `${pot.balance.toFixed(2)} SOL`}
+                  </div>
+                  <div className="text-[11px] text-pot-muted">TVL</div>
+                </div>
+                <div className="w-px h-8 bg-pot-border" />
+                <div className="text-center">
+                  <div className="text-lg font-bold text-white">{pot.memberCount}</div>
+                  <div className="text-[11px] text-pot-muted">Members</div>
+                </div>
+                <div className="w-px h-8 bg-pot-border" />
+                <div className="text-center">
+                  <div className="text-lg font-bold text-white">{pot.tradeCount}</div>
+                  <div className="text-[11px] text-pot-muted">Trades</div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Strategy rules */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-6">
+          {STRATEGY_RULES.map((rule) => (
+            <div
+              key={rule.label}
+              className="flex items-start gap-2 text-sm"
+            >
+              <span className="shrink-0 mt-0.5">{rule.icon}</span>
+              <span className="text-gray-300">{rule.label}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Disclaimer + CTA */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <p className="text-xs text-pot-muted max-w-md leading-relaxed">
+            ONE POT is a demo vault with real funds. It is not a recommendation.
+            Crypto assets are volatile — you may lose part or all of your deposit.
+          </p>
+          <Link
+            href={`/pots/${ONE_POT_PUBKEY}`}
+            className="shrink-0 rounded-xl bg-pot-green px-6 py-2.5 text-sm font-bold text-pot-dark hover:brightness-110 transition active:scale-[0.98]"
+          >
+            Join ONE POT →
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Phase 1 hackathon backbone — all 4 items:

1. OnePotBanner — featured gradient-border vault card on /, /leaderboard, /vaults. Reads balance from usePot(). Pubkey from NEXT_PUBLIC_ONE_POT_PUBKEY. Compact variant for secondary pages.

2. /faq page — full English FAQ, 5 categories (Basics/Money/Token/Safety/Season), accordion UI, risk disclosures block. Content verbatim from product brief. No financial promises. Link added to Navbar (desktop + mobile drawer).

3. DisclaimerModal + DisclaimerBanner — one-time gate component (localStorage v1), 4 required disclosures with checkbox acceptance. Export for use on any deposit flow. DisclaimerBanner for standalone use in footers.

4. /dashboard page — 6 sections: Hero stats, My POTs grid, Pending Votes, Quests (active + points table), Referrals (link + earnings). Connected-only, shows connect prompt otherwise.

5. Navbar — adds /dashboard (wallet-gated) + /faq links, Season 1 ticker in top bar. Mobile drawer updated.

6. layout.tsx — footer with legal disclaimers (4 disclosures), nav links, copyright. body is flex-col so footer sticks to bottom.