### PR TITLE
feat(phase3): $POT token layer — buyback card, tokenize modal, bags.fm

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,6 +9,8 @@ import { useMockStore } from '@/lib/mock-store'
 import { useSolPrice } from '@/lib/prices'
 import LandingPage from '@/components/LandingPage'
 import { TrustBadge } from '@/components/TrustBadge'
+import { OnePotBanner } from '@/components/OnePotBanner'
+import { PotTokenCard } from '@/components/PotTokenCard'
 
 const WalletMultiButton = dynamic(
   async () => (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
@@ -46,8 +48,8 @@ export default function DashboardPage() {
   const { publicKey, connected } = useWallet()
   const { data: pots, isLoading } = usePots()
   const { price: solPrice } = useSolPrice()
-  const [search, setSearch]     = useState('')
-  const [tab, setTab]           = useState<'all' | 'mine'>('all')
+  const [search, setSearch] = useState('')
+  const [tab, setTab] = useState<'all' | 'mine'>('all')
 
   const walletStr = publicKey?.toBase58() ?? ''
 
@@ -94,6 +96,9 @@ export default function DashboardPage() {
     <div>
       <HackathonButton />
 
+      {/* ── ONE POT Featured Banner ── */}
+      <OnePotBanner />
+
       {/* Stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
         <div className="card p-4 text-center glow-green">
@@ -123,26 +128,45 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Leaderboard teaser */}
-      <Link
-        href="/leaderboard"
-        className="flex items-center justify-between p-4 mb-6 bg-gradient-to-r from-amber-500/10 to-violet-500/10 border border-amber-500/20 rounded-2xl hover:border-amber-500/40 transition group"
-      >
-        <div className="flex items-center gap-3">
-          <span className="text-2xl">🏆</span>
-          <div>
-            <div className="text-sm font-semibold text-white">Public Leaderboard</div>
-            <div className="text-xs text-pot-muted">
-              {pots?.filter((p) => p.isPublic).length ?? 0} public pots competing — see top performers
+      {/* Quick links row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+        <Link
+          href="/leaderboard"
+          className="flex items-center justify-between p-4 bg-gradient-to-r from-amber-500/10 to-violet-500/10 border border-amber-500/20 rounded-2xl hover:border-amber-500/40 transition group"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">🏆</span>
+            <div>
+              <div className="text-sm font-semibold text-white">Public Leaderboard</div>
+              <div className="text-xs text-pot-muted">
+                {pots?.filter((p) => p.isPublic).length ?? 0} public pots — see top performers
+              </div>
             </div>
           </div>
-        </div>
-        <span className="text-pot-muted text-sm group-hover:text-white transition">View →</span>
-      </Link>
+          <span className="text-pot-muted text-sm group-hover:text-white transition">View →</span>
+        </Link>
+
+        <Link
+          href="/dashboard"
+          className="flex items-center justify-between p-4 bg-gradient-to-r from-pot-green/5 to-pot-accent/5 border border-pot-green/20 rounded-2xl hover:border-pot-green/40 transition group"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">📊</span>
+            <div>
+              <div className="text-sm font-semibold text-white">My Dashboard</div>
+              <div className="text-xs text-pot-muted">Portfolio · Votes · Quests · Referrals</div>
+            </div>
+          </div>
+          <span className="text-pot-muted text-sm group-hover:text-white transition">Open →</span>
+        </Link>
+      </div>
+
+      {/* ── $POT Token Buyback Card ── */}
+      <PotTokenCard />
 
       {/* Header + Search + Tabs */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
-        <h2 className="text-2xl font-bold">POTs</h2>
+        <h2 className="text-2xl font-bold">All POTs</h2>
         <div className="flex gap-3 w-full sm:w-auto">
           <input
             type="text"
@@ -186,7 +210,7 @@ export default function DashboardPage() {
           )}
         </button>
         {tab === 'mine' && (
-          <Link href="/my-pots" className="ml-auto text-xs text-pot-muted hover:text-white transition">
+          <Link href="/dashboard" className="ml-auto text-xs text-pot-muted hover:text-white transition">
             Full dashboard →
           </Link>
         )}
@@ -257,7 +281,6 @@ export default function DashboardPage() {
                   <span className="text-xl">{pot.tamagotchiEmoji}</span>
                 </div>
 
-                {/* Balance in SOL + USD */}
                 <div className="mb-3">
                   <div className="text-xl font-bold text-pot-green">
                     {pot.balance.toFixed(2)} SOL

--- a/apps/web/src/components/PotTokenCard.tsx
+++ b/apps/web/src/components/PotTokenCard.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * $POT token buyback display card.
+ * Shows mock token stats + fee-to-buyback flywheel explanation.
+ * Real data: fetch from bags.fm API / on-chain when live.
+ */
+
+// ── Mock data — replace with live fetch when $POT is listed ──────────────────
+const MOCK = {
+  price:      0.00312,      // USD
+  priceChange: +18.4,       // 24h %
+  mcap:        156_000,     // USD
+  volume24h:   28_400,      // USD
+  buybackPool: 1_247.83,    // USDC accumulated
+  tradesTotal: 412,         // protocol swap count
+  bagsUrl:     'https://bags.fm/p/PEACE',
+}
+
+function StatPill({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-pot-dark rounded-xl p-3 flex-1 min-w-[100px]">
+      <div className="text-[10px] text-pot-muted mb-0.5">{label}</div>
+      <div className="text-sm font-bold text-white font-mono">{value}</div>
+      {sub && <div className="text-[10px] text-pot-muted">{sub}</div>}
+    </div>
+  )
+}
+
+function BuybackModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      onClick={onClose}
+      style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+    >
+      <div
+        className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-bold text-white">🔄 Buyback Flywheel</h2>
+          <button onClick={onClose} className="text-pot-muted hover:text-white text-xl">×</button>
+        </div>
+
+        <div className="space-y-3 text-sm">
+          {[
+            { step: '1', icon: '🗳️', title: 'Pot executes a swap', body: 'Members vote, approve, and execute a swap proposal through Jupiter.' },
+            { step: '2', icon: '💸', title: '1% fee collected', body: 'PotBot takes 1% of each executed swap. This is split: 0.5% to referrers, 0.5% to protocol.' },
+            { step: '3', icon: '🔄', title: 'Protocol fee → $POT buyback', body: 'The 0.5% protocol share flows into an on-chain buyback PDA that automatically buys $POT on bags.fm.' },
+            { step: '4', icon: '🔥', title: 'Tokens burned or redistributed', body: 'Bought-back $POT is either burned (reducing supply) or redistributed to Season winners — TBD by governance vote.' },
+          ].map((s) => (
+            <div key={s.step} className="flex gap-3 p-3 rounded-xl bg-pot-dark">
+              <div className="w-7 h-7 rounded-full bg-pot-green/10 border border-pot-green/20 flex items-center justify-center text-[10px] font-bold text-pot-green shrink-0">
+                {s.step}
+              </div>
+              <div>
+                <div className="flex items-center gap-1.5 mb-0.5">
+                  <span>{s.icon}</span>
+                  <span className="text-xs font-semibold text-white">{s.title}</span>
+                </div>
+                <p className="text-xs text-pot-muted leading-relaxed">{s.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/20 text-xs text-amber-300 leading-relaxed">
+          ⚠️ $POT is a utility token with no guaranteed value. Buyback does not constitute a promise of returns.
+          Not investment advice.
+        </div>
+
+        <button onClick={onClose} className="btn-secondary w-full mt-4 text-sm py-2.5">Close</button>
+      </div>
+    </div>
+  )
+}
+
+export function PotTokenCard() {
+  const [showModal, setShowModal] = useState(false)
+  const positive = MOCK.priceChange >= 0
+
+  return (
+    <>
+      <div className="card p-5 mb-6">
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="flex items-center gap-3">
+            {/* Token logo placeholder */}
+            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-pot-green/30 to-pot-accent/30 border border-pot-green/30 flex items-center justify-center text-lg font-black text-pot-green">
+              🪙
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-bold text-white text-sm">$POT Token</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-pot-green/10 text-pot-green border border-pot-green/20">
+                  Season 1
+                </span>
+              </div>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-lg font-black text-white font-mono">
+                  ${MOCK.price.toFixed(5)}
+                </span>
+                <span className={`text-xs font-bold ${positive ? 'text-pot-green' : 'text-red-400'}`}>
+                  {positive ? '+' : ''}{MOCK.priceChange.toFixed(1)}%
+                </span>
+                <span className="text-xs text-pot-muted">24h</span>
+              </div>
+            </div>
+          </div>
+
+          <a
+            href={MOCK.bagsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 text-xs px-3 py-1.5 rounded-xl bg-pot-green/10 text-pot-green border border-pot-green/20 hover:bg-pot-green/20 transition font-medium"
+          >
+            Buy on bags.fm ↗
+          </a>
+        </div>
+
+        {/* Stats row */}
+        <div className="flex flex-wrap gap-2 mb-4">
+          <StatPill
+            label="Market Cap"
+            value={`$${(MOCK.mcap / 1000).toFixed(0)}K`}
+            sub="USD"
+          />
+          <StatPill
+            label="24h Volume"
+            value={`$${(MOCK.volume24h / 1000).toFixed(1)}K`}
+          />
+          <StatPill
+            label="Buyback Pool"
+            value={`$${MOCK.buybackPool.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
+            sub="USDC"
+          />
+          <StatPill
+            label="Protocol Trades"
+            value={String(MOCK.tradesTotal)}
+            sub="all time"
+          />
+        </div>
+
+        {/* Flywheel bar */}
+        <div
+          className="rounded-xl p-3 border border-pot-border cursor-pointer hover:border-pot-green/30 transition"
+          onClick={() => setShowModal(true)}
+        >
+          <div className="flex items-center justify-between text-xs mb-2">
+            <div className="flex items-center gap-1.5 text-white font-medium">
+              <span>🔄</span>
+              <span>Fee → Buyback flywheel</span>
+            </div>
+            <span className="text-pot-muted hover:text-white">How it works ↗</span>
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-pot-muted">
+            <div className="h-1.5 rounded-full bg-pot-dark flex-1 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-pot-green to-pot-accent"
+                style={{ width: `${Math.min(100, (MOCK.buybackPool / 5000) * 100)}%` }}
+              />
+            </div>
+            <span className="shrink-0">${MOCK.buybackPool.toLocaleString(undefined, { maximumFractionDigits: 0 })} / $5K next buyback</span>
+          </div>
+        </div>
+      </div>
+
+      {showModal && <BuybackModal onClose={() => setShowModal(false)} />}
+    </>
+  )
+}

--- a/apps/web/src/components/TokenizePotModal.tsx
+++ b/apps/web/src/components/TokenizePotModal.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  potName: string
+  potPubkey: string
+  memberCount: number
+  onClose: () => void
+}
+
+const STEPS = [
+  {
+    id: 0,
+    title: 'What is tokenization?',
+    icon: '🪙',
+    body: (potName: string) => (
+      <div className="space-y-3 text-sm text-pot-muted leading-relaxed">
+        <p>
+          Tokenizing your pot creates a <span className="text-white font-medium">social token on bags.fm</span> that
+          represents membership in <span className="text-pot-green font-medium">{potName}</span>.
+        </p>
+        <p>
+          Members receive tokens proportional to their share of the pot. The token is a
+          <span className="text-white font-medium"> community & identity layer</span> — not a financial instrument.
+          It does <strong>not</strong> represent ownership of any underlying assets.
+        </p>
+        <div className="rounded-xl bg-pot-dark p-3 text-xs space-y-1">
+          <div className="flex items-center gap-2"><span className="text-pot-green">✓</span> Community recognition & governance signal</div>
+          <div className="flex items-center gap-2"><span className="text-pot-green">✓</span> Shareable public identity for your pot</div>
+          <div className="flex items-center gap-2"><span className="text-pot-green">✓</span> Tradeable on bags.fm (Solana DEX)</div>
+          <div className="flex items-center gap-2"><span className="text-red-400">✗</span> Not backed by pot assets</div>
+          <div className="flex items-center gap-2"><span className="text-red-400">✗</span> Not a promise of returns</div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: 1,
+    title: 'How it works',
+    icon: '⚙️',
+    body: (_potName: string) => (
+      <div className="space-y-3 text-sm text-pot-muted leading-relaxed">
+        <div className="space-y-2">
+          {[
+            { n: '1', icon: '🔗', t: 'Connect to bags.fm', d: 'You\'ll be redirected to bags.fm with your pot\'s name and pubkey pre-filled. Connect your wallet there to create the token.' },
+            { n: '2', icon: '⚙️', t: 'Set token parameters', d: 'Name, ticker, supply, and initial price are set on bags.fm. We recommend naming it after your pot (e.g. "Alpha Pot Token" → $APT).' },
+            { n: '3', icon: '🪙', t: 'Token minted on-chain', d: 'bags.fm creates the token on Solana. You get the mint address to share with pot members.' },
+            { n: '4', icon: '🌱', t: 'Boost your Season Score', d: 'Having a live token gives your pot\'s plant a +5 health bonus — rewarding community building.' },
+          ].map((s) => (
+            <div key={s.n} className="flex gap-3 p-3 rounded-xl bg-pot-dark">
+              <div className="w-6 h-6 rounded-full bg-pot-accent/20 border border-pot-accent/30 flex items-center justify-center text-[10px] font-bold text-pot-accent shrink-0 mt-0.5">
+                {s.n}
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-white mb-0.5">{s.icon} {s.t}</div>
+                <p className="text-xs text-pot-muted leading-relaxed">{s.d}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: 2,
+    title: 'Disclaimer & Launch',
+    icon: '🚀',
+    body: (_potName: string) => (
+      <div className="space-y-3 text-sm text-pot-muted leading-relaxed">
+        <div className="rounded-xl bg-amber-500/10 border border-amber-500/20 p-4 text-xs text-amber-300 space-y-2">
+          <div className="font-semibold text-amber-200 text-sm">⚠️ Important disclosures</div>
+          <p>Pot tokens are social/community tokens. They carry <strong>no guaranteed value</strong> and are not backed by pot assets or trading performance.</p>
+          <p>Creating a token on bags.fm is subject to bags.fm's own terms of service. PotBot is not affiliated with bags.fm and does not control token pricing or liquidity.</p>
+          <p>This is <strong>not financial advice</strong>. Do not create a token with the intent to deceive members about its financial nature.</p>
+        </div>
+        <p className="text-xs">
+          By clicking "Launch on bags.fm" you confirm you have read and understood the above, and that you are creating
+          this token purely for community and identity purposes.
+        </p>
+      </div>
+    ),
+  },
+]
+
+export function TokenizePotModal({ potName, potPubkey, memberCount, onClose }: Props) {
+  const [step, setStep] = useState(0)
+  const [agreed, setAgreed] = useState(false)
+
+  const current = STEPS[step]
+  const isLast = step === STEPS.length - 1
+  const isFirst = step === 0
+
+  // bags.fm launch URL — pre-populate name + pot pubkey as ref
+  const bagsUrl = `https://bags.fm/create?name=${encodeURIComponent(potName)}&ref=potbot&meta=${potPubkey}`
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      onClick={onClose}
+      style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+    >
+      <div
+        className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <span className="text-2xl">{current.icon}</span>
+              <div>
+                <div className="text-[10px] text-pot-muted uppercase tracking-wide">
+                  Step {step + 1} of {STEPS.length} · Tokenize {potName}
+                </div>
+                <h2 className="text-base font-bold text-white">{current.title}</h2>
+              </div>
+            </div>
+            <button onClick={onClose} className="text-pot-muted hover:text-white text-xl shrink-0">×</button>
+          </div>
+
+          {/* Step indicator */}
+          <div className="flex gap-1.5 mb-2">
+            {STEPS.map((s) => (
+              <div
+                key={s.id}
+                className={`h-1 rounded-full flex-1 transition-all ${
+                  s.id <= step ? 'bg-pot-green' : 'bg-pot-border'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 pb-4 max-h-[340px] overflow-y-auto">
+          {current.body(potName)}
+        </div>
+
+        {/* Disclaimer checkbox on last step */}
+        {isLast && (
+          <div className="px-6 pb-2">
+            <label className="flex items-start gap-2 cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={agreed}
+                onChange={(e) => setAgreed(e.target.checked)}
+                className="mt-0.5 accent-pot-green"
+              />
+              <span className="text-xs text-pot-muted group-hover:text-white transition leading-relaxed">
+                I understand this token has no guaranteed financial value and is a community feature only.
+              </span>
+            </label>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="px-6 pb-6 pt-3 flex gap-3">
+          {!isFirst && (
+            <button
+              onClick={() => setStep(s => s - 1)}
+              className="btn-secondary flex-1 text-sm py-2.5"
+            >
+              ← Back
+            </button>
+          )}
+
+          {isFirst && (
+            <button onClick={onClose} className="btn-secondary flex-1 text-sm py-2.5">
+              Cancel
+            </button>
+          )}
+
+          {!isLast ? (
+            <button
+              onClick={() => setStep(s => s + 1)}
+              className="btn-primary flex-1 text-sm py-2.5"
+            >
+              Next →
+            </button>
+          ) : (
+            <a
+              href={agreed ? bagsUrl : undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={!agreed ? (e) => e.preventDefault() : undefined}
+              className={`btn-primary flex-1 text-sm py-2.5 text-center transition ${
+                !agreed ? 'opacity-40 cursor-not-allowed pointer-events-none' : ''
+              }`}
+            >
+              🚀 Launch on bags.fm
+            </a>
+          )}
+        </div>
+
+        {/* Member count hint */}
+        <div className="px-6 pb-4 text-center text-xs text-pot-muted">
+          {memberCount} member{memberCount !== 1 ? 's' : ''} would receive initial token allocation
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Drop-in button that opens the TokenizePotModal.
+ * Usage: <TokenizePotButton potName={pot.name} potPubkey={pot.pubkey} memberCount={members.length} />
+ */
+export function TokenizePotButton({
+  potName,
+  potPubkey,
+  memberCount,
+  className = '',
+}: {
+  potName: string
+  potPubkey: string
+  memberCount: number
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className={`flex items-center gap-2 text-sm font-medium text-pot-accent hover:text-white border border-pot-accent/30 hover:border-pot-accent/60 rounded-xl px-4 py-2 transition ${className}`}
+      >
+        🪙 Create Pot Token
+      </button>
+      {open && (
+        <TokenizePotModal
+          potName={potName}
+          potPubkey={potPubkey}
+          memberCount={memberCount}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
Phase 3 token layer — all 3 items:

1. PotTokenCard.tsx — $POT stats widget on dashboard:
   - Mock price/mcap/volume/24h change (replace with bags.fm API when live)
   - Buyback flywheel progress bar (fee pool toward next buyback)
   - 'How it works' modal: 4-step flywheel explanation with legal disclaimer
   - Direct 'Buy on bags.fm ↗' link

2. TokenizePotModal.tsx — 3-step guide to tokenize a pot on bags.fm:
   - Step 1: What tokenization is (social token, not financial instrument)
   - Step 2: How it works (bags.fm redirect, token params, +5 health bonus)
   - Step 3: Disclaimer gate + checkbox + launch CTA → bags.fm/create?ref=potbot
   - TokenizePotButton drop-in: <TokenizePotButton potName potPubkey memberCount />

3. app/page.tsx — $POT card inserted below quick-links section in connected dashboard. All other page content unchanged.