### PR TITLE
feat(phase4): onboarding tutorial, OG images, layout polish

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,30 +1,45 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { AppProviders } from './providers'
 import { Navbar } from '@/components/Navbar'
+import { OnboardingTutorial } from '@/components/OnboardingTutorial'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'PotBot v2 — Group Trading Vaults on Solana',
-  description: 'Create group trading vaults, govern together, trade together, win together.',
+  title: 'PotBot — Group Trading Vaults on Solana',
+  description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
   metadataBase: new URL('https://potbot.fun'),
-  alternates: {
-    canonical: '/',
-  },
+  alternates: { canonical: '/' },
   openGraph: {
-    title: 'PotBot v2 — Group Trading Vaults on Solana',
-    description: 'Create group trading vaults, govern together, trade together, win together.',
+    title: 'PotBot — Group Trading Vaults on Solana',
+    description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
     url: 'https://potbot.fun',
     siteName: 'PotBot',
     type: 'website',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'PotBot — Group Trading Vaults on Solana',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'PotBot v2 — Group Trading Vaults on Solana',
-    description: 'Create group trading vaults, govern together, trade together, win together.',
+    site: '@PotBot_sol',
+    creator: '@PotBot_sol',
+    title: 'PotBot — Group Trading Vaults on Solana',
+    description: 'Pool funds, vote on swaps, withdraw any time. Trustless group treasury management on Solana.',
+    images: ['/og-image.png'],
+  },
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1,
   },
 }
 
-// Runs before React hydrates — prevents light/dark flash on first paint.
 const THEME_BOOTSTRAP = `
 (function(){
   try {
@@ -39,22 +54,82 @@ const THEME_BOOTSTRAP = `
 })();
 `.trim()
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+const FOOTER_LINKS = [
+  { label: 'FAQ',         href: '/faq' },
+  { label: 'Leaderboard', href: '/leaderboard' },
+  { label: 'Hackathon',   href: '/hackathon' },
+  { label: 'For Agents',  href: '/for-agents' },
+  { label: 'GitHub',      href: 'https://github.com/YD811/potbot-v2', external: true },
+  { label: 'Twitter',     href: 'https://x.com/PotBot_sol', external: true },
+]
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }} />
       </head>
-      <body className="min-h-screen bg-pot-dark text-white antialiased">
+      <body className="min-h-screen bg-pot-dark text-white antialiased flex flex-col">
         <AppProviders>
           <Navbar />
-          <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+          {/* ── First-time onboarding tutorial ── */}
+          <OnboardingTutorial />
+
+          <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
             {children}
           </main>
+
+          {/* ── Footer ─────────────────────────────────────────── */}
+          <footer className="border-t border-pot-border/40 bg-pot-dark/80 mt-16">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              {/* Links row */}
+              <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mb-6">
+                <Link href="/" className="flex items-center gap-2">
+                  <span className="text-xl">🪴</span>
+                  <span className="font-bold text-white">Pot<span className="text-pot-green">Bot</span></span>
+                  <span className="text-xs text-pot-muted">v2 · Solana Frontier 2026</span>
+                </Link>
+                <nav className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-pot-muted justify-center">
+                  {FOOTER_LINKS.map(({ label, href, external }) =>
+                    external ? (
+                      <a key={label} href={href} target="_blank" rel="noopener noreferrer"
+                        className="hover:text-white transition">{label}</a>
+                    ) : (
+                      <Link key={label} href={href} className="hover:text-white transition">{label}</Link>
+                    )
+                  )}
+                </nav>
+              </div>
+
+              {/* Disclaimers */}
+              <div className="border-t border-pot-border/30 pt-5 space-y-1.5 text-[11px] text-pot-muted leading-relaxed">
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Non-custodial:</span>{' '}
+                  PotBot is non-custodial software. You retain full custody of your funds via the smart contract.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Risk:</span>{' '}
+                  Crypto assets are volatile. You may lose some or all of the funds you deposit. Past performance does not predict future results.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Not advice:</span>{' '}
+                  PotBot is not investment advice. Members make their own decisions through on-chain voting.
+                </p>
+                <p>
+                  <span className="font-semibold text-pot-muted/70">Jurisdictions:</span>{' '}
+                  Use of PotBot is restricted in certain jurisdictions. By using this app you confirm compliance with your local laws.{' '}
+                  <Link href="/faq" className="underline hover:text-white">See FAQ</Link>
+                </p>
+                <p className="pt-1 text-pot-border">
+                  © 2026 PotBot · Built on Solana · Open source ·{' '}
+                  <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noopener noreferrer" className="underline hover:text-white">
+                    View code
+                  </a>
+                </p>
+              </div>
+            </div>
+          </footer>
         </AppProviders>
       </body>
     </html>

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,148 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'PotBot — Group Trading Vaults on Solana'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #0a0e17 0%, #0d1520 50%, #0a0e17 100%)',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Background grid */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: 'radial-gradient(circle at 50% 50%, rgba(0,255,136,0.06) 0%, transparent 70%)',
+          }}
+        />
+
+        {/* Top accent line */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 4,
+            background: 'linear-gradient(90deg, #00ff88, #8b5cf6, #00ff88)',
+          }}
+        />
+
+        {/* Season badge */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 32,
+            padding: '8px 20px',
+            borderRadius: 100,
+            background: 'rgba(0,255,136,0.08)',
+            border: '1px solid rgba(0,255,136,0.2)',
+            color: '#00ff88',
+            fontSize: 18,
+            fontWeight: 600,
+          }}
+        >
+          🌱 Season 1: The Garden · Solana Frontier 2026
+        </div>
+
+        {/* Logo + name */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 24 }}>
+          <div
+            style={{
+              width: 96,
+              height: 96,
+              borderRadius: 24,
+              background: 'rgba(0,255,136,0.08)',
+              border: '2px solid rgba(0,255,136,0.25)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 52,
+            }}
+          >
+            🪴
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ fontSize: 72, fontWeight: 900, color: '#ffffff', lineHeight: 1 }}>
+              Pot<span style={{ color: '#00ff88' }}>Bot</span>
+            </span>
+            <span style={{ fontSize: 22, color: '#6b7280', marginTop: 4 }}>v2 · Solana</span>
+          </div>
+        </div>
+
+        {/* Tagline */}
+        <div
+          style={{
+            fontSize: 28,
+            color: '#d1d5db',
+            textAlign: 'center',
+            maxWidth: 700,
+            lineHeight: 1.4,
+            marginBottom: 48,
+          }}
+        >
+          Group Trading Vaults on Solana
+        </div>
+
+        {/* Three feature pills */}
+        <div style={{ display: 'flex', gap: 16 }}>
+          {[
+            { icon: '💰', label: 'Pool Funds' },
+            { icon: '🗳️', label: 'Vote Together' },
+            { icon: '🌱', label: 'Grow Your Plant' },
+          ].map((f) => (
+            <div
+              key={f.label}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '12px 24px',
+                borderRadius: 16,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                color: '#ffffff',
+                fontSize: 20,
+                fontWeight: 600,
+              }}
+            >
+              <span style={{ fontSize: 26 }}>{f.icon}</span>
+              {f.label}
+            </div>
+          ))}
+        </div>
+
+        {/* URL */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 32,
+            color: '#4b5563',
+            fontSize: 18,
+            letterSpacing: 1,
+          }}
+        >
+          potbot.fun
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/apps/web/src/app/pots/[pubkey]/opengraph-image.tsx
+++ b/apps/web/src/app/pots/[pubkey]/opengraph-image.tsx
@@ -1,0 +1,157 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'PotBot Vault'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+// In production this would fetch real pot data from Supabase/on-chain
+// For demo/hackathon: static fallback using pubkey from params
+export default async function PotOgImage({
+  params,
+}: {
+  params: { pubkey: string }
+}) {
+  const { pubkey } = params
+  const shortKey = `${pubkey.slice(0, 4)}…${pubkey.slice(-4)}`
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #0a0e17 0%, #111827 60%, #0a0e17 100%)',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          position: 'relative',
+        }}
+      >
+        {/* Glow */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: 'radial-gradient(circle at 50% 40%, rgba(0,255,136,0.08) 0%, transparent 65%)',
+          }}
+        />
+
+        {/* Top bar */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 4,
+            background: 'linear-gradient(90deg, #00ff88, #8b5cf6, #00ff88)',
+          }}
+        />
+
+        {/* PotBot wordmark */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 28,
+            left: 40,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            color: '#6b7280',
+            fontSize: 20,
+            fontWeight: 700,
+          }}
+        >
+          🪴 <span style={{ color: '#ffffff' }}>Pot</span>
+          <span style={{ color: '#00ff88' }}>Bot</span>
+        </div>
+
+        {/* Pot pubkey badge */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 28,
+            right: 40,
+            padding: '6px 16px',
+            borderRadius: 100,
+            background: 'rgba(0,255,136,0.06)',
+            border: '1px solid rgba(0,255,136,0.15)',
+            color: '#00ff88',
+            fontSize: 16,
+            fontFamily: 'monospace',
+          }}
+        >
+          {shortKey}
+        </div>
+
+        {/* Main content */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 20 }}>
+          <div style={{ fontSize: 80 }}>🪴</div>
+
+          <div
+            style={{
+              fontSize: 48,
+              fontWeight: 900,
+              color: '#ffffff',
+              textAlign: 'center',
+            }}
+          >
+            PotBot Vault
+          </div>
+
+          <div
+            style={{
+              fontSize: 22,
+              color: '#9ca3af',
+              textAlign: 'center',
+              maxWidth: 600,
+            }}
+          >
+            Group trading vault on Solana · Vote on swaps, grow together
+          </div>
+
+          {/* Stats row (static for OG — real data needs server-side fetch) */}
+          <div style={{ display: 'flex', gap: 20, marginTop: 12 }}>
+            {[
+              { label: 'Non-custodial', icon: '🔐' },
+              { label: 'On-chain voting', icon: '🗳️' },
+              { label: 'Jupiter swaps', icon: '⚡' },
+            ].map((s) => (
+              <div
+                key={s.label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '10px 20px',
+                  borderRadius: 14,
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  color: '#d1d5db',
+                  fontSize: 18,
+                }}
+              >
+                {s.icon} {s.label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 28,
+            color: '#374151',
+            fontSize: 16,
+          }}
+        >
+          potbot.fun
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/apps/web/src/components/OnboardingTutorial.tsx
+++ b/apps/web/src/components/OnboardingTutorial.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'potbot-onboarding-v1'
+
+interface Step {
+  id: number
+  emoji: string
+  title: string
+  body: string
+  cta?: string
+  highlight?: string
+}
+
+const STEPS: Step[] = [
+  {
+    id: 0,
+    emoji: '🪴',
+    title: 'Welcome to PotBot',
+    body: 'PotBot is a group trading vault on Solana. Pool funds with friends, vote on swaps together, and grow a living plant that tracks your community's health.',
+    highlight: 'Not a fund. Not a casino. A coordination tool.',
+  },
+  {
+    id: 1,
+    emoji: '💰',
+    title: 'Create or Join a POT',
+    body: 'Create a new vault in seconds and invite members via referral link. Or deposit into any public POT to join the community. Your share is always proportional to your deposit.',
+    highlight: 'Your funds are non-custodial — controlled by Solana smart contract.',
+  },
+  {
+    id: 2,
+    emoji: '🗳️',
+    title: 'Propose → Vote → Execute',
+    body: 'Any member can propose a token swap. Members vote YES or NO. When quorum is reached, any member can execute the trade on Jupiter. No single person has control.',
+    highlight: 'Every trade requires group consensus.',
+  },
+  {
+    id: 3,
+    emoji: '🌱',
+    title: 'Grow Your Plant',
+    body: 'Your pot's plant grows with community activity — deposits, votes, proposals, and new members all boost plant health. Top 3 plants on the Season 1 leaderboard win prize pool rewards.',
+    highlight: 'Plant health is activity-based. Not tied to trading P&L.',
+  },
+]
+
+function StepDot({ active, done, onClick }: { active: boolean; done: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-2.5 h-2.5 rounded-full transition-all duration-300 ${
+        active ? 'bg-pot-green scale-125' : done ? 'bg-pot-green/40' : 'bg-pot-border'
+      }`}
+      aria-label="Go to step"
+    />
+  )
+}
+
+interface OnboardingTutorialProps {
+  /** Force-show regardless of localStorage (for preview/demo) */
+  forceShow?: boolean
+}
+
+export function OnboardingTutorial({ forceShow = false }: OnboardingTutorialProps) {
+  const [visible, setVisible] = useState(false)
+  const [step, setStep] = useState(0)
+  const [animating, setAnimating] = useState(false)
+
+  useEffect(() => {
+    if (forceShow) { setVisible(true); return }
+    const seen = localStorage.getItem(STORAGE_KEY)
+    if (!seen) setVisible(true)
+  }, [forceShow])
+
+  if (!visible) return null
+
+  const current = STEPS[step]
+  const isLast = step === STEPS.length - 1
+
+  function dismiss() {
+    if (!forceShow) localStorage.setItem(STORAGE_KEY, '1')
+    setVisible(false)
+  }
+
+  function goTo(idx: number) {
+    if (animating || idx === step) return
+    setAnimating(true)
+    setTimeout(() => {
+      setStep(idx)
+      setAnimating(false)
+    }, 150)
+  }
+
+  function next() {
+    if (isLast) { dismiss(); return }
+    goTo(step + 1)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.80)', backdropFilter: 'blur(10px)' }}
+      onClick={dismiss}
+    >
+      {/* Card */}
+      <div
+        className="relative w-full max-w-sm rounded-3xl border border-pot-border bg-pot-card shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+        style={{ boxShadow: '0 0 60px rgba(0,255,136,0.08)' }}
+      >
+        {/* Gradient accent top */}
+        <div
+          className="h-1 w-full"
+          style={{ background: 'linear-gradient(90deg, #00ff88, #8b5cf6, #00ff88)' }}
+        />
+
+        {/* Skip */}
+        <button
+          onClick={dismiss}
+          className="absolute top-4 right-4 text-pot-muted hover:text-white text-sm transition"
+        >
+          Skip all
+        </button>
+
+        {/* Content */}
+        <div
+          className={`px-7 py-8 transition-opacity duration-150 ${animating ? 'opacity-0' : 'opacity-100'}`}
+        >
+          {/* Step counter */}
+          <div className="text-[10px] text-pot-muted mb-4 tracking-widest uppercase">
+            Step {step + 1} of {STEPS.length}
+          </div>
+
+          {/* Emoji icon */}
+          <div
+            className="w-20 h-20 rounded-2xl flex items-center justify-center text-5xl mb-6 mx-auto"
+            style={{ background: 'rgba(0,255,136,0.06)', border: '1px solid rgba(0,255,136,0.15)' }}
+          >
+            {current.emoji}
+          </div>
+
+          {/* Title */}
+          <h2 className="text-xl font-black text-white text-center mb-3 leading-tight">
+            {current.title}
+          </h2>
+
+          {/* Body */}
+          <p className="text-sm text-pot-muted text-center leading-relaxed mb-5">
+            {current.body}
+          </p>
+
+          {/* Highlight pill */}
+          {current.highlight && (
+            <div className="rounded-xl bg-pot-green/8 border border-pot-green/20 px-4 py-3 text-xs text-pot-green text-center font-medium mb-6">
+              {current.highlight}
+            </div>
+          )}
+
+          {/* Progress dots */}
+          <div className="flex justify-center gap-2 mb-6">
+            {STEPS.map((s) => (
+              <StepDot
+                key={s.id}
+                active={s.id === step}
+                done={s.id < step}
+                onClick={() => goTo(s.id)}
+              />
+            ))}
+          </div>
+
+          {/* CTA */}
+          <button
+            onClick={next}
+            className="btn-primary w-full text-sm py-3 font-semibold"
+          >
+            {isLast ? '🚀 Start using PotBot' : 'Next →'}
+          </button>
+
+          {step > 0 && (
+            <button
+              onClick={() => goTo(step - 1)}
+              className="w-full text-center text-xs text-pot-muted hover:text-white transition mt-3"
+            >
+              ← Back
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Reset onboarding so it shows again — useful for testing or user-triggered replay */
+export function resetOnboarding() {
+  localStorage.removeItem(STORAGE_KEY)
+}


### PR DESCRIPTION
Phase 4 hackathon polish — all items:

1. OnboardingTutorial.tsx — 4-step first-time modal:
   - localStorage gate (potbot-onboarding-v1), shows once per device
   - Steps: Welcome → Create/Join → Vote/Execute → Plant
   - Dot navigation, back/skip, green gradient top bar
   - forceShow prop for preview/demo; resetOnboarding() utility export

2. layout.tsx — mounts <OnboardingTutorial /> globally in AppProviders, adds og:image + twitter:image meta pointing to /og-image.png, adds twitter:site + twitter:creator, explicit viewport meta.

3. opengraph-image.tsx (root) — Next.js edge ImageResponse 1200×630:
   - Dark background, green radial glow, top gradient bar
   - PotBot logo + name, tagline, 3 feature pills, potbot.fun URL
   - Season 1 badge

4. pots/[pubkey]/opengraph-image.tsx — per-pot OG card:
   - Shows pubkey short-form, vault name, key features
   - Same dark brand treatment