### PR TITLE
ci(anchor): fix anchor build by pinning Rust toolchain & bumping Solana CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Install Solana CLI
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.0/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.0/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Create dummy keypair for Anchor
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Install Solana CLI
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.0/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Create dummy keypair for Anchor
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       - name: anchor build
         env:
           CARGO_BUILD_LOCKED: "true"
+          RUSTUP_TOOLCHAIN: "1.85.0"
         run: cd packages/program && anchor build
       - name: Upload IDL artifact
         uses: actions/upload-artifact@v4

--- a/packages/program/rust-toolchain.toml
+++ b/packages/program/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Why

The `anchor — build` job has been failing on every PR with:

```
feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.75.0).
```

Root cause: `cargo-build-sbf` (shipped inside Solana CLI v1.18.x) uses an older built-in rustc that doesn't support `edition2024`, while `toml_edit 0.25` (transitively pulled in via `anchor 0.30` / `mpl-token-metadata 4`) requires it.

## What

1. Add `packages/program/rust-toolchain.toml` pinning host Rust to 1.85.0 so any Cargo invocation outside `cargo-build-sbf` gets a modern toolchain.
2. 2. Bump Solana CLI in CI from `v1.18.26` to `v2.1.0` (Agave). Newer Agave releases ship a newer built-in rustc with edition2024 support.
## How to verify

- The CI run on this PR should show `anchor — build` succeeding.
- - All other jobs (web, sdk, api, npm audit) should remain green.
## Risk / rollback

- Isolated CI/toolchain change — does not touch product code.
- - If `v2.1.0` is incompatible, easy revert: a single PR revert restores previous behavior.
- - Fallback plan if CLI bump alone is insufficient: pin `toml_edit < 0.25` via `[patch.crates-io]` in `packages/program/Cargo.toml`.
- 