### PR TITLE
feat(hackathon+pot+vision): PR-E + PR-F + PR-G bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,24 @@ Built for [Solana Frontier 2026](https://colosseum.com/frontier) · [@PotBot_sol
 
 ## 🧑‍⚖️ For Judges — Try It in 60 Seconds
 
-**No wallet needed** — the DApp runs in demo mode with seeded vaults, proposals, and AI agent activity.
+**No wallet needed** — `potbot.fun` shows a live flagship pot in read-only mode at the top of `/vaults`.
+
+> Lifecycle legend used everywhere on this repo and the site:
+> 🟢 Live (mainnet) · 🟡 Devnet · 🔵 Phase 2 Q3 2026 · 🟣 Phase 3 Q4 2026 · ⚪ Vision
+
+### Live now (mainnet · Explorer-verifiable) 🟢
+
+- `pot_vault` Anchor program with 30+ instructions: deposit, propose, vote, `execute_swap` via Jupiter v6 CPI, withdraw.
+- Solana Blinks endpoints — `/api/actions/<potPubkey>/{deposit,vote}` — render as cards in Phantom / Backpack / X.
+- MCP server `@potbot/mcp@0.2.0` on npm — 18 tools, HTTP+SSE+stdio transports.
+- Squads v4 multisig path for the creator role on high-value pots.
+- Helius RPC + webhooks for realtime pot events.
+- PWA manifest installable on iOS / Android.
+
+### Try it
 
 ```bash
-# 1. Open the live DApp (demo mode, no wallet)
+# 1. Open the live DApp
 open https://potbot.fun
 
 # 2. Connect to MCP server (Claude / any AI agent)
@@ -41,20 +55,19 @@ npx @potbot/mcp
 
 # 3. Clone and run locally
 git clone https://github.com/YD811/potbot-v2.git
-cd potbot-v2
-npm install
-cd apps/web && npx next dev
-# → http://localhost:3000
+cd potbot-v2 && npm install
+cd apps/web && npx next dev    # → http://localhost:3000
 ```
 
-**On-chain (devnet):**
-- Program ID: `GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK`
-- Connect Phantom → switch to devnet → interact live
-- **Test MCP with Claude:**
+### Test MCP with Claude
 
 ```
 list_vaults → get_vault_analytics → create_swap_proposal → vote_on_proposal
 ```
+
+### Full roadmap with explicit status per feature
+
+→ [potbot.fun/roadmap](https://potbot.fun/roadmap) — every Live, Devnet, Phase 2, Phase 3, and Vision item, with chips.
 
 ---
 

--- a/apps/web/src/app/hackathon/page.tsx
+++ b/apps/web/src/app/hackathon/page.tsx
@@ -1,343 +1,548 @@
-'use client'
-
-import { useState } from 'react'
 import Link from 'next/link'
+import type { Metadata } from 'next'
+import { StatusBadge, type StatusTier } from '@/components/StatusBadge'
 
-const BOUNTIES = [
+export const metadata: Metadata = {
+  title: 'PotBot · Solana Frontier 2026 — judge page',
+  description:
+    'PotBot is a group trading vault on Solana. Deposit, propose, vote, execute — all on-chain. Real Jupiter v6 CPI, MCP server, Solana Blinks. This page is the judge-facing summary for Solana Frontier 2026.',
+}
+
+const PROGRAM_ID =
+  process.env.NEXT_PUBLIC_PROGRAM_ID ?? 'GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK'
+const FLAGSHIP_POT = process.env.NEXT_PUBLIC_ONE_POT_PUBKEY ?? ''
+const CLUSTER = process.env.NEXT_PUBLIC_SOLANA_CLUSTER ?? 'devnet'
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://potbot.fun'
+const EXPLORER_SUFFIX = CLUSTER === 'mainnet-beta' ? '' : `?cluster=${CLUSTER}`
+
+interface Track {
+  sponsor: string
+  emoji: string
+  what: string
+  proof: string
+  proofHref?: string
+  tier: StatusTier
+}
+
+const TRACKS: Track[] = [
   {
     sponsor: 'Jupiter',
-    prize: '$10,000',
-    track: 'Best DEX Integration',
-    color: '#37B24D',
-    emoji: '⚡',
-    summary: 'Full Jupiter DEX stack integrated into PotBot governance flow.',
-    details: [
-      {
-        title: 'Swap V2 — Best-price routing',
-        desc: 'Group vaults execute swaps via Jupiter Swap V2 API. Any member can propose a swap; once approved by governance, the vault PDA signs the transaction. Server-side API key injection keeps the key off the client.',
-      },
-      {
-        title: 'Trigger Orders (Limit Orders)',
-        desc: 'Members can propose limit orders: "buy X token when price hits Y". The vault creates a Jupiter Trigger order on-chain. Executed automatically by Jupiter when the condition is met.',
-      },
-      {
-        title: 'DCA — Dollar Cost Averaging',
-        desc: 'Governance can approve recurring buy/sell proposals: e.g. "buy 0.5 SOL of BONK every day for 7 days". Fully parameterized: cycle duration, total cycles, amount per cycle.',
-      },
-      {
-        title: 'Price API v2 — Real-time feeds',
-        desc: 'Token prices fetched via Jupiter Price API v2 with API key auth. Proxied server-side via /api/jupiter/price/v2 to keep credentials secure. Used in AI agent triggers and PnL calculations.',
-      },
-      {
-        title: 'Governance-gated execution',
-        desc: 'No swap happens without a passed proposal. Every Jupiter call goes through: propose → vote → timelock → execute. The vault PDA is the signer — individual members cannot bypass governance.',
-      },
-    ],
+    emoji: '🪐',
+    what: 'Jupiter v6 CPI inside `pot_vault::execute_swap`. Vault PDA signs.',
+    proof: 'See `programs/pot_vault/src/instructions/execute_swap.rs` — mode-aware (AdminDirect / Proposal / StrategyTrigger), JUPITER_V6_PROGRAM_ID constraint, vault-PDA signer.',
+    proofHref: 'https://github.com/YD811/potbot-v2/blob/main/programs/pot_vault/src/instructions/execute_swap.rs',
+    tier: 'live',
   },
   {
-    sponsor: 'Ika / Encrypt',
-    prize: '$10,000',
-    track: 'Privacy & ZK Layer',
-    color: '#7048E8',
-    emoji: '🔒',
-    summary: 'STAMPPOT — ZK privacy layer for pot membership and transactions.',
-    details: [
-      {
-        title: 'STAMPPOT privacy layer',
-        desc: 'Built on PrivacyCash ZK proofs. Members can participate in a pot without revealing their wallet address publicly. The vault tracks shares via zero-knowledge commitments.',
-      },
-      {
-        title: 'Private membership',
-        desc: 'With STAMPPOT enabled, joining a pot does not expose your wallet on-chain in a readable form. You hold a ZK proof of membership instead of a visible MemberAccount.',
-      },
-      {
-        title: 'Shielded withdrawals',
-        desc: 'Members can withdraw their share to a stealth address, breaking the on-chain link between vault participation and the final destination wallet.',
-      },
-    ],
+    sponsor: 'Solana Actions / Blinks',
+    emoji: '⚡',
+    what: 'Vote and deposit straight from a tweet — no app install.',
+    proof: 'Endpoints at `/api/actions/[potPubkey]/{deposit,vote}`. Tweet a pot — Twitter renders an interactive Blink card.',
+    proofHref: '/api/actions',
+    tier: 'live',
+  },
+  {
+    sponsor: 'MCP / Model Context Protocol',
+    emoji: '🤖',
+    what: 'Claude / GPT / any MCP-aware agent can manage a pot.',
+    proof: '`@potbot/mcp@0.2.0` on npm — HTTP + SSE, x402 payments. 9 free tools + 3 paid.',
+    proofHref: 'https://www.npmjs.com/package/@potbot/mcp',
+    tier: 'live',
+  },
+  {
+    sponsor: 'Helius',
+    emoji: '⚡',
+    what: 'RPC + webhooks + priority fees for the entire stack.',
+    proof: 'Wired in `apps/api/src/services/helius.ts` and front-end via `NEXT_PUBLIC_HELIUS_RPC`.',
+    proofHref: 'https://github.com/YD811/potbot-v2/blob/main/apps/api/src/services/helius.ts',
+    tier: 'live',
+  },
+  {
+    sponsor: 'Squads v4',
+    emoji: '🛡',
+    what: 'Optional multisig path for the pot creator role.',
+    proof: 'Detection in `apps/web/src/lib/squads.ts`. UI banner highlights when a pot is owned by a Squads vault.',
+    proofHref: 'https://github.com/YD811/potbot-v2/blob/main/apps/web/src/lib/squads.ts',
+    tier: 'live',
+  },
+  {
+    sponsor: 'Solana Mobile (Saga / Seeker)',
+    emoji: '📱',
+    what: 'PWA manifest ships today, dApp Store metadata next.',
+    proof: '`apps/web/public/manifest.json` is mainnet-ready (theme color, icons, categories). Saga / Seeker dApp Store entry on the roadmap.',
+    proofHref: 'https://github.com/YD811/potbot-v2/blob/main/apps/web/public/manifest.json',
+    tier: 'live',
   },
   {
     sponsor: 'Dune Analytics',
-    prize: '$5,000',
-    track: 'On-Chain Analytics',
-    color: '#F03E3E',
     emoji: '📊',
-    summary: 'Full PnL dashboard with on-chain data, Pyth prices, and Supabase snapshots.',
-    details: [
-      {
-        title: 'Per-member PnL tracking',
-        desc: 'Every deposit records the SOL/USD price at entry time (via Pyth oracle). PnL is calculated as: current share value − entry cost, in both SOL and USD.',
-      },
-      {
-        title: 'Daily NAV snapshots',
-        desc: 'A daily cron job snapshots each vault\'s Net Asset Value into pot_nav_daily. This powers performance charts and rolling return calculations.',
-      },
-      {
-        title: 'Cross-pot portfolio view',
-        desc: 'Members can see their total portfolio PnL across all pots they\'re in. Aggregated from on-chain share data + Supabase price snapshots.',
-      },
-      {
-        title: 'Leaderboard analytics',
-        desc: 'Public vault leaderboard ranks pots by TVL, trade volume, and member growth. All data derived from on-chain Anchor accounts — fully verifiable.',
-      },
+    what: 'Public on-chain dashboard fed from Anchor accounts.',
+    proof: 'Dune SIM portfolio + activity wired in `VaultPortfolio` component. Public dashboard at dune.com/potbot ships when `DUNE_API_KEY` is set in Vercel.',
+    tier: 'devnet',
+  },
+  {
+    sponsor: 'Privy',
+    emoji: '🪪',
+    what: 'Email / social login → 60-second onboarding for non-crypto users.',
+    proof: 'PR #32 on the GitHub repo. Awaiting `NEXT_PUBLIC_PRIVY_APP_ID` env to ship to mainnet.',
+    proofHref: 'https://github.com/YD811/potbot-v2/pull/32',
+    tier: 'phase-2',
+  },
+  {
+    sponsor: 'Pyth Network',
+    emoji: '🔮',
+    what: 'In-program oracle guard — re-reads price inside execute_swap to reject keepers that fired on stale data.',
+    proof: 'Code path is reserved (StrategyTrigger mode); Pyth SDK wiring is the next mainnet promotion.',
+    tier: 'phase-2',
+  },
+  {
+    sponsor: 'Metaplex Token Metadata',
+    emoji: '🎨',
+    what: 'Tamagotchi NFT mint at L4 (Bloom).',
+    proof: '`mint_tamagotchi_nft.rs` written, gated behind level check. Ships at Phase 3.',
+    proofHref: 'https://github.com/YD811/potbot-v2/blob/main/programs/pot_vault/src/instructions/mint_tamagotchi_nft.rs',
+    tier: 'phase-3',
+  },
+  {
+    sponsor: 'Light Protocol',
+    emoji: '🪶',
+    what: 'ZK-compressed audit log for swap events + NAV snapshots.',
+    proof: 'Spec lives in `docs/architecture/architecture-onchain.md`. Phase 2 cut.',
+    tier: 'phase-2',
+  },
+  {
+    sponsor: 'Adevar Labs',
+    emoji: '🔒',
+    what: 'Pre-mainnet-GA security audit (target post-hackathon).',
+    proof: 'Audit credits requested via Superteam NL. Out-of-scope for May 11 submission, in-scope for accelerator phase.',
+    tier: 'vision',
+  },
+]
+
+interface ArchLayer {
+  layer: string
+  color: string
+  items: { name: string; tier: StatusTier }[]
+}
+
+const ARCHITECTURE: ArchLayer[] = [
+  {
+    layer: 'On-chain · Anchor 0.30',
+    color: 'green',
+    items: [
+      { name: 'pot_vault program (30+ ix)', tier: 'live' },
+      { name: 'create_pot · deposit · withdraw', tier: 'live' },
+      { name: 'create_proposal · vote · execute_swap', tier: 'live' },
+      { name: 'Jupiter v6 CPI (vault-PDA signer)', tier: 'live' },
+      { name: 'Pot admin (pause / allowed mints)', tier: 'live' },
+      { name: 'Strategy slot accounts', tier: 'devnet' },
+      { name: 'Pyth in-program oracle guard', tier: 'phase-2' },
+      { name: 'Tamagotchi NFT mint (Metaplex)', tier: 'phase-3' },
     ],
   },
   {
-    sponsor: 'Umbra',
-    prize: '$5,000',
-    track: 'Stealth Payments',
-    color: '#1C7ED6',
-    emoji: '🌫️',
-    summary: 'Stealth address support for private vault withdrawals.',
-    details: [
-      {
-        title: 'Stealth withdrawal addresses',
-        desc: 'Members can generate a one-time stealth address for their withdrawal. The vault sends SOL to the stealth address instead of the registered wallet, breaking the on-chain trail.',
-      },
-      {
-        title: 'Combined with STAMPPOT',
-        desc: 'When used alongside STAMPPOT ZK layer, the full flow is private: hidden membership + stealth withdrawal = no on-chain link between the user and their pot activity.',
-      },
+    layer: 'Off-chain · Next.js 14 + apps/api',
+    color: 'purple',
+    items: [
+      { name: 'Pot detail UX (sticky hero, sponsor rail)', tier: 'live' },
+      { name: 'Solana Action endpoints', tier: 'live' },
+      { name: 'Helius RPC + webhook ingest', tier: 'live' },
+      { name: 'PotBot AI base layer (suggestions feed)', tier: 'devnet' },
+      { name: 'User AI delegate (rules + presets)', tier: 'devnet' },
+      { name: 'Privy embedded wallets', tier: 'phase-2' },
+      { name: 'STAMPPOT privacy preview', tier: 'phase-3' },
     ],
   },
   {
-    sponsor: 'SNS',
-    prize: '$5,000',
-    track: 'Solana Name Service',
-    color: '#E67700',
-    emoji: '🏷️',
-    summary: 'SNS reverse lookup for human-readable wallet names across the app.',
-    details: [
-      {
-        title: 'Reverse SNS lookup',
-        desc: 'All wallet addresses in the UI are resolved to .sol names when available. Member lists, proposal authors, and deposit history all show "alice.sol" instead of raw pubkeys.',
-      },
-      {
-        title: 'SNS in governance',
-        desc: 'Proposal cards show "alice.sol proposed: swap 1 SOL → BONK" instead of truncated addresses. Makes governance readable for non-technical group members.',
-      },
-      {
-        title: 'SNS-gated pots',
-        desc: 'Pot creators can restrict membership to .sol name holders, adding a layer of identity verification to private vaults.',
-      },
-    ],
-  },
-  {
-    sponsor: 'Kora',
-    prize: '$5,000',
-    track: 'Group Finance',
-    color: '#2F9E44',
-    emoji: '🏦',
-    summary: 'Core group finance primitives: shared treasury, budget grants, multi-level governance.',
-    details: [
-      {
-        title: 'Multi-member shared vault',
-        desc: 'Up to 1,000 members per pot. Each member holds shares proportional to their deposit. Shares represent a claim on the vault\'s SOL balance.',
-      },
-      {
-        title: 'Budget grant proposals',
-        desc: 'Governance can allocate a budget to an active trader: "give Alice 20% of vault for 7 days". Alice can swap freely within budget; unused funds return automatically.',
-      },
-      {
-        title: '5-level governance system',
-        desc: 'Trade level, withdraw level, member change level, settings level, yield level — each independently configurable. Supports everything from single-signer autocracy to multi-sig consensus.',
-      },
-      {
-        title: 'Withdrawal reserves',
-        desc: 'Protocol-level fee reserves and withdrawal buffers ensure the vault can always process redemptions even during active yield strategies.',
-      },
+    layer: 'Composability · Solana ecosystem',
+    color: 'amber',
+    items: [
+      { name: 'Jupiter v6 swap (CPI)', tier: 'live' },
+      { name: 'Squads v4 multisig (optional creator)', tier: 'live' },
+      { name: '@potbot/mcp on npm', tier: 'live' },
+      { name: 'Solana Blinks (Twitter/X)', tier: 'live' },
+      { name: 'PWA manifest (Saga / Seeker)', tier: 'live' },
+      { name: 'Dune SIM analytics', tier: 'devnet' },
+      { name: 'Light Protocol ZK audit log', tier: 'phase-2' },
+      { name: 'Saga / Seeker dApp Store entry', tier: 'vision' },
     ],
   },
 ]
 
-const STACK = [
-  'Solana · Anchor 0.30',
-  'Jupiter Swap V2 + Trigger + DCA',
-  'Pyth Network (price feeds)',
-  'PrivacyCash ZK proofs',
-  'Solana Name Service',
-  'Next.js 14 · TanStack Query',
-  'Supabase · Cloudflare Pages',
+const WEDGE = [
+  { who: 'Squads', does: 'Multisig custody', noTrade: true },
+  { who: 'Drift Vaults', does: 'Single-strategy structured products', noTrade: false, why: 'Curators only — no group governance per swap' },
+  { who: 'Kamino / Gauntlet', does: 'Institutional curators', noTrade: false, why: 'No group primitive for friends pooling capital' },
+  { who: 'PotBot', does: 'Group trading vault', noTrade: false, why: 'Deposit + vote + Jupiter CPI in one Anchor program', highlight: true },
 ]
 
 export default function HackathonPage() {
-  const [open, setOpen] = useState<string | null>(null)
-
-  const totalPrize = BOUNTIES.reduce((sum, b) => sum + parseInt(b.prize.replace(/\D/g, '')), 0)
+  const programExplorerUrl = `https://explorer.solana.com/address/${PROGRAM_ID}${EXPLORER_SUFFIX}`
+  const flagshipUrl = FLAGSHIP_POT ? `${APP_URL}/pots/${FLAGSHIP_POT}` : null
+  const flagshipBlinkUrl = FLAGSHIP_POT ? `${APP_URL}/api/actions/${FLAGSHIP_POT}/deposit` : null
 
   return (
-    <main style={{ fontFamily: 'system-ui, sans-serif', background: '#08080f', color: '#e8e8f0', minHeight: '100vh' }}>
-
-      {/* Nav */}
-      <div style={{ borderBottom: '1px solid #1a1a2e', padding: '14px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <a href="/" style={{ color: '#7048E8', fontWeight: 800, fontSize: 18, textDecoration: 'none' }}>🫕 PotBot</a>
-        <div style={{ display: 'flex', gap: 16, fontSize: 13 }}>
-          <a href="https://t.me/Trade_pot_bot" target="_blank" rel="noreferrer" style={{ color: '#a0a0c0', textDecoration: 'none' }}>Telegram Bot</a>
-          <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noreferrer" style={{ color: '#a0a0c0', textDecoration: 'none' }}>GitHub</a>
-          <a href="https://x.com/PotBot_sol" target="_blank" rel="noreferrer" style={{ color: '#a0a0c0', textDecoration: 'none' }}>Twitter</a>
+    <main className="min-h-screen bg-pot-dark text-white">
+      {/* Top banner */}
+      <div className="bg-gradient-to-b from-pot-accent/10 to-transparent border-b border-pot-border">
+        <div className="max-w-[1100px] mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-3 flex-wrap">
+          <Link href="/" className="text-pot-accent font-bold text-base flex items-center gap-2">
+            🫕 <span>PotBot</span>
+          </Link>
+          <div className="flex items-center gap-3 text-xs">
+            <span className="text-pot-muted">Solana Frontier 2026 · Apr 6 – May 11</span>
+            <span className="hidden sm:inline text-pot-muted">·</span>
+            <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noreferrer" className="text-pot-muted hover:text-white transition">
+              GitHub
+            </a>
+            <a href="https://x.com/PotBot_sol" target="_blank" rel="noreferrer" className="text-pot-muted hover:text-white transition">
+              X
+            </a>
+            <Link href="/roadmap" className="text-pot-muted hover:text-white transition">
+              Roadmap
+            </Link>
+          </div>
         </div>
       </div>
 
       {/* Hero */}
-      <section style={{ textAlign: 'center', padding: '80px 24px 56px', background: 'radial-gradient(ellipse at 50% 0%, #1a0a3e 0%, #08080f 60%)' }}>
-        <div style={{ display: 'inline-block', background: '#7048E820', border: '1px solid #7048E840', borderRadius: 100, padding: '6px 18px', fontSize: 12, color: '#9d6fff', fontWeight: 700, letterSpacing: 2, textTransform: 'uppercase', marginBottom: 20 }}>
-          Solana Frontier Hackathon 2026 · Apr 6 – May 11
-        </div>
-        <h1 style={{ fontSize: 'clamp(40px, 7vw, 80px)', fontWeight: 900, margin: '0 0 16px', lineHeight: 1.05, background: 'linear-gradient(135deg, #fff 30%, #9d6fff)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
-          🫕 PotBot
-        </h1>
-        <p style={{ fontSize: 'clamp(17px, 2.5vw, 22px)', color: '#8080b0', maxWidth: 560, margin: '0 auto 12px', lineHeight: 1.6 }}>
-          Group trading vaults on Solana. Pool capital, vote on swaps, share the gains.
-        </p>
-        <p style={{ fontSize: 14, color: '#5050a0', marginBottom: 40 }}>
-          Targeting <strong style={{ color: '#9d6fff' }}>${totalPrize.toLocaleString()}</strong> across {BOUNTIES.length} bounty tracks
-        </p>
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <a href="https://t.me/Trade_pot_bot" target="_blank" rel="noreferrer"
-            style={{ background: '#7048E8', color: '#fff', padding: '13px 28px', borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: 'none' }}>
-            🚀 Try the Bot
-          </a>
-          <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noreferrer"
-            style={{ background: '#12121e', color: '#e8e8f0', padding: '13px 28px', borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: 'none', border: '1px solid #2a2a4a' }}>
-            View Source →
-          </a>
-        </div>
-      </section>
+      <section className="px-4 sm:px-6 py-12 sm:py-20 text-center">
+        <div className="max-w-3xl mx-auto">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-pot-accent/30 bg-pot-accent/10 text-pot-accent text-[11px] font-bold uppercase tracking-wider mb-6">
+            🏁 Submission for Colosseum / Solana Frontier 2026
+          </div>
+          <h1 className="text-4xl sm:text-6xl font-black mb-4 leading-tight bg-gradient-to-br from-white to-pot-accent bg-clip-text text-transparent">
+            Squads moves money.<br />PotBot trades it.
+          </h1>
+          <p className="text-base sm:text-xl text-pot-muted max-w-2xl mx-auto">
+            Group trading vaults on Solana. Five friends spin up a pot, deposit SOL, vote on a Jupiter swap, and execute it on-chain in under 60 seconds. All in a single Anchor program.
+          </p>
 
-      {/* Bounty tracks — accordion */}
-      <section style={{ padding: '60px 24px', maxWidth: 860, margin: '0 auto' }}>
-        <h2 style={{ textAlign: 'center', fontSize: 30, fontWeight: 800, marginBottom: 8 }}>What We Built — Per Bounty</h2>
-        <p style={{ textAlign: 'center', color: '#5050a0', marginBottom: 48, fontSize: 15 }}>
-          Click each track to see exact implementation details
-        </p>
-
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {BOUNTIES.map((b) => {
-            const isOpen = open === b.sponsor
-            return (
-              <div key={b.sponsor} style={{
-                background: '#10101c',
-                border: `1px solid ${isOpen ? b.color + '60' : '#1e1e36'}`,
-                borderRadius: 16,
-                overflow: 'hidden',
-                transition: 'border-color 0.2s',
-              }}>
-                {/* Header */}
-                <button
-                  onClick={() => setOpen(isOpen ? null : b.sponsor)}
-                  style={{
-                    width: '100%', background: 'none', border: 'none', cursor: 'pointer',
-                    padding: '20px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16,
-                    color: '#e8e8f0', textAlign: 'left',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                    <span style={{ fontSize: 28 }}>{b.emoji}</span>
-                    <div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-                        <span style={{ fontSize: 18, fontWeight: 800 }}>{b.sponsor}</span>
-                        <span style={{ fontSize: 14, fontWeight: 800, color: b.color }}>{b.prize}</span>
-                        <span style={{ fontSize: 11, background: b.color + '20', color: b.color, borderRadius: 100, padding: '2px 10px', fontWeight: 600 }}>{b.track}</span>
-                      </div>
-                      <div style={{ fontSize: 13, color: '#6060a0', marginTop: 4 }}>{b.summary}</div>
-                    </div>
-                  </div>
-                  <span style={{ color: b.color, fontSize: 20, flexShrink: 0, transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}>▾</span>
-                </button>
-
-                {/* Expandable details */}
-                {isOpen && (
-                  <div style={{ borderTop: `1px solid ${b.color}30`, padding: '0 24px 24px' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-                      {b.details.map((d, i) => (
-                        <div key={i} style={{
-                          padding: '16px 0',
-                          borderBottom: i < b.details.length - 1 ? '1px solid #1a1a30' : 'none',
-                          display: 'flex', gap: 16,
-                        }}>
-                          <div style={{ width: 6, height: 6, borderRadius: '50%', background: b.color, flexShrink: 0, marginTop: 7 }} />
-                          <div>
-                            <div style={{ fontSize: 14, fontWeight: 700, color: '#d0d0f0', marginBottom: 6 }}>{d.title}</div>
-                            <div style={{ fontSize: 13, color: '#6060a0', lineHeight: 1.65 }}>{d.desc}</div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            )
-          })}
+          <div className="mt-8 flex items-center justify-center gap-2 sm:gap-3 flex-wrap">
+            {flagshipUrl ? (
+              <a
+                href={flagshipUrl}
+                className="px-5 sm:px-6 py-3 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold transition text-sm sm:text-base"
+              >
+                🪴 Open flagship pot
+              </a>
+            ) : (
+              <Link
+                href="/vaults"
+                className="px-5 sm:px-6 py-3 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold transition text-sm sm:text-base"
+              >
+                🪴 Browse public pots
+              </Link>
+            )}
+            <Link
+              href="/create"
+              className="px-5 sm:px-6 py-3 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold transition text-sm sm:text-base"
+            >
+              + Create your pot
+            </Link>
+            <a
+              href="https://www.npmjs.com/package/@potbot/mcp"
+              target="_blank"
+              rel="noreferrer"
+              className="px-5 sm:px-6 py-3 rounded-xl bg-pot-card border border-pot-border hover:border-pot-accent/40 text-white font-bold transition text-sm sm:text-base"
+            >
+              🤖 Install MCP
+            </a>
+          </div>
         </div>
       </section>
 
-      {/* Architecture overview */}
-      <section style={{ padding: '0 24px 60px', maxWidth: 860, margin: '0 auto' }}>
-        <div style={{ background: '#10101c', border: '1px solid #1e1e36', borderRadius: 20, padding: '32px 40px' }}>
-          <h3 style={{ fontSize: 20, fontWeight: 800, marginBottom: 24 }}>🏗️ Architecture</h3>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 20 }}>
-            {[
-              { layer: 'On-Chain', color: '#37B24D', items: ['Anchor 0.30 program', 'PotAccount PDA', 'ProposalAccount PDA', 'MemberAccount PDA', 'Tamagotchi NFT mint', 'Timelock enforcement'] },
-              { layer: 'Off-Chain', color: '#7048E8', items: ['Next.js 14 frontend', 'Jupiter API proxy', 'Pyth price feeds', 'Supabase PostgreSQL', 'PnL calculation engine', 'AI agent evaluation loop'] },
-              { layer: 'Integrations', color: '#E67700', items: ['Jupiter Swap V2', 'Jupiter Trigger', 'Jupiter DCA', 'Pyth Network', 'Solana Name Service', 'PrivacyCash ZK'] },
-            ].map(({ layer, color, items }) => (
-              <div key={layer}>
-                <div style={{ fontSize: 12, fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 12 }}>{layer}</div>
-                {items.map(item => (
-                  <div key={item} style={{ fontSize: 13, color: '#7070a0', padding: '4px 0', borderBottom: '1px solid #14142a', display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ color, opacity: 0.6 }}>·</span> {item}
-                  </div>
+      {/* Live now block */}
+      <section className="px-4 sm:px-6 pb-12">
+        <div className="max-w-[1100px] mx-auto bg-pot-card border border-pot-green/30 rounded-3xl p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-5 flex-wrap">
+            <h2 className="text-xl sm:text-2xl font-bold text-white">🟢 Live now — judge can verify</h2>
+            <StatusBadge tier={CLUSTER === 'mainnet-beta' ? 'live' : 'devnet'} compact />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <LiveCard
+              title="Anchor program"
+              value={PROGRAM_ID}
+              href={programExplorerUrl}
+              hrefLabel="View on Solana Explorer"
+              mono
+            />
+            {FLAGSHIP_POT ? (
+              <LiveCard
+                title="Flagship pot"
+                value={FLAGSHIP_POT}
+                href={flagshipUrl ?? undefined}
+                hrefLabel="Open in app"
+                mono
+              />
+            ) : (
+              <LiveCard
+                title="Flagship pot"
+                value="(awaiting mainnet deploy)"
+                hrefLabel="See devnet pots →"
+                href="/vaults"
+              />
+            )}
+            <LiveCard
+              title="MCP server"
+              value="@potbot/mcp@0.2.0"
+              href="https://www.npmjs.com/package/@potbot/mcp"
+              hrefLabel="View on npm"
+            />
+            <LiveCard
+              title="Solana Blink (deposit)"
+              value={flagshipBlinkUrl ?? `${APP_URL}/api/actions/<potPubkey>/deposit`}
+              href={flagshipBlinkUrl ?? undefined}
+              hrefLabel={flagshipBlinkUrl ? 'Open Action endpoint' : 'See live Blink after deploy'}
+              mono
+            />
+            <LiveCard
+              title="Source code"
+              value="github.com/YD811/potbot-v2"
+              href="https://github.com/YD811/potbot-v2"
+              hrefLabel="Browse the repo"
+            />
+            <LiveCard
+              title="Public roadmap"
+              value="Every feature, every phase"
+              href="/roadmap"
+              hrefLabel="Open /roadmap"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* The wedge */}
+      <section className="px-4 sm:px-6 pb-12">
+        <div className="max-w-[1100px] mx-auto">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-2">The wedge</h2>
+          <p className="text-pot-muted max-w-2xl mb-6">
+            Group on-chain governance baked <strong className="text-white">into the swap instruction</strong>. Nobody else ships this primitive.
+          </p>
+          <div className="overflow-x-auto rounded-2xl border border-pot-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-pot-card text-left">
+                  <th className="px-4 py-3 text-xs uppercase tracking-wide text-pot-muted">Project</th>
+                  <th className="px-4 py-3 text-xs uppercase tracking-wide text-pot-muted">What it does</th>
+                  <th className="px-4 py-3 text-xs uppercase tracking-wide text-pot-muted">Group-trade primitive?</th>
+                </tr>
+              </thead>
+              <tbody>
+                {WEDGE.map((w) => (
+                  <tr
+                    key={w.who}
+                    className={`border-t border-pot-border ${w.highlight ? 'bg-pot-accent/5' : ''}`}
+                  >
+                    <td className={`px-4 py-3 font-bold ${w.highlight ? 'text-pot-accent' : 'text-white'}`}>{w.who}</td>
+                    <td className="px-4 py-3 text-pot-muted">{w.does}</td>
+                    <td className="px-4 py-3">
+                      {w.highlight ? (
+                        <span className="inline-flex items-center gap-1.5 text-pot-green font-semibold">
+                          ✅ Yes — pot_vault::execute_swap
+                        </span>
+                      ) : (
+                        <span className="text-pot-muted text-xs">{w.why ?? '—'}</span>
+                      )}
+                    </td>
+                  </tr>
                 ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Sponsor tracks */}
+      <section className="px-4 sm:px-6 pb-12">
+        <div className="max-w-[1100px] mx-auto">
+          <div className="flex items-end justify-between gap-3 mb-6 flex-wrap">
+            <div>
+              <h2 className="text-2xl sm:text-3xl font-bold text-white">Sponsor tracks &amp; integrations</h2>
+              <p className="text-pot-muted text-sm mt-1">Every claim is labelled with its lifecycle status. Live items are verifiable on Explorer.</p>
+            </div>
+            <Link href="/roadmap" className="text-xs text-pot-accent hover:underline font-semibold">
+              See the full roadmap →
+            </Link>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {TRACKS.map((t) => (
+              <div
+                key={t.sponsor}
+                className="bg-pot-card border border-pot-border hover:border-pot-accent/30 rounded-2xl p-4 sm:p-5 transition"
+              >
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-2xl shrink-0">{t.emoji}</span>
+                    <h3 className="font-bold text-white truncate">{t.sponsor}</h3>
+                  </div>
+                  <StatusBadge tier={t.tier} compact />
+                </div>
+                <p className="mt-2 text-sm text-white/90">{t.what}</p>
+                <p className="mt-2 text-xs text-pot-muted leading-relaxed">{t.proof}</p>
+                {t.proofHref && (
+                  <a
+                    href={t.proofHref}
+                    target={t.proofHref.startsWith('http') ? '_blank' : undefined}
+                    rel={t.proofHref.startsWith('http') ? 'noreferrer' : undefined}
+                    className="mt-3 inline-block text-xs text-pot-accent hover:underline font-semibold"
+                  >
+                    Source / proof ↗
+                  </a>
+                )}
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Timeline */}
-      <section style={{ padding: '0 24px 60px', maxWidth: 600, margin: '0 auto' }}>
-        <h2 style={{ textAlign: 'center', fontSize: 26, fontWeight: 800, marginBottom: 36 }}>Build Timeline</h2>
-        {[
-          { date: 'Apr 6', label: 'Hackathon started · repo initialized', done: true },
-          { date: 'Apr 18', label: 'Anchor program + all compile errors fixed', done: true },
-          { date: 'Apr 21', label: 'Jupiter full stack · Pyth PnL · Supabase backend · localStorage removed', done: true },
-          { date: 'Apr 25', label: 'Devnet deploy · E2E demo flow', done: false },
-          { date: 'May 1', label: 'Demo video · submission draft', done: false },
-          { date: 'May 11', label: '🏁 Submission deadline', done: false },
-        ].map((t, i) => (
-          <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 20, marginBottom: 20 }}>
-            <div style={{
-              width: 40, height: 40, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center',
-              fontSize: 16, flexShrink: 0,
-              background: t.done ? '#2F9E44' : '#10101c',
-              border: t.done ? 'none' : '2px solid #2a2a4a',
-            }}>
-              {t.done ? '✓' : '○'}
-            </div>
-            <div style={{ paddingTop: 8 }}>
-              <div style={{ fontSize: 11, color: '#4040a0', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 1 }}>{t.date}</div>
-              <div style={{ fontSize: 14, fontWeight: t.done ? 600 : 400, color: t.done ? '#d0d0f0' : '#5050a0', marginTop: 2 }}>{t.label}</div>
-            </div>
+      {/* Architecture */}
+      <section className="px-4 sm:px-6 pb-12">
+        <div className="max-w-[1100px] mx-auto">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-2">Architecture</h2>
+          <p className="text-pot-muted text-sm mb-6 max-w-2xl">
+            Three layers — on-chain, off-chain, composability. Each item carries its lifecycle chip so nothing on this page is over-promised.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {ARCHITECTURE.map((layer) => (
+              <div key={layer.layer} className="bg-pot-card border border-pot-border rounded-2xl p-5">
+                <h3 className={`text-xs font-bold uppercase tracking-wider mb-3 ${
+                  layer.color === 'green' ? 'text-pot-green' :
+                  layer.color === 'purple' ? 'text-pot-accent' : 'text-amber-300'
+                }`}>
+                  {layer.layer}
+                </h3>
+                <ul className="space-y-2">
+                  {layer.items.map((it) => (
+                    <li key={it.name} className="flex items-center gap-2 text-sm text-white">
+                      <StatusBadge tier={it.tier} compact label={it.tier === 'live' ? '🟢' : it.tier === 'devnet' ? '🟡' : it.tier === 'phase-2' ? '🔵' : it.tier === 'phase-3' ? '🟣' : '⚪'} />
+                      <span className="leading-snug">{it.name}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
-        ))}
-      </section>
-
-      {/* Stack pills */}
-      <section style={{ padding: '0 24px 80px', textAlign: 'center' }}>
-        <div style={{ fontSize: 11, color: '#3030a0', fontWeight: 700, letterSpacing: 2, marginBottom: 14, textTransform: 'uppercase' }}>Tech Stack</div>
-        <div>
-          {STACK.map(s => (
-            <span key={s} style={{ display: 'inline-block', background: '#10101c', border: '1px solid #1e1e36', borderRadius: 100, padding: '6px 16px', margin: '4px', fontSize: 12, color: '#7070a0' }}>
-              {s}
-            </span>
-          ))}
-        </div>
-        <div style={{ marginTop: 40, fontSize: 13, color: '#3030a0' }}>
-          Built by <a href="https://x.com/CryptoYDao" target="_blank" rel="noreferrer" style={{ color: '#7048E8', textDecoration: 'none' }}>@CryptoYDao</a>
-          {' · '}Y-DAO Amsterdam{' · '}Superteam NL
         </div>
       </section>
 
+      {/* 90-second pitch */}
+      <section className="px-4 sm:px-6 pb-12">
+        <div className="max-w-[1100px] mx-auto bg-pot-card border border-pot-border rounded-3xl p-6 sm:p-8">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-5">90-second pitch</h2>
+          <ol className="space-y-4 text-sm sm:text-base">
+            <PitchStep range="0–15s" headline="Problem">
+              Five friends want to trade together. Today they share a seed phrase or build a Squads multisig with no trading UI. Both suck.
+            </PitchStep>
+            <PitchStep range="15–30s" headline="Solution">
+              PotBot is a group trading vault. Deposit. Propose. Vote. Execute. All on-chain, in one Anchor program.
+            </PitchStep>
+            <PitchStep range="30–60s" headline="Live demo">
+              Open `/vaults` → click a public pot → deposit 0.05 SOL via wallet → propose a swap → vote yes → watch it execute on Jupiter, Solana Explorer link visible.
+            </PitchStep>
+            <PitchStep range="60–80s" headline="Differentiation">
+              Solana Blinks turn any proposal into a tweet anyone can vote on. MCP lets Claude/GPT manage a pot. The on-chain `execute_swap` instruction is mode-aware — Admin / Proposal / AI-trigger — and matches mode-source strictly.
+            </PitchStep>
+            <PitchStep range="80–90s" headline="Ask">
+              Mainnet is live (or shipping this sprint). We want Colosseum to ship the privacy layer (Token-2022 confidential transfers) and the Saga / Seeker dApp Store entry.
+            </PitchStep>
+          </ol>
+        </div>
+      </section>
+
+      {/* What's next */}
+      <section className="px-4 sm:px-6 pb-16">
+        <div className="max-w-[1100px] mx-auto bg-gradient-to-br from-pot-accent/10 to-pot-green/5 border border-pot-accent/30 rounded-3xl p-6 sm:p-8 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-3">What ships next</h2>
+          <p className="text-pot-muted max-w-xl mx-auto mb-5 text-sm sm:text-base">
+            Privy embedded wallets, Pyth in-program oracle guard, Meteora &amp; Kamino yield CPIs, Light Protocol ZK audit log, Tamagotchi NFT mint, STAMPPOT privacy mode. Each phase tagged on the public roadmap.
+          </p>
+          <Link
+            href="/roadmap"
+            className="inline-block px-5 py-3 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold transition text-sm sm:text-base"
+          >
+            🗺️ Open /roadmap
+          </Link>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t border-pot-border px-4 sm:px-6 py-8">
+        <div className="max-w-[1100px] mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-pot-muted">
+          <div>
+            Built by{' '}
+            <a href="https://x.com/CryptoYDao" target="_blank" rel="noreferrer" className="text-pot-accent hover:underline">
+              @CryptoYDao
+            </a>
+            {' · '}Y-DAO Amsterdam{' · '}Superteam NL
+          </div>
+          <div className="flex items-center gap-3">
+            <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noreferrer" className="hover:text-white transition">GitHub</a>
+            <span>·</span>
+            <a href="https://x.com/PotBot_sol" target="_blank" rel="noreferrer" className="hover:text-white transition">X</a>
+            <span>·</span>
+            <Link href="/roadmap" className="hover:text-white transition">Roadmap</Link>
+            <span>·</span>
+            <Link href="/" className="hover:text-white transition">Home</Link>
+          </div>
+        </div>
+      </footer>
     </main>
+  )
+}
+
+function LiveCard({
+  title,
+  value,
+  href,
+  hrefLabel,
+  mono,
+}: {
+  title: string
+  value: string
+  href?: string
+  hrefLabel?: string
+  mono?: boolean
+}) {
+  const valueClass = `text-xs sm:text-sm break-all ${mono ? 'font-mono text-pot-green' : 'text-white'}`
+  return (
+    <div className="bg-pot-dark/40 border border-pot-border rounded-2xl p-4">
+      <div className="text-[10px] uppercase tracking-wider text-pot-muted font-bold mb-1.5">{title}</div>
+      <div className={valueClass}>{value}</div>
+      {href && hrefLabel && (
+        <a
+          href={href}
+          target={href.startsWith('http') ? '_blank' : undefined}
+          rel={href.startsWith('http') ? 'noreferrer' : undefined}
+          className="mt-2 inline-block text-[11px] text-pot-accent hover:underline font-semibold"
+        >
+          {hrefLabel} ↗
+        </a>
+      )}
+    </div>
+  )
+}
+
+function PitchStep({
+  range,
+  headline,
+  children,
+}: {
+  range: string
+  headline: string
+  children: React.ReactNode
+}) {
+  return (
+    <li className="flex gap-3 sm:gap-4">
+      <div className="shrink-0 w-16 sm:w-20 text-[10px] sm:text-xs uppercase tracking-wider font-bold text-pot-accent pt-1">
+        {range}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="font-bold text-white">{headline}</div>
+        <div className="text-pot-muted text-sm mt-0.5">{children}</div>
+      </div>
+    </li>
   )
 }

--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useParams, useSearchParams } from 'next/navigation'
 import { useWallet } from '@solana/wallet-adapter-react'
 import dynamic from 'next/dynamic'
@@ -15,11 +15,9 @@ import { usePotRole } from '@/hooks/usePotRole'
 import { calculateTamaStats } from '@/lib/tamagotchi/stats'
 import { PnLDashboard } from '@/components/PnLDashboard'
 import { SharesPanel } from '@/components/SharesPanel'
-import { VaultAnalyticsStrip } from '@/components/VaultAnalyticsStrip'
 import { StrategyPanel } from '@/components/StrategyPanel'
 import { AIAgentPanel } from '@/components/AIAgentPanel'
 import { GovernanceSettings } from '@/components/GovernanceSettings'
-import { VaultTab } from '@/components/VaultTab'
 import DepositPanel from '@/components/DepositPanel'
 import SharesTab from '@/components/SharesTab'
 import ReferralPanel from '@/components/ReferralPanel'
@@ -28,47 +26,43 @@ import { ShareBlinkButton } from '@/components/ShareBlinkButton'
 import { StrategyProposalBuilder } from '@/components/StrategyProposalBuilder'
 import { PotBotAISuggestions } from '@/components/PotBotAISuggestions'
 import { StatusBadge } from '@/components/StatusBadge'
+import { PotHeroStrip } from '@/components/PotHeroStrip'
+import { SponsorRail } from '@/components/SponsorRail'
+import { PotActivityFeed } from '@/components/PotActivityFeed'
+import { MembersList } from '@/components/MembersList'
+import { PremiumFeatures } from '@/components/PremiumFeatures'
 import { reverseSNS } from '@/lib/sns'
 import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import SwapExecuteButton from '@/components/SwapExecuteButton'
 import CreateProposalModal from '@/components/pot/CreateProposalModal'
 import { PublicKey } from '@solana/web3.js'
 import VaultPortfolio from '@/components/VaultPortfolio'
-import PotNotificationFeed from '@/components/PotNotificationFeed'
-import PotAnalyticsWidget from '@/components/PotAnalyticsWidget'
 
-
-// SSR-safe wallet button (same pattern as Navbar)
+// SSR-safe wallet button
 const WalletMultiButtonDynamic = dynamic(
   async () => (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
   { ssr: false },
 )
 
-/* ── Tab order (Phase 1) ──
-   Primary journey: Deposit → Overview → Vault → Proposals → Tamagotchi → Shares
-   Docs is a link, not a tab (leads to /docs).
-   Secondary tabs keep existing power-user views (positions, strategy, governance, agent, members, referral). */
-const TABS = [
-  'deposit', 'overview', 'vault', 'proposals', 'tamagotchi', 'shares',
-  'positions', 'analytics', 'strategy', 'governance', 'agent', 'members', 'referral',
-] as const
+/* ── Tab order (PR-F vision-mode collapse) ──
+   Old layout had 13 tabs. New layout has 4, mapped to user mental model:
+   - Trade   → first action: deposit, propose, vote, recent activity
+   - Community → who's in this pot, governance, referrals
+   - AI      → PotBot AI base layer + your AI delegate
+   - Features → roadmap stuff: tamagotchi, premium, privacy preview */
+const TABS = ['trade', 'community', 'ai', 'features'] as const
 type Tab = (typeof TABS)[number]
 
 const TAB_LABELS: Record<Tab, string> = {
-  deposit:    '💰 Deposit',
-  overview:   'Overview',
-  vault:      '🏠 Vault',
-  proposals:  '🗳️ Proposals',
-  tamagotchi: '🌱 Tamagotchi',
-  shares:     '🪙 Shares',
-  positions:  '📊 P&L',
-  analytics:  '🔎 Analytics',
-  strategy:   '⚙️ Strategy',
-  governance: '🏛️ Gov',
-  agent:      '🤖 AI',
-  members:    'Members',
-  referral:   '🔗 Referral',
+  trade:     '🔄 Trade',
+  community: '👥 Community',
+  ai:        '🤖 AI',
+  features:  '🌟 Features',
 }
+
+/* Cluster — use NEXT_PUBLIC_SOLANA_CLUSTER if present, else default to devnet */
+const CLUSTER: 'mainnet-beta' | 'devnet' =
+  (process.env.NEXT_PUBLIC_SOLANA_CLUSTER as 'mainnet-beta' | 'devnet') ?? 'devnet'
 
 /* ── Proposal status helpers ── */
 const STATUS_COLORS: Record<string, string> = {
@@ -86,8 +80,7 @@ const STATUS_LABELS: Record<string, string> = {
   pending:  '🕐 Pending',
 }
 
-/* Inline wallet gate: any block that needs a connected wallet wraps its
-   content in <WalletGate>. If wallet is not connected, show CTA inline. */
+/* Inline wallet gate */
 function WalletGate({
   connected,
   title,
@@ -106,19 +99,6 @@ function WalletGate({
       {title && <p className="text-white font-semibold">{title}</p>}
       {subtitle && <p className="text-pot-muted text-sm max-w-md">{subtitle}</p>}
       <div className="mt-2"><WalletMultiButtonDynamic /></div>
-    </div>
-  )
-}
-
-/* Metric tile — min-width sized for 8-character values (e.g. "9,999.99"),
-   tabular-nums so digits don't jitter. */
-function MetricTile({ label, value, accent }: { label: string; value: string; accent?: 'green' | 'accent' }) {
-  const valueClass =
-    accent === 'green' ? 'text-pot-green' : accent === 'accent' ? 'text-pot-accent' : 'text-white'
-  return (
-    <div className="bg-pot-card border border-pot-border rounded-2xl p-4 min-w-[132px]">
-      <div className="text-xs text-pot-muted mb-1 whitespace-nowrap">{label}</div>
-      <div className={`text-2xl font-bold tabular-nums ${valueClass}`}>{value}</div>
     </div>
   )
 }
@@ -146,7 +126,6 @@ function ProposalCard({
       role="button"
       aria-expanded={expanded}
     >
-      {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
           <p className="text-white font-semibold text-sm leading-snug break-words">{proposal.description}</p>
@@ -159,7 +138,6 @@ function ProposalCard({
         </span>
       </div>
 
-      {/* Vote bars */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <span className="text-xs text-pot-muted w-8">YES</span>
@@ -177,7 +155,6 @@ function ProposalCard({
         </div>
       </div>
 
-      {/* Expanded details — full description + voter count */}
       {expanded && (
         <div className="border-t border-pot-border/50 pt-3 text-xs text-pot-muted space-y-1">
           <div><span className="text-pot-muted">Pubkey:</span> <span className="font-mono text-pot-green break-all">{proposal.pubkey}</span></div>
@@ -190,8 +167,6 @@ function ProposalCard({
         </div>
       )}
 
-      {/* Actions — Yes/No clickable for any voter (member or owner).
-         Phase 2 will extend with reason input + proposal categories. */}
       {canVote && proposal.status === 'active' && (
         <div className="flex gap-3 pt-1" onClick={(e) => e.stopPropagation()}>
           <button
@@ -219,7 +194,7 @@ function ProposalCard({
   )
 }
 
-/* ── Tamagotchi placeholder (Phase 1: structure & CTA; real NFT mint + duels in Phase 3) ── */
+/* ── Tamagotchi block (used inside Features tab) ── */
 const TAMA_STAGES = [
   { lvl: 1, emoji: '🌱', name: 'Seedling',   unlock: 'Starting state for every new pot' },
   { lvl: 2, emoji: '🌿', name: 'Sprout',     unlock: 'Lower protocol fees · custom emoji' },
@@ -228,137 +203,98 @@ const TAMA_STAGES = [
   { lvl: 5, emoji: '🌲', name: 'Mature Tree', unlock: 'Mainnet-only perks · cross-pot composability' },
 ] as const
 
-function TamagotchiTab({ stats }: { stats: ReturnType<typeof calculateTamaStats> }) {
+function TamagotchiBlock({ stats }: { stats: ReturnType<typeof calculateTamaStats> }) {
   const level = Math.max(1, Math.min(5, Math.floor(stats.hp / 20) + 1))
   const duelsUnlocked = level >= 3
 
   return (
-    <div className="space-y-6 w-full">
-
-      {/* ── How it works (PROMINENT — first thing the user reads) ── */}
-      <div className="bg-gradient-to-br from-pot-green/5 to-pot-accent/5 border border-pot-green/20 rounded-2xl p-6">
-        <div className="flex items-center gap-2 mb-3">
+    <section className="bg-pot-card border border-pot-border rounded-2xl p-5 sm:p-6 space-y-5">
+      <header className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
           <span className="text-2xl">🌱</span>
-          <h3 className="font-bold text-white text-lg">How the Tamagotchi works</h3>
+          <h3 className="font-bold text-white text-lg">Tamagotchi</h3>
+          <StatusBadge tier="phase-3" compact />
         </div>
-        <ol className="space-y-2.5 text-sm text-pot-muted leading-relaxed list-none">
-          <li className="flex gap-3">
-            <span className="text-pot-green font-bold shrink-0">1.</span>
-            <span>Every new pot starts at <span className="text-white font-semibold">Level 1 — Seedling 🌱</span>.</span>
-          </li>
-          <li className="flex gap-3">
-            <span className="text-pot-green font-bold shrink-0">2.</span>
-            <span>The plant grows from <span className="text-white font-semibold">member activity</span> — deposits, votes, proposals, new members. <span className="text-white font-semibold">Not from trading P&amp;L.</span></span>
-          </li>
-          <li className="flex gap-3">
-            <span className="text-pot-green font-bold shrink-0">3.</span>
-            <span><span className="text-white font-semibold">⚔️ Pot duels</span> with other public pots <span className="text-white font-semibold">unlock at Level 3 (Bud)</span>.</span>
-          </li>
-        </ol>
-      </div>
+        <button
+          disabled
+          className="px-3 py-1.5 rounded-xl bg-pot-green/20 text-pot-green border border-pot-green/30 text-xs font-bold cursor-not-allowed opacity-60"
+          title="NFT mint ships at Bloom (Level 4) in Phase 3"
+        >
+          🪙 Mint NFT (Level 4+)
+        </button>
+      </header>
+      <p className="text-sm text-pot-muted">
+        The plant grows from <span className="text-white font-semibold">member activity</span> —
+        deposits, votes, proposals, new members. Not from trading P&amp;L. Pot duels unlock at Level 3.
+      </p>
 
-      {/* Current level + progress */}
-      <div className="bg-pot-card border border-pot-border rounded-2xl p-6">
-        <div className="flex items-start justify-between mb-4 gap-3 flex-wrap">
-          <div className="min-w-0">
-            <h3 className="font-bold text-white text-lg">Your pot&apos;s plant</h3>
-            <p className="text-pot-muted text-sm mt-1">
-              Level {level} · {TAMA_STAGES[level - 1].name} · HP {stats.hp}/100
-            </p>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <StatusBadge tier="phase-3" compact />
-            <button
-              disabled
-              className="px-4 py-2 rounded-xl bg-pot-green/20 text-pot-green border border-pot-green/30 text-sm font-bold cursor-not-allowed opacity-60"
-              title="NFT mint ships at Bloom (Level 4) in Phase 3"
+      <div className="flex items-center justify-between bg-pot-dark rounded-xl p-3">
+        {TAMA_STAGES.map((s) => (
+          <div key={s.lvl} className="flex flex-col items-center">
+            <div
+              className={`text-3xl transition ${
+                s.lvl === level ? 'scale-125' : s.lvl < level ? 'opacity-70' : 'opacity-25 grayscale'
+              }`}
             >
-              🪙 Mint NFT (Level 4+)
-            </button>
-          </div>
-        </div>
-        <div className="flex items-center justify-between bg-pot-dark rounded-xl p-4">
-          {TAMA_STAGES.map((s) => (
-            <div key={s.lvl} className="flex flex-col items-center">
-              <div
-                className={`text-4xl transition ${
-                  s.lvl === level ? 'scale-125' : s.lvl < level ? 'opacity-70' : 'opacity-25 grayscale'
-                }`}
-              >
-                {s.emoji}
-              </div>
-              <div className={`text-[10px] mt-1 ${s.lvl === level ? 'text-pot-green font-bold' : 'text-pot-muted'}`}>
-                L{s.lvl}
-              </div>
+              {s.emoji}
             </div>
-          ))}
+            <div className={`text-[10px] mt-1 ${s.lvl === level ? 'text-pot-green font-bold' : 'text-pot-muted'}`}>
+              L{s.lvl}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between text-xs text-pot-muted mb-1">
+          <span>Level {level} — {TAMA_STAGES[level - 1].name} · HP {stats.hp}/100</span>
+          <span>{stats.hp % 20}/20 to L{Math.min(level + 1, 5)}</span>
         </div>
-        <div className="mt-4">
-          <div className="flex items-center justify-between text-xs text-pot-muted mb-1">
-            <span>Progress to Level {Math.min(level + 1, 5)} ({TAMA_STAGES[Math.min(level, 4)].name})</span>
-            <span>{stats.hp % 20}/20</span>
-          </div>
-          <div className="h-2 bg-pot-dark rounded-full overflow-hidden">
-            <div className="h-full bg-gradient-to-r from-pot-green to-pot-accent" style={{ width: `${((stats.hp % 20) / 20) * 100}%` }} />
-          </div>
+        <div className="h-2 bg-pot-dark rounded-full overflow-hidden">
+          <div className="h-full bg-gradient-to-r from-pot-green to-pot-accent" style={{ width: `${((stats.hp % 20) / 20) * 100}%` }} />
         </div>
       </div>
 
-      {/* Activity that grows the plant */}
-      <div className="bg-pot-card border border-pot-border rounded-2xl p-6">
-        <h3 className="font-bold text-white mb-3">What feeds the plant</h3>
-        <ul className="space-y-2 text-sm text-pot-muted">
-          <li>💰 <span className="text-white">Deposits</span> — each new deposit feeds XP.</li>
-          <li>🗳️ <span className="text-white">Votes &amp; proposals</span> — active governance keeps HP high.</li>
-          <li>👥 <span className="text-white">New members</span> — community growth boosts the plant.</li>
-          <li>⏳ <span className="text-white">Continuous activity</span> — long stretches of inactivity decay HP.</li>
-        </ul>
-      </div>
-
-      {/* Level unlock table */}
-      <div className="bg-pot-card border border-pot-border rounded-2xl p-6">
-        <h3 className="font-bold text-white mb-3">What each level unlocks</h3>
-        <div className="space-y-2">
-          {TAMA_STAGES.map((s) => {
-            const reached = s.lvl <= level
-            return (
-              <div
-                key={s.lvl}
-                className={`flex items-start gap-3 p-3 rounded-xl border ${
-                  reached ? 'border-pot-green/30 bg-pot-green/5' : 'border-pot-border bg-pot-dark/40'
-                }`}
-              >
-                <span className={`text-2xl shrink-0 ${reached ? '' : 'opacity-40 grayscale'}`}>{s.emoji}</span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-bold text-white">L{s.lvl} · {s.name}</span>
-                    {reached && <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-pot-green/20 text-pot-green border border-pot-green/30">unlocked</span>}
-                  </div>
-                  <div className={`text-xs mt-0.5 ${reached ? 'text-pot-muted' : 'text-pot-muted/60'}`}>{s.unlock}</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {TAMA_STAGES.map((s) => {
+          const reached = s.lvl <= level
+          return (
+            <div
+              key={s.lvl}
+              className={`flex items-start gap-2 p-2.5 rounded-xl border ${
+                reached ? 'border-pot-green/30 bg-pot-green/5' : 'border-pot-border bg-pot-dark/40'
+              }`}
+            >
+              <span className={`text-lg shrink-0 ${reached ? '' : 'opacity-40 grayscale'}`}>{s.emoji}</span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-bold text-white text-xs">L{s.lvl} · {s.name}</span>
+                  {reached && (
+                    <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-pot-green/20 text-pot-green border border-pot-green/30">
+                      unlocked
+                    </span>
+                  )}
                 </div>
+                <div className={`text-[11px] mt-0.5 ${reached ? 'text-pot-muted' : 'text-pot-muted/60'}`}>{s.unlock}</div>
               </div>
-            )
-          })}
-        </div>
+            </div>
+          )
+        })}
       </div>
 
-      {/* Duels — gated at L3 */}
-      <div className={`bg-pot-card border rounded-2xl p-6 ${duelsUnlocked ? 'border-pot-accent/40' : 'border-pot-border'}`}>
-        <div className="flex items-start justify-between gap-3 flex-wrap">
+      <div className={`bg-pot-dark/40 border rounded-xl p-3 ${duelsUnlocked ? 'border-pot-accent/40' : 'border-pot-border'}`}>
+        <div className="flex items-center justify-between gap-3 flex-wrap">
           <div className="min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="font-bold text-white">⚔️ Duels</h3>
-              <StatusBadge tier="phase-3" compact />
-            </div>
-            <p className="text-sm text-pot-muted mt-1">
+            <p className="font-bold text-white text-sm">⚔️ Duels</p>
+            <p className="text-xs text-pot-muted">
               {duelsUnlocked
-                ? 'Challenge another public pot. Winner takes a slice of the loser&apos;s shares.'
-                : `Unlocks at Level 3 — Bud (your pot is at L${level}).`}
+                ? 'Challenge another public pot. Winner takes a slice of the loser’s shares.'
+                : `Unlocks at Level 3 — Bud (you’re at L${level}).`}
             </p>
           </div>
           <button
             disabled={!duelsUnlocked}
-            className={`px-4 py-2 rounded-xl text-sm font-bold border transition shrink-0 ${
+            className={`px-3 py-1.5 rounded-lg text-xs font-bold border transition shrink-0 ${
               duelsUnlocked
                 ? 'bg-pot-accent/20 hover:bg-pot-accent/40 text-pot-accent border-pot-accent/40'
                 : 'bg-pot-dark text-pot-muted border-pot-border cursor-not-allowed'
@@ -368,7 +304,7 @@ function TamagotchiTab({ stats }: { stats: ReturnType<typeof calculateTamaStats>
           </button>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 
@@ -395,7 +331,7 @@ export default function PotPage() {
     }
   }, [pubkey])
 
-  // Track referral in Supabase (replaces localStorage)
+  // Track referral in Supabase
   useEffect(() => {
     const ref = searchParams.get('ref')
     if (!ref || !pubkey || !isSupabaseConfigured) return
@@ -410,8 +346,7 @@ export default function PotPage() {
   const { data: proposals = [] } = useProposals(pubkey)
   const { role } = usePotRole(pubkey)
 
-  // Default landing tab is deposit — first thing user can do.
-  const [activeTab, setActiveTab] = useState<Tab>('deposit')
+  const [activeTab, setActiveTab] = useState<Tab>('trade')
   const [proposalFilter, setProposalFilter] = useState<'all' | 'active' | 'passed' | 'executed' | 'rejected'>('all')
   const [snsName, setSnsName] = useState<string>('')
   const [isMember, setIsMember] = useState(false)
@@ -448,7 +383,7 @@ export default function PotPage() {
         <div className="text-center max-w-md">
           <div className="text-5xl mb-4">❌</div>
           <h1 className="text-2xl font-bold text-white mb-2">Vault not found</h1>
-          <p className="text-pot-muted mb-4">This vault doesn't exist or has been closed.</p>
+          <p className="text-pot-muted mb-4">This vault doesn&apos;t exist or has been closed.</p>
           <Link href="/" className="inline-block px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-lg font-semibold transition">
             Back to Home
           </Link>
@@ -464,6 +399,7 @@ export default function PotPage() {
   const canVote = canManage
   const canExecute = isOwner
   const canWithdraw = canManage
+  const isLive = CLUSTER === 'mainnet-beta'
 
   const tamaStats = calculateTamaStats({
     tradeVolume: potAny.totalVolume ?? 0,
@@ -476,80 +412,68 @@ export default function PotPage() {
   const nextProposalId = (potAny.nextProposalId ?? proposals.length) as number
   const activeProposalsCount = proposals.filter((p: any) => p.status === 'active').length
 
+  const yourMember = userPubkey
+    ? members.find((m: any) => (m.wallet ?? m.pubkey) === userPubkey.toString())
+    : null
+  const yourSharePct = yourMember && potAny.totalShares > 0
+    ? (yourMember.shares / potAny.totalShares) * 100
+    : undefined
+
+  const lastSwapTx = potAny.lastSwapTx ?? potAny.lastSwapSignature
+  const squadsManaged = potAny.isSquadsVault === true
+
+  const goToDeposit = () => {
+    setActiveTab('trade')
+    requestAnimationFrame(() => {
+      document.getElementById('deposit-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }
+
+  const goToPropose = () => {
+    setActiveTab('trade')
+    requestAnimationFrame(() => {
+      document.getElementById('propose-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }
+
   return (
     <div className="min-h-screen bg-pot-dark pb-12">
-      {/* Header — in-flow (no internal sticky; global navbar handles sticking) */}
-      <div className="bg-gradient-to-b from-pot-card to-pot-dark border-b border-pot-border px-6 py-6">
-        <div className="max-w-[1400px] mx-auto">
-          <div className="flex items-start justify-between mb-4 gap-4 flex-wrap">
-            <div className="flex items-center gap-4 min-w-0">
-              <div className="text-6xl shrink-0">{pot.emoji}</div>
-              <div className="min-w-0">
-                <h1 className="text-3xl font-bold text-white mb-1 break-words">{pot.name}</h1>
-                {snsName && <p className="text-sm font-mono text-pot-green">{snsName}</p>}
-                <p className="text-xs text-pot-muted font-mono mt-1 break-all">{pubkey}</p>
-                <div className="mt-2">
-                  <span className="px-3 py-1 bg-pot-card border border-pot-border text-xs rounded-full text-pot-muted">
-                    You: {role === 'creator' ? 'Creator' : role === 'member' ? 'Member' : 'Viewer'}
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div className="flex flex-col items-end gap-2 shrink-0">
-              {userPubkey && (
-                <div className="flex gap-2 flex-wrap justify-end">
-                  {isOwner && (
-                    <Link
-                      href={`/pots/${pubkey}/settings`}
-                      className="px-3 py-2 text-xs bg-pot-border hover:bg-pot-accent/20 text-white rounded-lg transition"
-                    >
-                      ⚙️ Settings
-                    </Link>
-                  )}
-                  {isMember && !isOwner && (
-                    <button className="px-3 py-2 text-xs bg-pot-border hover:bg-red-500/20 text-pot-muted hover:text-red-400 rounded-lg transition">
-                      👋 Leave
-                    </button>
-                  )}
-                  {!isMember && !isOwner && (
-                    <button
-                      onClick={() => setActiveTab('deposit')}
-                      className="px-3 py-2 text-xs bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold rounded-lg transition"
-                    >
-                      + Join Vault
-                    </button>
-                  )}
-                </div>
-              )}
-              <div className="text-right">
-                <div className="text-xs text-pot-muted">Owner</div>
-                <p className="text-xs font-mono text-pot-green break-all max-w-xs text-right">{ownerAddress}</p>
-              </div>
-            </div>
-          </div>
+      {/* Sticky hero strip */}
+      <PotHeroStrip
+        emoji={pot.emoji}
+        name={pot.name}
+        snsName={snsName}
+        pubkey={pubkey}
+        ownerLabel={role === 'creator' ? 'Creator' : role === 'member' ? 'Member' : 'Viewer'}
+        isPublic={!!potAny.isPublic}
+        isLive={isLive}
+        squadsManaged={squadsManaged}
+        tvlSol={pot.balance}
+        members={pot.memberCount ?? members.length ?? 0}
+        yourSharePct={yourSharePct}
+        activeProposals={activeProposalsCount}
+        tamaHp={tamaStats.hp}
+        onDepositClick={goToDeposit}
+        onProposeClick={goToPropose}
+        canPropose={canManage}
+      />
 
-          {/* Status badges */}
-          <div className="flex gap-2 flex-wrap">
-            {potAny.isPublic && <span className="px-3 py-1 bg-pot-accent/20 text-pot-accent text-xs rounded-full font-semibold">🌍 Public</span>}
-            {potAny.isActive && <span className="px-3 py-1 bg-pot-green/20 text-pot-green text-xs rounded-full font-semibold">✓ Active</span>}
-            {isMember && <span className="px-3 py-1 bg-blue-500/20 text-blue-400 text-xs rounded-full font-semibold">🙋 Member</span>}
-            {isOwner && <span className="px-3 py-1 bg-pot-accent/30 text-pot-accent text-xs rounded-full font-semibold">👑 Owner</span>}
-            {tamaStats.hp < 30 && <span className="px-3 py-1 bg-red-500/20 text-red-400 text-xs rounded-full font-semibold">🔥 Low HP!</span>}
-          </div>
-        </div>
-      </div>
-
-      {/* Analytics strip — members only */}
-      {canManage && <VaultAnalyticsStrip pubkey={pubkey} />}
+      {/* Sponsor rail */}
+      <SponsorRail
+        potPubkey={pubkey}
+        lastSwapTx={lastSwapTx}
+        squadsManaged={squadsManaged}
+        cluster={CLUSTER}
+      />
 
       {/* Tabs row */}
-      <div className="border-b border-pot-border bg-pot-dark sticky top-0 z-30">
+      <div className="border-b border-pot-border bg-pot-dark">
         <div className="max-w-[1400px] mx-auto px-3 sm:px-6 flex gap-1 overflow-x-auto items-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {TABS.map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
-              className={`px-3 sm:px-4 py-3 text-xs sm:text-sm font-medium whitespace-nowrap transition shrink-0 ${
+              className={`px-3 sm:px-5 py-3 text-xs sm:text-sm font-semibold whitespace-nowrap transition shrink-0 ${
                 activeTab === tab
                   ? 'text-pot-accent border-b-2 border-pot-accent'
                   : 'text-pot-muted hover:text-white border-b-2 border-transparent'
@@ -561,211 +485,178 @@ export default function PotPage() {
         </div>
       </div>
 
-      {/* Content — full-width container */}
-      <div className="max-w-[1400px] mx-auto px-6 py-8 w-full">
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-6 sm:py-8 w-full">
 
-        {/* ── Deposit ── first action. Wallet-gated inline. */}
-        {activeTab === 'deposit' && (
-          <WalletGate
-            connected={!!userPubkey}
-            title="Connect your wallet to deposit"
-            subtitle="Deposit SOL and receive vault shares. You can withdraw per this vault's policy."
-          >
-            <DepositPanel potPubkey={pubkey} potName={pot.name} vaultBalance={pot.balance} />
-          </WalletGate>
-        )}
+        {/* ════════════════════ TRADE TAB ════════════════════
+            The killer demo flow. Everything a judge needs to see in 60s:
+            deposit → propose → vote → activity. */}
+        {activeTab === 'trade' && (
+          <div className="space-y-8 w-full">
 
-        {/* ── Overview ── key metrics + user's shares + P&L + active proposals.
-             NO tab-link duplication — the top tab bar already handles nav. */}
-        {activeTab === 'overview' && (
-          <div className="space-y-6 w-full">
-            {/* Metric tiles — min-w-[132px] sized for 8-char values, tabular-nums */}
-            <div className="flex gap-4 flex-wrap">
-              <MetricTile label="TVL (SOL)"    value={pot.balance.toFixed(2)} />
-              <MetricTile label="Members"      value={String(pot.memberCount ?? 0)} />
-              <MetricTile label="Proposals"    value={String(proposals.length)} accent={activeProposalsCount ? 'accent' : undefined} />
-              <MetricTile label="Active"       value={String(activeProposalsCount)} accent="accent" />
-              <MetricTile label="Trades"       value={String(pot.tradeCount ?? 0)} />
-              <MetricTile label="Total Shares" value={(pot.totalShares ?? 0).toLocaleString()} />
-              <MetricTile label="🌱 Tama HP"   value={`${tamaStats.hp}/100`} accent="green" />
-            </div>
+            {/* Squads banner if pot is multisig-managed */}
+            <SquadsBanner potPubkey={pubkey} />
 
-            {/* Your position & P&L — shown inline as dashboard summary.
-               Full management still lives in /shares and /positions tabs. */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 w-full">
-              <div className="lg:col-span-2 w-full">
-                <SharesPanel potPubkey={pubkey} />
+            {/* ── Deposit / Withdraw ── primary action */}
+            <section id="deposit-section" className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-bold text-white">💰 Deposit / Withdraw</h2>
+                <StatusBadge tier="live" compact />
               </div>
-              <div className="w-full space-y-6">
-                <PnLDashboard potPubkey={pubkey} vaultBalanceSol={pot.balance} />
-                <PotNotificationFeed potPubkey={pubkey} />
-              </div>
-            </div>
-
-            {/* Active proposals callout */}
-            {activeProposalsCount > 0 && (
-              <div className="bg-pot-accent/10 border border-pot-accent/30 rounded-2xl p-5 flex items-center justify-between gap-4 flex-wrap w-full">
-                <div>
-                  <p className="text-pot-accent font-bold">🗳️ {activeProposalsCount} active proposal{activeProposalsCount > 1 ? 's' : ''} need your vote</p>
-                  <p className="text-sm text-pot-muted mt-1">Participate in governance to shape this vault's strategy.</p>
-                </div>
-                <button
-                  onClick={() => setActiveTab('proposals')}
-                  className="px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-lg text-sm font-semibold transition shrink-0"
-                >
-                  Vote Now →
-                </button>
-              </div>
-            )}
-
-            {/* Strategy callout (if configured) */}
-            {potAny.yieldStrategy && (
-              <div className="bg-pot-card border border-pot-border/50 rounded-2xl p-6 w-full">
-                <div className="flex items-start gap-4">
-                  <div className="text-3xl">⚙️</div>
-                  <div className="flex-1">
-                    <h3 className="font-bold text-white mb-2">Active Strategy</h3>
-                    <p className="text-sm text-pot-muted mb-4">This vault runs an automated {potAny.yieldStrategy} strategy.</p>
-                    <button
-                      onClick={() => setActiveTab('strategy')}
-                      className="px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-lg text-sm font-semibold transition"
-                    >
-                      View Details
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Solana Blinks — share strip moved to bottom (point 6 — side feature, not main story) */}
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 rounded-2xl border border-pot-border bg-pot-card/50">
-              <div>
-                <div className="text-sm font-semibold text-white">⚡ Share as Solana Blink</div>
-                <div className="text-xs text-pot-muted mt-0.5">
-                  Post this pot on X — followers can deposit or vote without leaving the tweet.
-                </div>
-              </div>
-              <ShareBlinkButton potPubkey={pubkey} kind="deposit" />
-            </div>
-          </div>
-        )}
-
-        {/* ── Vault ── members / owner only */}
-        {activeTab === 'vault' && (
-          canManage ? (
-            <VaultTab potPubkey={pubkey} isCreator={isOwner} />
-          ) : (
-            <WalletGate
-              connected={!!userPubkey}
-              title="Connect wallet to check membership"
-              subtitle="Vault settings are visible to members and the owner."
-            >
-              <div className="bg-pot-card border border-pot-border rounded-2xl p-8 text-center">
-                <div className="text-4xl mb-4">🔒</div>
-                <p className="text-white font-semibold mb-2">Members only</p>
-                <p className="text-pot-muted text-sm mb-4">Join this vault to access vault settings.</p>
-                <button
-                  onClick={() => setActiveTab('deposit')}
-                  className="px-4 py-2 bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold rounded-lg transition"
-                >
-                  Deposit to Join
-                </button>
-              </div>
-            </WalletGate>
-          )
-        )}
-
-        {/* ── Proposals ── single "+ Create Proposal" opens categorized modal (Phase 2).
-             Modal maps each category to the right on-chain ProposalType. */}
-        {activeTab === 'proposals' && (
-          <div className="space-y-6 w-full">
-            {/* Header row with single CTA */}
-            {canManage && (
-              <div className="flex items-center justify-between gap-4 flex-wrap">
-                <div className="min-w-0">
-                  <h2 className="text-lg font-bold text-white">Proposals</h2>
-                  <p className="text-sm text-pot-muted">
-                    Propose a change, everyone with shares votes Yes/No.
-                  </p>
-                </div>
-                <button
-                  onClick={() => setProposalModalOpen(true)}
-                  className="px-5 py-2.5 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-xl text-sm font-bold transition shrink-0"
-                >
-                  + Create Proposal
-                </button>
-              </div>
-            )}
-
-            {!canManage && userPubkey && (
-              <div className="bg-pot-card border border-pot-border rounded-2xl p-5 flex items-center justify-between gap-4 flex-wrap">
-                <p className="text-pot-muted text-sm">Only members can create or vote on proposals.</p>
-                <button
-                  onClick={() => setActiveTab('deposit')}
-                  className="px-4 py-2 bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold rounded-lg text-sm transition"
-                >
-                  Deposit to Join
-                </button>
-              </div>
-            )}
-
-            {!userPubkey && (
               <WalletGate
-                connected={false}
-                title="Connect wallet to vote"
-                subtitle="Voting and proposal creation require a connected member wallet."
-              >{null}</WalletGate>
-            )}
+                connected={!!userPubkey}
+                title="Connect your wallet to deposit"
+                subtitle="Deposit SOL and receive vault shares. Withdraw anytime per this vault’s policy."
+              >
+                <DepositPanel potPubkey={pubkey} potName={pot.name} vaultBalance={pot.balance} />
+              </WalletGate>
+            </section>
 
-            {/* Proposals filter tabs */}
-            {proposals.length > 0 && (
-              <div className="flex items-center gap-2 overflow-x-auto pb-1 -mb-1">
-                {(['all','active','passed','executed','rejected'] as const).map((f) => {
-                  const count = f === 'all' ? proposals.length : proposals.filter((x: any) => x.status === f).length
-                  return (
+            {/* ── Active proposals ── 2-col layout: list + activity feed */}
+            <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div className="lg:col-span-2 space-y-3">
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-bold text-white">🗳️ Proposals</h2>
+                    {activeProposalsCount > 0 && (
+                      <span className="px-2 py-0.5 rounded-full bg-pot-accent/20 text-pot-accent text-[11px] font-bold animate-pulse">
+                        {activeProposalsCount} active
+                      </span>
+                    )}
+                  </div>
+                  {canManage && (
                     <button
-                      key={f}
-                      onClick={() => setProposalFilter(f)}
-                      className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium transition border ${
-                        proposalFilter === f
-                          ? 'bg-pot-accent/20 text-pot-accent border-pot-accent/30'
-                          : 'bg-pot-card text-pot-muted border-pot-border hover:text-white'
-                      }`}
+                      onClick={() => setProposalModalOpen(true)}
+                      className="px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-xl text-xs sm:text-sm font-bold transition"
                     >
-                      {f === 'all' ? 'All' : f.charAt(0).toUpperCase() + f.slice(1)}
-                      <span className="ml-1.5 text-[10px] opacity-60">{count}</span>
+                      + Create Proposal
                     </button>
-                  )
-                })}
-              </div>
-            )}
+                  )}
+                </div>
 
-            {/* Proposals list */}
-            {proposals.length === 0 ? (
-              <div className="text-center py-16 bg-pot-card border border-pot-border rounded-2xl w-full">
-                <div className="text-5xl mb-4">🗳️</div>
-                <p className="text-white font-semibold mb-1">No proposals yet</p>
-                <p className="text-pot-muted text-sm">
-                  {canManage ? 'Click "+ Create Proposal" to submit the first one.' : 'Join the vault to create proposals.'}
-                </p>
+                {!canManage && userPubkey && (
+                  <div className="bg-pot-card border border-pot-border rounded-2xl p-4 flex items-center justify-between gap-3 flex-wrap">
+                    <p className="text-pot-muted text-xs">Only members can vote or propose. Deposit to join.</p>
+                  </div>
+                )}
+
+                {proposals.length > 0 && (
+                  <div className="flex items-center gap-2 overflow-x-auto pb-1 -mb-1">
+                    {(['all','active','passed','executed','rejected'] as const).map((f) => {
+                      const count = f === 'all'
+                        ? proposals.length
+                        : proposals.filter((x: any) => x.status === f).length
+                      return (
+                        <button
+                          key={f}
+                          onClick={() => setProposalFilter(f)}
+                          className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium transition border ${
+                            proposalFilter === f
+                              ? 'bg-pot-accent/20 text-pot-accent border-pot-accent/30'
+                              : 'bg-pot-card text-pot-muted border-pot-border hover:text-white'
+                          }`}
+                        >
+                          {f === 'all' ? 'All' : f.charAt(0).toUpperCase() + f.slice(1)}
+                          <span className="ml-1.5 text-[10px] opacity-60">{count}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+
+                {proposals.length === 0 ? (
+                  <div className="text-center py-12 bg-pot-card border border-pot-border rounded-2xl">
+                    <div className="text-4xl mb-3">🗳️</div>
+                    <p className="text-white font-semibold mb-1">No proposals yet</p>
+                    <p className="text-pot-muted text-xs">
+                      {canManage
+                        ? 'Use the proposal builder below to draft your first swap.'
+                        : 'Join the vault to create proposals.'}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {proposals
+                      .filter((p: any) => proposalFilter === 'all' || p.status === proposalFilter)
+                      .slice(0, 6)
+                      .map((p: any) => (
+                        <ProposalCard
+                          key={p.pubkey}
+                          proposal={p}
+                          potAddress={pubkey}
+                          canVote={canVote}
+                          canExecute={canExecute}
+                        />
+                      ))}
+                  </div>
+                )}
               </div>
-            ) : (
+
               <div className="space-y-4">
-                {proposals
-                  .filter((p: any) => proposalFilter === 'all' || p.status === proposalFilter)
-                  .map((p: any) => (
-                    <ProposalCard
-                      key={p.pubkey}
-                      proposal={p}
-                      potAddress={pubkey}
-                      canVote={canVote}
-                      canExecute={canExecute}
-                    />
-                  ))}
-              </div>
-            )}
+                <PotActivityFeed pot={pot} proposals={proposals} members={members} cluster={CLUSTER} />
 
-            {/* Modal */}
+                <div className="bg-pot-card border border-pot-border rounded-2xl p-4 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-base">⚡</span>
+                    <h4 className="font-bold text-white text-sm">Share as Solana Blink</h4>
+                  </div>
+                  <p className="text-[11px] text-pot-muted">
+                    Post this pot on X. Followers can deposit or vote without leaving the tweet.
+                  </p>
+                  <ShareBlinkButton potPubkey={pubkey} kind="deposit" />
+                </div>
+              </div>
+            </section>
+
+            {/* ── Propose Swap (StrategyProposalBuilder) ── */}
+            <section id="propose-section" className="space-y-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h2 className="text-lg font-bold text-white">🛠️ Propose a swap</h2>
+                <StatusBadge tier="live" compact label="Live · Jupiter v6 CPI" />
+              </div>
+              <StrategyProposalBuilder
+                potName={pot.name}
+                potBalanceSol={pot.balance}
+                onSubmit={() => setProposalModalOpen(true)}
+              />
+              <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
+                <summary className="cursor-pointer text-xs text-pot-muted hover:text-white">
+                  Legacy strategy panel (debug)
+                </summary>
+                <div className="mt-3">
+                  <StrategyPanel potPubkey={pubkey} />
+                </div>
+              </details>
+            </section>
+
+            {/* ── Holdings preview ── shares + P&L + portfolio collapsed by default */}
+            <section className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-bold text-white">📊 Holdings</h2>
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <div className="lg:col-span-2"><SharesPanel potPubkey={pubkey} /></div>
+                <div><PnLDashboard potPubkey={pubkey} vaultBalanceSol={pot.balance} /></div>
+              </div>
+              {vaultPda && (
+                <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
+                  <summary className="cursor-pointer text-sm text-white font-semibold">
+                    🔎 Vault portfolio (live, Dune SIM)
+                  </summary>
+                  <div className="mt-4">
+                    <VaultPortfolio vaultPda={vaultPda} potName={pot.name} />
+                  </div>
+                </details>
+              )}
+              <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
+                <summary className="cursor-pointer text-sm text-white font-semibold">
+                  🪙 Manage shares (withdraw)
+                </summary>
+                <div className="mt-4">
+                  <SharesTab potPubkey={pubkey} canWithdraw={canWithdraw} />
+                </div>
+              </details>
+            </section>
+
             <CreateProposalModal
               open={proposalModalOpen}
               onClose={() => setProposalModalOpen(false)}
@@ -778,92 +669,49 @@ export default function PotPage() {
           </div>
         )}
 
-        {/* ── Tamagotchi ── Phase 1 placeholder with evolution + mechanics + L3-gated duels */}
-        {activeTab === 'tamagotchi' && <TamagotchiTab stats={tamaStats} />}
-
-        {/* ── Shares ── */}
-        {activeTab === 'shares' && (
-          <div className="space-y-4">
-            <div className="flex justify-end">
-              <button
-                disabled={!canWithdraw}
-                title={!canWithdraw ? 'Members only' : undefined}
-                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Withdraw
-              </button>
-            </div>
-            <SharesTab potPubkey={pubkey} canWithdraw={canWithdraw} />
-          </div>
-        )}
-
-        {/* ── Positions / P&L — powered by Dune SIM ── */}
-        {activeTab === 'positions' && (
-          <div className="space-y-6 w-full">
-            {/* Real-time vault portfolio: token balances + USD values + activity feed */}
-            {vaultPda && (
-              <VaultPortfolio vaultPda={vaultPda} potName={pot.name} />
-            )}
-            {/* PnL dashboard (mock-mode / on-chain) */}
-            <PnLDashboard potPubkey={pubkey} vaultBalanceSol={pot.balance} />
-          </div>
-        )}
-
-
-        {/* ── Analytics ── */}
-        {activeTab === 'analytics' && (
-          <PotAnalyticsWidget potPubkey={pubkey} vaultPubkey={vaultPda || undefined} />
-        )}
-
-        {/* ── Strategy ── proposal builder. Picking the action + token + amount
-             prefills a swap proposal; "Submit as Proposal" opens the standard
-             governance modal where the proposal is finalised and signed. */}
-        {activeTab === 'strategy' && (
-          <div className="space-y-4">
-            <SquadsBanner potPubkey={pubkey} />
-            <StrategyProposalBuilder
-              potName={pot.name}
-              potBalanceSol={pot.balance}
-              onSubmit={() => setProposalModalOpen(true)}
-            />
-            <details className="bg-pot-card border border-pot-border rounded-2xl p-5">
-              <summary className="cursor-pointer font-bold text-white">Legacy strategy panel</summary>
-              <div className="mt-4">
-                <StrategyPanel potPubkey={pubkey} />
+        {/* ════════════════════ COMMUNITY TAB ════════════════════ */}
+        {activeTab === 'community' && (
+          <div className="space-y-8 w-full">
+            <section className="space-y-3">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-lg font-bold text-white">👥 Members</h2>
+                  <span className="text-xs text-pot-muted">
+                    {members.length} member{members.length === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <ShareBlinkButton potPubkey={pubkey} kind="deposit" />
               </div>
-            </details>
+              <MembersList
+                members={members}
+                totalShares={pot.totalShares ?? 0}
+                ownerAddress={ownerAddress}
+                cluster={CLUSTER}
+              />
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-bold text-white">🏛️ Governance</h2>
+                <StatusBadge tier={isLive ? 'live' : 'devnet'} compact />
+              </div>
+              <SquadsBanner potPubkey={pubkey} />
+              <GovernanceSettings isAdmin={isOwner} potPubkey={pubkey} />
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-bold text-white">🔗 Referral</h2>
+                <StatusBadge tier="live" compact />
+              </div>
+              <ReferralPanel potPubkey={pubkey} potName={pot.name} />
+            </section>
           </div>
         )}
 
-        {/* ── Governance Settings ── */}
-        {activeTab === 'governance' && (
-          <div className="space-y-4">
-            <SquadsBanner potPubkey={pubkey} />
-            <div className="flex gap-2 justify-end">
-              <button
-                disabled={!isOwner}
-                title={!isOwner ? 'Creator only' : undefined}
-                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Add Member
-              </button>
-              <button
-                disabled={!isOwner}
-                title={!isOwner ? 'Creator only' : undefined}
-                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Remove Member
-              </button>
-            </div>
-            <GovernanceSettings isAdmin={isOwner} potPubkey={pubkey} />
-          </div>
-        )}
-
-        {/* ── AI Agent — two-tier:
-             1. PotBot AI (always-on) decision-support feed,
-             2. User AI delegate (opt-in) with rules & strategy presets. */}
-        {activeTab === 'agent' && (
-          <div className="space-y-4">
+        {/* ════════════════════ AI TAB ════════════════════ */}
+        {activeTab === 'ai' && (
+          <div className="space-y-6 w-full">
             <PotBotAISuggestions
               potPubkey={pubkey}
               potName={pot.name}
@@ -888,51 +736,59 @@ export default function PotPage() {
           </div>
         )}
 
-        {/* ── Members ── */}
-        {activeTab === 'members' && (
-          <div className="space-y-4 w-full">
-            <div className="flex justify-end">
-              <button
-                disabled={!isOwner}
-                title={!isOwner ? 'Creator only' : undefined}
-                className="px-4 py-2 rounded-lg border border-pot-border text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        {/* ════════════════════ FEATURES TAB ════════════════════
+            Roadmap surface: Tamagotchi · Premium · Privacy preview.
+            Each block carries its phase chip; nothing is hidden, nothing is
+            over-promised. Links to /roadmap for the full inventory. */}
+        {activeTab === 'features' && (
+          <div className="space-y-6 w-full">
+            <div className="bg-pot-card/50 border border-pot-border rounded-2xl p-5 flex items-center justify-between gap-3 flex-wrap">
+              <div>
+                <p className="text-white font-semibold">🗺️ Want the full picture?</p>
+                <p className="text-xs text-pot-muted mt-0.5">
+                  See every PotBot feature and its phase on the public roadmap.
+                </p>
+              </div>
+              <Link
+                href="/roadmap"
+                className="px-4 py-2 bg-pot-accent hover:bg-pot-accent/90 text-white rounded-xl text-xs font-bold transition shrink-0"
               >
-                Manage
-              </button>
+                Open /roadmap →
+              </Link>
             </div>
-            {members.length === 0 ? (
-              <div className="text-center py-12 bg-pot-card border border-pot-border rounded-2xl">
-                <p className="text-pot-muted">No members yet</p>
+
+            <TamagotchiBlock stats={tamaStats} />
+
+            <PremiumFeatures
+              potPubkey={new PublicKey(pubkey)}
+              potName={pot.name}
+              tamagotchiLevel={Math.max(1, Math.min(5, Math.floor(tamaStats.hp / 20) + 1))}
+              isTokenized={!!potAny.isTokenized}
+              hasSnsdomain={!!snsName}
+              hasTamagotchiNft={!!potAny.hasTamagotchiNft}
+              snsAddress={snsName || undefined}
+            />
+
+            <section className="bg-pot-card border border-pot-border rounded-2xl p-5 sm:p-6 space-y-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-2xl">🔒</span>
+                <h3 className="font-bold text-white text-lg">STAMPPOT — privacy preview</h3>
+                <StatusBadge tier="phase-3" compact />
               </div>
-            ) : (
-              <div className="space-y-2">
-                {members.map((m: any, i: number) => {
-                  const addr = m.wallet ?? m.pubkey ?? 'unknown'
-                  const sharesPct = pot.totalShares > 0
-                    ? ((m.shares / pot.totalShares) * 100).toFixed(1)
-                    : '0.0'
-                  return (
-                    <div key={addr + i} className="flex items-center justify-between bg-pot-card border border-pot-border rounded-xl p-4">
-                      <div className="min-w-0 flex-1 mr-4">
-                        <p className="text-white font-mono text-sm break-all">{addr}</p>
-                        {m.joinedAt && (
-                          <p className="text-xs text-pot-muted mt-0.5">Joined {new Date(m.joinedAt).toLocaleDateString()}</p>
-                        )}
-                      </div>
-                      <div className="text-right shrink-0">
-                        <p className="text-white font-bold tabular-nums">{m.shares?.toLocaleString() ?? 0} shares</p>
-                        <p className="text-xs text-pot-muted tabular-nums">{sharesPct}%</p>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
+              <p className="text-sm text-pot-muted">
+                Auditable-Private mode adds a privacy layer to deposits and votes via
+                PrivacyCash Merkle membership proofs and stealth addresses. Same Anchor
+                program, same governance, just with shielded balances. Ships in Phase 3.
+              </p>
+              <Link
+                href="/roadmap#phase-3"
+                className="inline-block text-xs text-pot-accent hover:underline"
+              >
+                Read the architecture spec →
+              </Link>
+            </section>
           </div>
         )}
-
-        {/* ── Referral ── */}
-        {activeTab === 'referral' && <ReferralPanel potPubkey={pubkey} potName={pot.name} />}
       </div>
     </div>
   )

--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -27,6 +27,7 @@ import { SquadsBanner } from '@/components/SquadsBanner'
 import { ShareBlinkButton } from '@/components/ShareBlinkButton'
 import { StrategyProposalBuilder } from '@/components/StrategyProposalBuilder'
 import { PotBotAISuggestions } from '@/components/PotBotAISuggestions'
+import { StatusBadge } from '@/components/StatusBadge'
 import { reverseSNS } from '@/lib/sns'
 import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import SwapExecuteButton from '@/components/SwapExecuteButton'
@@ -265,13 +266,16 @@ function TamagotchiTab({ stats }: { stats: ReturnType<typeof calculateTamaStats>
               Level {level} · {TAMA_STAGES[level - 1].name} · HP {stats.hp}/100
             </p>
           </div>
-          <button
-            disabled
-            className="px-4 py-2 rounded-xl bg-pot-green/20 text-pot-green border border-pot-green/30 text-sm font-bold cursor-not-allowed opacity-60 shrink-0"
-            title="NFT mint ships at Bloom (Level 4)"
-          >
-            🪙 Mint NFT (Level 4+)
-          </button>
+          <div className="flex items-center gap-2 shrink-0">
+            <StatusBadge tier="phase-3" compact />
+            <button
+              disabled
+              className="px-4 py-2 rounded-xl bg-pot-green/20 text-pot-green border border-pot-green/30 text-sm font-bold cursor-not-allowed opacity-60"
+              title="NFT mint ships at Bloom (Level 4) in Phase 3"
+            >
+              🪙 Mint NFT (Level 4+)
+            </button>
+          </div>
         </div>
         <div className="flex items-center justify-between bg-pot-dark rounded-xl p-4">
           {TAMA_STAGES.map((s) => (
@@ -342,7 +346,10 @@ function TamagotchiTab({ stats }: { stats: ReturnType<typeof calculateTamaStats>
       <div className={`bg-pot-card border rounded-2xl p-6 ${duelsUnlocked ? 'border-pot-accent/40' : 'border-pot-border'}`}>
         <div className="flex items-start justify-between gap-3 flex-wrap">
           <div className="min-w-0">
-            <h3 className="font-bold text-white">⚔️ Duels</h3>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="font-bold text-white">⚔️ Duels</h3>
+              <StatusBadge tier="phase-3" compact />
+            </div>
             <p className="text-sm text-pot-muted mt-1">
               {duelsUnlocked
                 ? 'Challenge another public pot. Winner takes a slice of the loser&apos;s shares.'
@@ -870,6 +877,7 @@ export default function PotPage() {
                 <span className="text-[10px] px-2 py-0.5 rounded-full bg-pot-border text-pot-muted uppercase tracking-wide">
                   user layer
                 </span>
+                <StatusBadge tier="devnet" compact />
               </div>
               <p className="text-xs text-pot-muted mb-4 break-words">
                 Sits on top of the base layer. Configure rules, presets and a delegate so your AI

--- a/apps/web/src/app/roadmap/page.tsx
+++ b/apps/web/src/app/roadmap/page.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import Link from 'next/link'
+import { StatusBadge, type StatusTier } from '@/components/StatusBadge'
+
+interface Feature {
+  name: string
+  desc: string
+  doc?: string
+  emoji?: string
+}
+
+interface Section {
+  tier: StatusTier
+  title: string
+  blurb: string
+  features: Feature[]
+}
+
+const SECTIONS: Section[] = [
+  {
+    tier: 'live',
+    title: 'Live · mainnet',
+    blurb: 'Working today. Verifiable on Solana Explorer. The judge clicks through and watches it run.',
+    features: [
+      { emoji: '🪴', name: 'pot_vault Anchor program', desc: '30+ instructions deployed: create_pot, deposit, withdraw, vote, execute_swap, pot_admin, treasury config.', doc: '/docs/architecture/program' },
+      { emoji: '⚡', name: 'execute_swap with Jupiter v6 CPI', desc: 'Vault PDA signs the swap directly. Three modes (AdminDirect / Proposal / StrategyTrigger) in one instruction with strict mode-source matching.' },
+      { emoji: '🗳️', name: 'On-chain governance + voting', desc: 'Proposal → vote → mark_proposal_passed → execute. Quorum, approval %, risk caps configurable per pot.' },
+      { emoji: '🪙', name: 'Solana Blinks (vote + deposit)', desc: 'GET / POST endpoints at /api/actions/[potPubkey]/{deposit,vote}. Pot proposal becomes a tweet anyone can act on without leaving X.' },
+      { emoji: '🤖', name: '@potbot/mcp on npm', desc: '18 tools (free + paid via x402). HTTP+SSE+stdio transports. Any LLM can drive a pot.' },
+      { emoji: '🛡️', name: 'Helius RPC + webhooks', desc: 'Priority fees, realtime pot events to Supabase, off-chain mirror for analytics.' },
+      { emoji: '🤝', name: 'Squads v4 multisig (creator role)', desc: 'High-value pots can be owned by a Squads multisig instead of a single key. Banner + lib live.' },
+      { emoji: '📊', name: 'Public leaderboard', desc: 'Live ranking by Season Score = volume × members × pet_health.' },
+    ],
+  },
+  {
+    tier: 'devnet',
+    title: 'Devnet · mainnet target this sprint',
+    blurb: 'Proven on devnet. Mainnet cut targeted within the current quarter.',
+    features: [
+      { emoji: '⚙️', name: 'Strategy slot accounts', desc: 'create_strategy, close_strategy, mark_proposal_passed. Strategy parks on-chain, AI agents and keepers can attach to slots.' },
+      { emoji: '🌱', name: 'Tamagotchi state machine', desc: 'Five levels (Seedling → Sprout → Bud → Bloom → Mature Tree). HP grows from member activity, not P&L.', doc: '/docs/architecture/governance' },
+      { emoji: '🪪', name: 'Personal AI Voters', desc: 'MemberDelegate + vote_as_delegate. Members register an AI agent wallet to vote on their behalf, revocable on-chain with a reason string.' },
+      { emoji: '🤖', name: 'PotBot AI suggestion feed', desc: 'Decision-support layer surfacing 4 candidate proposals every 60s with confidence + impact %. Vote still required.' },
+      { emoji: '📈', name: 'Dune SIM portfolio + activity', desc: 'Vault holdings + tx history via Dune SIM SVM endpoints. Drives leaderboard TVL and keeper pre-flight checks.' },
+      { emoji: '🎛️', name: 'Strategy proposal builder', desc: 'Token search (ticker or contract address) → action select → amount slider → preview → submit as proposal.' },
+    ],
+  },
+  {
+    tier: 'phase-2',
+    title: 'Phase 2 · Q3 2026',
+    blurb: 'Designed and scaffolded in code. Ships next quarter.',
+    features: [
+      { emoji: '🔐', name: 'Pyth in-program oracle guard', desc: 'execute_swap re-reads Pyth price feeds inside the instruction and rejects keepers that fire on the wrong condition. Triggers cannot be faked.' },
+      { emoji: '🌾', name: 'Meteora DLMM + DAMM yield CPI', desc: 'Park idle pot capital in Meteora pools. CPI path scaffolded, yield_strategy field on PotAccount supports it.' },
+      { emoji: '🏦', name: 'Kamino lending CPI', desc: 'Lending-based yield strategy as an alternative to Meteora. Same allocation surface.' },
+      { emoji: '✉️', name: 'Privy embedded wallets', desc: 'Email + social login + Solana auto-create wallet. PR #32 ready, awaiting Privy app ID.' },
+      { emoji: '🪶', name: 'Light Protocol ZK-compressed audit log', desc: 'SwapEvent + NavSnapshot compressed accounts cut rent ~5000× while keeping full on-chain audit trail.', doc: '/docs/architecture/architecture-onchain' },
+      { emoji: '🪙', name: 'init_share_mint graduation', desc: 'Off-chain shares (Seedling) graduate to on-chain SPL mint at Sprout+. Members hold transferable, DeFi-composable share tokens.', doc: '/docs/architecture/etf-token-system' },
+      { emoji: '🎯', name: 'Advanced strategies (SL / TP / trailing / DCA)', desc: 'Stop-loss, take-profit, trailing-stop, recurring DCA — all built on the existing proposal flow.' },
+    ],
+  },
+  {
+    tier: 'phase-3',
+    title: 'Phase 3 · Q4 2026',
+    blurb: 'Architecture set. Some UI placeholders already in the app.',
+    features: [
+      { emoji: '🎨', name: 'Tamagotchi NFT mint', desc: 'Soulbound NFT minted at Bloom (L4). Metadata via Metaplex Token Metadata, evolves with pot stage.' },
+      { emoji: '⚔️', name: 'Pot duels', desc: 'Vault-vs-vault PnL competition unlocked at Bud (L3). Winner takes a slice of the loser\'s shares.' },
+      { emoji: '💎', name: 'Premium tier', desc: 'SNS subdomain (yourpot.potbot.sol), share tokenization (tokenize_pot), priority on-chain features. Currently visible as "Available" placeholders.' },
+      { emoji: '🥷', name: 'STAMPPOT — Auditable-Private mode', desc: 'PrivacyCash deposits + Merkle membership proofs + stealth addresses. Vault balance still public; the wallet-to-share link is hidden.', doc: '/docs/architecture/private-pots' },
+    ],
+  },
+  {
+    tier: 'vision',
+    title: 'Vision · 2027+',
+    blurb: 'Pitch-deck. No code yet. The product will get here.',
+    features: [
+      { emoji: '🔒', name: 'STAMPPOT — Sealed-Private mode', desc: 'Commit-reveal voting, encrypted strategy params, shielded balances via Light Protocol confidential transfer.' },
+      { emoji: '📱', name: 'Saga / Seeker dApp Store entry', desc: 'PWA manifest is mainnet-ready; dApp Store listing with on-device wallet integration is the next mobile step.' },
+      { emoji: '🪙', name: '$POT governance token', desc: 'Protocol fee buyback + season distribution to Money Tree winners. Honest emissions, no airdrop farming.' },
+      { emoji: '🔗', name: 'Cross-pot composability', desc: 'One member, many pots, single unified portfolio view. Squads v4 as kill_switch_admin for all Sealed pots.' },
+      { emoji: '✅', name: 'Adevar Labs audit', desc: 'Full security audit before mainnet GA push.' },
+    ],
+  },
+]
+
+export default function RoadmapPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 space-y-12">
+      <header>
+        <div className="flex items-center gap-3 mb-3 flex-wrap">
+          <span className="text-3xl">🗺️</span>
+          <h1 className="text-3xl sm:text-4xl font-black text-white">PotBot — Full Roadmap</h1>
+        </div>
+        <p className="text-pot-muted text-sm sm:text-base leading-relaxed max-w-2xl">
+          Every feature, every integration, with an explicit lifecycle chip. We ship what&apos;s
+          live, scaffold what&apos;s next, and tell you the truth about what&apos;s still on paper.
+          Group trading on Solana — the whole arc.
+        </p>
+        <div className="flex flex-wrap items-center gap-2 mt-4">
+          <StatusBadge tier="live" compact />
+          <StatusBadge tier="devnet" compact />
+          <StatusBadge tier="phase-2" compact />
+          <StatusBadge tier="phase-3" compact />
+          <StatusBadge tier="vision" compact />
+        </div>
+      </header>
+
+      {SECTIONS.map((section) => (
+        <section key={section.tier}>
+          <div className="flex items-center gap-3 mb-2 flex-wrap">
+            <h2 className="text-xl sm:text-2xl font-bold text-white">{section.title}</h2>
+            <StatusBadge tier={section.tier} compact />
+          </div>
+          <p className="text-sm text-pot-muted mb-5 max-w-2xl break-words">{section.blurb}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {section.features.map((f) => (
+              <div key={f.name} className="card p-4 sm:p-5">
+                <div className="flex items-start gap-3">
+                  {f.emoji && <span className="text-2xl shrink-0">{f.emoji}</span>}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="font-bold text-white text-sm sm:text-base break-words">{f.name}</h3>
+                    </div>
+                    <p className="text-xs sm:text-sm text-pot-muted mt-1 break-words leading-relaxed">{f.desc}</p>
+                    {f.doc && (
+                      <Link
+                        href={f.doc}
+                        className="inline-block mt-2 text-[11px] text-pot-accent hover:text-white transition"
+                      >
+                        Spec →
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <footer className="border-t border-pot-border pt-8 text-sm text-pot-muted">
+        <p className="break-words">
+          Mainnet program: <code className="font-mono text-pot-green text-xs break-all">GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK</code>
+        </p>
+        <p className="mt-2">
+          Submission writeup: <Link href="/" className="text-pot-accent hover:text-white">potbot.fun</Link> ·
+          Repo: <a href="https://github.com/YD811/potbot-v2" target="_blank" rel="noreferrer" className="text-pot-accent hover:text-white">github.com/YD811/potbot-v2</a>
+        </p>
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/src/components/CreatePrivatePotForm.tsx
+++ b/apps/web/src/components/CreatePrivatePotForm.tsx
@@ -6,6 +6,8 @@ import { PotSDK } from '@potbot/sdk';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 
+import { StatusBadge } from '@/components/StatusBadge'
+
 interface CreatePrivatePotFormProps {
   onSuccess?: () => void;
 }
@@ -91,7 +93,7 @@ export function CreatePrivatePotForm({ onSuccess }: CreatePrivatePotFormProps) {
         <div className="flex items-center space-x-3 mb-6">
           <span className="text-3xl">🔐</span>
           <div>
-            <h2 className="text-xl font-semibold text-white">Create Private Pot</h2>
+            <h2 className="text-xl font-semibold text-white">Create Private Pot</h2> <StatusBadge tier="phase-3" compact />
             <p className="text-pot-muted">Invite-only trading vault</p>
           </div>
         </div>

--- a/apps/web/src/components/MembersList.tsx
+++ b/apps/web/src/components/MembersList.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * MembersList — richer member roster with copy-pubkey, share %, joined date,
+ * delegate status, owner crown.
+ *
+ * Replaces the inline rendering that was previously in pots/[pubkey]/page.tsx
+ * Members tab. Drop-in: same shape of `members` and `pot` from React-Query.
+ */
+
+interface Member {
+  wallet?: string
+  pubkey?: string
+  shares?: number
+  joinedAt?: string | number
+  delegateActive?: boolean
+}
+
+interface Props {
+  members: Member[]
+  totalShares: number
+  ownerAddress?: string
+  cluster?: 'mainnet-beta' | 'devnet'
+}
+
+function abbreviate(addr?: string) {
+  if (!addr) return 'unknown'
+  if (addr.length <= 12) return addr
+  return `${addr.slice(0, 6)}…${addr.slice(-6)}`
+}
+
+function jdenticonGradient(seed: string) {
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) {
+    hash = seed.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  const h1 = hash & 0xff
+  const h2 = (hash >> 8) & 0xff
+  return `linear-gradient(135deg, hsl(${h1},70%,50%), hsl(${h2},70%,40%))`
+}
+
+export function MembersList({ members, totalShares, ownerAddress, cluster = 'devnet' }: Props) {
+  const [copied, setCopied] = useState<string | null>(null)
+  const explorerSuffix = cluster === 'mainnet-beta' ? '' : '?cluster=devnet'
+
+  const copy = (s: string) => {
+    navigator.clipboard.writeText(s)
+    setCopied(s)
+    setTimeout(() => setCopied(null), 1200)
+  }
+
+  if (!members || members.length === 0) {
+    return (
+      <div className="text-center py-12 bg-pot-card border border-pot-border rounded-2xl">
+        <div className="text-4xl mb-3">👻</div>
+        <p className="text-white font-semibold mb-1">No members yet</p>
+        <p className="text-sm text-pot-muted">Share this pot or post it as a Solana Blink to invite people.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {members.map((m, i) => {
+        const addr = m.wallet ?? m.pubkey ?? 'unknown'
+        const shares = m.shares ?? 0
+        const sharesPct = totalShares > 0 ? (shares / totalShares) * 100 : 0
+        const isOwner = ownerAddress && addr === ownerAddress
+        return (
+          <div
+            key={addr + i}
+            className="flex items-center justify-between gap-3 bg-pot-card border border-pot-border hover:border-pot-accent/30 rounded-xl p-3 sm:p-4 transition"
+          >
+            <div className="flex items-center gap-3 min-w-0 flex-1">
+              <div
+                className="shrink-0 w-10 h-10 rounded-full ring-2 ring-pot-border"
+                style={{ background: jdenticonGradient(addr) }}
+                aria-hidden
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button
+                    onClick={() => copy(addr)}
+                    className="text-white font-mono text-sm hover:text-pot-green transition truncate"
+                    title={addr}
+                  >
+                    {abbreviate(addr)}
+                  </button>
+                  {copied === addr && (
+                    <span className="text-[10px] text-pot-green">copied ✓</span>
+                  )}
+                  {isOwner && (
+                    <span className="px-1.5 py-0.5 rounded-full bg-pot-accent/20 text-pot-accent text-[10px] font-bold uppercase tracking-wide">
+                      👑 Creator
+                    </span>
+                  )}
+                  {m.delegateActive && (
+                    <span className="px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-300 text-[10px] font-semibold uppercase tracking-wide">
+                      🤖 AI delegate
+                    </span>
+                  )}
+                </div>
+                <div className="text-[11px] text-pot-muted mt-0.5 flex items-center gap-2">
+                  {m.joinedAt && <span>Joined {new Date(m.joinedAt).toLocaleDateString()}</span>}
+                  <a
+                    href={`https://explorer.solana.com/address/${addr}${explorerSuffix}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-pot-green transition"
+                  >
+                    Explorer ↗
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div className="text-right shrink-0">
+              <p className="text-white font-bold tabular-nums text-sm">{shares.toLocaleString()}</p>
+              <p className="text-[11px] text-pot-muted tabular-nums">{sharesPct.toFixed(1)}%</p>
+              <div className="mt-1 w-20 h-1 bg-pot-dark rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-pot-green to-pot-accent"
+                  style={{ width: `${Math.min(100, sharesPct)}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -74,6 +74,7 @@ const NAV_LINKS = [
   { href: '/',            label: 'Home' },
   { href: '/leaderboard', label: '🏆 Leaderboard' },
   { href: '/vaults',      label: '⚡ Vaults' },
+  { href: '/roadmap',     label: '🗺️ Roadmap' },
   { href: '/create',      label: '+ Create' },
 ]
 

--- a/apps/web/src/components/OnboardingTutorial.tsx
+++ b/apps/web/src/components/OnboardingTutorial.tsx
@@ -40,7 +40,7 @@ const STEPS: Step[] = [
     emoji: '🌱',
     title: 'Grow Your Plant',
     body: 'Your pot\'s plant grows with community activity — deposits, votes, proposals, and new members all boost plant health. Top 3 plants on the Season 1 leaderboard win prize pool rewards.',
-    highlight: 'Plant health is activity-based. Not tied to trading P&L.',
+    highlight: 'Plant health is activity-based. NFT mint + duels ship in later phases.',
   },
 ]
 

--- a/apps/web/src/components/PotActivityFeed.tsx
+++ b/apps/web/src/components/PotActivityFeed.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useMemo } from 'react'
+
+/**
+ * PotActivityFeed — last few events for a pot (proposal created / passed /
+ * executed / new member, etc).
+ *
+ * Phase 1 implementation: synthesises events from the data we already have in
+ * the React-Query cache (proposals + members + pot stats). When a real
+ * Helius-powered event stream lands in apps/api, swap this component's data
+ * source for a useEvents() hook.
+ */
+
+interface Event {
+  id: string
+  ts: number
+  kind: 'proposal-created' | 'proposal-passed' | 'proposal-executed' | 'proposal-rejected' | 'member-joined' | 'pot-created'
+  text: string
+  /** optional Solana Explorer link target — proposal pubkey or member wallet */
+  explorerAddress?: string
+}
+
+interface Props {
+  pot: any
+  proposals: any[]
+  members: any[]
+  cluster?: 'mainnet-beta' | 'devnet'
+  limit?: number
+}
+
+const KIND_META: Record<Event['kind'], { icon: string; color: string }> = {
+  'proposal-created':  { icon: '🗳️', color: 'text-pot-accent' },
+  'proposal-passed':   { icon: '✅', color: 'text-pot-green' },
+  'proposal-executed': { icon: '🚀', color: 'text-blue-300' },
+  'proposal-rejected': { icon: '❌', color: 'text-red-400' },
+  'member-joined':     { icon: '👋', color: 'text-amber-300' },
+  'pot-created':       { icon: '🪴', color: 'text-pot-green' },
+}
+
+function formatRelative(ts: number) {
+  const seconds = Math.floor((Date.now() - ts) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(ts).toLocaleDateString()
+}
+
+export function PotActivityFeed({ pot, proposals, members, cluster = 'devnet', limit = 6 }: Props) {
+  const events: Event[] = useMemo(() => {
+    const out: Event[] = []
+    const explorerSuffix = cluster === 'mainnet-beta' ? '' : '?cluster=devnet'
+
+    if (pot?.createdAt) {
+      out.push({
+        id: 'pot-created',
+        ts: new Date(pot.createdAt).getTime(),
+        kind: 'pot-created',
+        text: `Pot created — ${pot.name ?? 'unnamed'}`,
+      })
+    }
+
+    for (const p of proposals ?? []) {
+      const ts = new Date(p.createdAt ?? p.created_at ?? Date.now()).getTime()
+      const desc = (p.description ?? `Proposal #${p.proposalId ?? '?'}`).slice(0, 80)
+      out.push({
+        id: `prop-${p.pubkey}-c`,
+        ts,
+        kind: 'proposal-created',
+        text: desc,
+        explorerAddress: p.pubkey,
+      })
+      if (p.status === 'passed' || p.status === 'executed') {
+        out.push({
+          id: `prop-${p.pubkey}-${p.status}`,
+          ts: ts + 1, // ensures ordering after creation
+          kind: p.status === 'executed' ? 'proposal-executed' : 'proposal-passed',
+          text: `Proposal ${p.status}: ${desc}`,
+          explorerAddress: p.pubkey,
+        })
+      }
+      if (p.status === 'rejected') {
+        out.push({
+          id: `prop-${p.pubkey}-rejected`,
+          ts: ts + 1,
+          kind: 'proposal-rejected',
+          text: `Proposal rejected: ${desc}`,
+          explorerAddress: p.pubkey,
+        })
+      }
+    }
+
+    for (const m of members ?? []) {
+      const ts = m.joinedAt ? new Date(m.joinedAt).getTime() : null
+      if (!ts) continue
+      const addr = m.wallet ?? m.pubkey ?? 'unknown'
+      out.push({
+        id: `member-${addr}`,
+        ts,
+        kind: 'member-joined',
+        text: `New member: ${addr.slice(0, 4)}…${addr.slice(-4)}`,
+        explorerAddress: addr,
+      })
+    }
+
+    return out.sort((a, b) => b.ts - a.ts).slice(0, limit).map((e) => ({
+      ...e,
+      explorerAddress: e.explorerAddress
+        ? `https://explorer.solana.com/address/${e.explorerAddress}${explorerSuffix}`
+        : undefined,
+    })) as Event[]
+  }, [pot, proposals, members, cluster, limit])
+
+  if (events.length === 0) {
+    return (
+      <div className="bg-pot-card border border-pot-border rounded-2xl p-6 text-center">
+        <div className="text-3xl mb-2">📭</div>
+        <p className="text-pot-muted text-sm">No activity yet — be the first to propose a swap.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-pot-card border border-pot-border rounded-2xl">
+      <div className="px-5 py-3 border-b border-pot-border flex items-center justify-between">
+        <h3 className="font-bold text-white text-sm">📡 Recent activity</h3>
+        <span className="text-[10px] text-pot-muted uppercase tracking-wide">last {events.length}</span>
+      </div>
+      <ul className="divide-y divide-pot-border/50">
+        {events.map((e) => {
+          const meta = KIND_META[e.kind]
+          return (
+            <li key={e.id} className="px-5 py-3 flex items-start gap-3 text-sm">
+              <span className="shrink-0 text-base leading-tight">{meta.icon}</span>
+              <div className="min-w-0 flex-1">
+                <p className={`${meta.color} font-medium truncate`}>{e.text}</p>
+                <p className="text-[11px] text-pot-muted mt-0.5">{formatRelative(e.ts)}</p>
+              </div>
+              {e.explorerAddress && (
+                <a
+                  href={e.explorerAddress as unknown as string}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 text-[11px] text-pot-muted hover:text-pot-green transition"
+                  title="View on Solana Explorer"
+                >
+                  ↗
+                </a>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/src/components/PotBotAISuggestions.tsx
+++ b/apps/web/src/components/PotBotAISuggestions.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useSolPrice } from '@/lib/prices'
+import { StatusBadge } from './StatusBadge'
 
 /**
  * Base PotBot AI — decision-support feed.
@@ -133,6 +134,7 @@ export function PotBotAISuggestions({ potPubkey, potName, potBalanceSol, onSubmi
             <span className="text-[10px] px-2 py-0.5 rounded-full bg-pot-accent/20 text-pot-accent border border-pot-accent/30 uppercase tracking-wide">
               base layer
             </span>
+            <StatusBadge tier="devnet" compact label="Devnet · mock" />
           </div>
           <p className="text-xs text-pot-muted mt-1 break-words">
             Decision-support feed for <span className="text-white">{potName}</span>. Reviews vault

--- a/apps/web/src/components/PotHeroStrip.tsx
+++ b/apps/web/src/components/PotHeroStrip.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { StatusBadge } from './StatusBadge'
+
+/**
+ * PotHeroStrip — compact, sticky-on-scroll hero for /pots/[pubkey].
+ *
+ * Replaces the old heavy gradient header. The judge gets vault identity,
+ * key metrics, network status, and the two primary CTAs (Deposit + Propose)
+ * in a single ~120px tall strip that stays anchored on scroll.
+ */
+
+interface Props {
+  emoji: string
+  name: string
+  snsName?: string
+  pubkey: string
+  ownerLabel?: string
+  isPublic?: boolean
+  isLive?: boolean
+  squadsManaged?: boolean
+  tvlSol: number
+  members: number
+  yourSharePct?: number
+  activeProposals: number
+  tamaHp?: number
+  onDepositClick: () => void
+  onProposeClick: () => void
+  canPropose: boolean
+}
+
+function abbreviate(addr: string) {
+  if (!addr) return ''
+  if (addr.length <= 12) return addr
+  return `${addr.slice(0, 4)}…${addr.slice(-4)}`
+}
+
+export function PotHeroStrip({
+  emoji,
+  name,
+  snsName,
+  pubkey,
+  ownerLabel,
+  isPublic,
+  isLive,
+  squadsManaged,
+  tvlSol,
+  members,
+  yourSharePct,
+  activeProposals,
+  tamaHp,
+  onDepositClick,
+  onProposeClick,
+  canPropose,
+}: Props) {
+  const [copied, setCopied] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const handle = () => setScrolled(window.scrollY > 120)
+    handle()
+    window.addEventListener('scroll', handle, { passive: true })
+    return () => window.removeEventListener('scroll', handle)
+  }, [])
+
+  const copyAddress = () => {
+    navigator.clipboard.writeText(pubkey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1400)
+  }
+
+  return (
+    <div
+      className={`sticky top-0 z-30 transition-all border-b border-pot-border bg-pot-dark/90 backdrop-blur ${
+        scrolled ? 'shadow-lg shadow-black/40' : ''
+      }`}
+    >
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-3 sm:py-4">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className={`shrink-0 transition-all ${scrolled ? 'text-3xl' : 'text-4xl sm:text-5xl'}`}>
+              {emoji}
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className={`font-bold text-white truncate transition-all ${scrolled ? 'text-base' : 'text-lg sm:text-xl'}`}>
+                  {name}
+                </h1>
+                <StatusBadge tier={isLive ? 'live' : 'devnet'} compact />
+                {isPublic && (
+                  <span className="px-1.5 py-0.5 rounded-full bg-pot-accent/15 text-pot-accent text-[10px] font-semibold uppercase tracking-wide">
+                    Public
+                  </span>
+                )}
+                {squadsManaged && (
+                  <span className="px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-300 text-[10px] font-semibold uppercase tracking-wide">
+                    🛡 Squads
+                  </span>
+                )}
+                {ownerLabel && (
+                  <span className="px-1.5 py-0.5 rounded-full bg-pot-card border border-pot-border text-pot-muted text-[10px] font-medium uppercase tracking-wide">
+                    {ownerLabel}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={copyAddress}
+                title="Copy full pubkey"
+                className="mt-0.5 text-[11px] text-pot-muted font-mono hover:text-pot-green transition flex items-center gap-1"
+              >
+                {snsName ? (
+                  <span className="text-pot-green">{snsName}</span>
+                ) : (
+                  <span>{abbreviate(pubkey)}</span>
+                )}
+                <span className="opacity-60">{copied ? '✓ copied' : '📋'}</span>
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 sm:gap-3 flex-wrap md:flex-nowrap">
+            <Metric label="TVL" value={`${tvlSol.toFixed(2)} SOL`} accent="green" />
+            <Metric label="Members" value={String(members)} />
+            {yourSharePct != null && yourSharePct > 0 && (
+              <Metric label="Your share" value={`${yourSharePct.toFixed(1)}%`} accent="accent" />
+            )}
+            {activeProposals > 0 && (
+              <Metric label="Active votes" value={String(activeProposals)} accent="accent" pulse />
+            )}
+            {tamaHp != null && (
+              <Metric label="Tama HP" value={`${tamaHp}/100`} />
+            )}
+
+            <div className="flex items-center gap-2 ml-1">
+              <button
+                onClick={onDepositClick}
+                className="px-3 sm:px-4 py-2 rounded-xl text-xs sm:text-sm font-bold bg-pot-green hover:bg-pot-green/90 text-pot-dark transition shrink-0"
+              >
+                💰 Deposit
+              </button>
+              <button
+                onClick={onProposeClick}
+                disabled={!canPropose}
+                className="px-3 sm:px-4 py-2 rounded-xl text-xs sm:text-sm font-bold bg-pot-accent hover:bg-pot-accent/90 text-white transition shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+                title={canPropose ? 'Open proposal builder' : 'Members only'}
+              >
+                🗳️ Propose
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  accent,
+  pulse,
+}: {
+  label: string
+  value: string
+  accent?: 'green' | 'accent'
+  pulse?: boolean
+}) {
+  const valueClass =
+    accent === 'green' ? 'text-pot-green' : accent === 'accent' ? 'text-pot-accent' : 'text-white'
+  return (
+    <div
+      className={`bg-pot-card border border-pot-border rounded-xl px-3 py-1.5 min-w-[78px] ${
+        pulse ? 'animate-pulse' : ''
+      }`}
+    >
+      <div className="text-[9px] uppercase tracking-wide text-pot-muted leading-none">{label}</div>
+      <div className={`text-sm sm:text-base font-bold tabular-nums ${valueClass} mt-0.5`}>{value}</div>
+    </div>
+  )
+}

--- a/apps/web/src/components/PremiumFeatures.tsx
+++ b/apps/web/src/components/PremiumFeatures.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { StatusBadge } from './StatusBadge';
+
 import { useState } from 'react';
 import { TokenizeSharesModal } from './TokenizeSharesModal';
 import { SnsModal } from './SnsModal';
@@ -66,7 +68,10 @@ export function PremiumFeatures({
     <>
       <div className="bg-pot-card p-6 rounded-xl border border-pot-border">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-white">Premium Features</h3>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-lg font-semibold text-white">Premium Features</h3>
+            <StatusBadge tier="phase-3" compact />
+          </div>
           <span className="text-xs px-2 py-1 bg-pot-accent/20 text-pot-accent rounded-full">
             Optional
           </span>

--- a/apps/web/src/components/SponsorRail.tsx
+++ b/apps/web/src/components/SponsorRail.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * SponsorRail — horizontal rail of sponsor / integration chips on /pots/[pubkey].
+ *
+ * Lifts the killer claim ("real Jupiter v6 CPI from a vault PDA") above the
+ * fold for hackathon judges. Each chip = (a) name, (b) what it does in this
+ * pot, (c) link to verifiable proof. Mobile: horizontal scroll, no clipping.
+ *
+ * Sources of truth:
+ * - Jupiter CPI happens in pot_vault::execute_swap. Any swap proposal that
+ *   resolved to executed has an Explorer tx — we point to the most recent.
+ * - Helius RPC is wired in apps/web/src/lib/rpc.ts via NEXT_PUBLIC_HELIUS_RPC.
+ * - Squads is conditional — only shown if creator is a multisig vault.
+ * - Solana Blink — opens an X intent pre-filled with the deposit Action URL.
+ * - MCP — links to the npm package.
+ */
+
+interface Props {
+  potPubkey: string
+  /** Last execute_swap tx signature, if any */
+  lastSwapTx?: string
+  /** True when creator authority is a Squads v4 multisig vault PDA */
+  squadsManaged?: boolean
+  /** Cluster — controls the Explorer link suffix */
+  cluster?: 'mainnet-beta' | 'devnet'
+}
+
+export function SponsorRail({
+  potPubkey,
+  lastSwapTx,
+  squadsManaged,
+  cluster = 'devnet',
+}: Props) {
+  const [copied, setCopied] = useState(false)
+
+  const explorerSuffix = cluster === 'mainnet-beta' ? '' : '?cluster=devnet'
+
+  const appUrl =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_APP_URL ?? 'https://potbot.fun')
+
+  const blinkUrl = `${appUrl}/api/actions/${potPubkey}/deposit`
+
+  const copyBlink = () => {
+    navigator.clipboard.writeText(blinkUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1400)
+  }
+
+  return (
+    <div className="border-b border-pot-border bg-pot-card/30">
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-2.5">
+        <div className="flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <span className="text-[10px] uppercase tracking-wider text-pot-muted shrink-0 mr-1">
+            Powered by
+          </span>
+
+          <Chip
+            href={
+              lastSwapTx
+                ? `https://explorer.solana.com/tx/${lastSwapTx}${explorerSuffix}`
+                : 'https://docs.jup.ag/'
+            }
+            color="green"
+            title={
+              lastSwapTx
+                ? 'View last on-chain swap on Solana Explorer'
+                : 'Jupiter v6 CPI — pot_vault::execute_swap'
+            }
+            label="🪐 Jupiter v6"
+            sub={lastSwapTx ? 'last tx ↗' : 'CPI'}
+          />
+
+          <Chip
+            href="https://www.helius.dev/"
+            color="amber"
+            title="Helius RPC + webhooks"
+            label="⚡ Helius"
+            sub="RPC"
+          />
+
+          {squadsManaged && (
+            <Chip
+              href={`https://app.squads.so/squads/${potPubkey}`}
+              color="blue"
+              title="This pot is owned by a Squads v4 multisig"
+              label="🛡 Squads v4"
+              sub="multisig"
+            />
+          )}
+
+          <Chip
+            href="https://docs.dialect.to/documentation/actions/blinks"
+            color="green"
+            title="Solana Actions endpoint — vote / deposit straight from a tweet"
+            label="⚡ Blinks"
+            sub="actions"
+          />
+
+          <button
+            type="button"
+            onClick={copyBlink}
+            title="Copy this pot's Blink URL"
+            className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border border-pot-border bg-pot-card hover:border-pot-green/50 text-[11px] text-white transition"
+          >
+            🔗 {copied ? 'Copied!' : 'Copy Blink URL'}
+          </button>
+
+          <Chip
+            href="https://www.npmjs.com/package/@potbot/mcp"
+            color="purple"
+            title="@potbot/mcp on npm — Claude/GPT can manage this pot"
+            label="🤖 MCP"
+            sub="agent api"
+          />
+
+          <Chip
+            href={`https://explorer.solana.com/address/${potPubkey}${explorerSuffix}`}
+            color="muted"
+            title="Verify this pot on Solana Explorer"
+            label="🔍 Explorer"
+            sub="verify"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Chip({
+  href,
+  color,
+  title,
+  label,
+  sub,
+}: {
+  href: string
+  color: 'green' | 'amber' | 'blue' | 'purple' | 'muted'
+  title: string
+  label: string
+  sub?: string
+}) {
+  const palette: Record<typeof color, { border: string; text: string; bg: string; hover: string }> = {
+    green:  { border: 'border-pot-green/30',  text: 'text-pot-green',  bg: 'bg-pot-green/5',  hover: 'hover:border-pot-green/60' },
+    amber:  { border: 'border-amber-500/30',  text: 'text-amber-300',  bg: 'bg-amber-500/5',  hover: 'hover:border-amber-500/60' },
+    blue:   { border: 'border-blue-500/30',   text: 'text-blue-300',   bg: 'bg-blue-500/5',   hover: 'hover:border-blue-500/60' },
+    purple: { border: 'border-pot-accent/30', text: 'text-pot-accent', bg: 'bg-pot-accent/5', hover: 'hover:border-pot-accent/60' },
+    muted:  { border: 'border-pot-border',    text: 'text-pot-muted',  bg: 'bg-pot-card',     hover: 'hover:border-pot-muted/60' },
+  }
+  const c = palette[color]
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      className={`shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border ${c.border} ${c.bg} ${c.hover} ${c.text} text-[11px] font-semibold transition whitespace-nowrap`}
+    >
+      <span>{label}</span>
+      {sub && <span className="opacity-60 text-[10px] font-medium">· {sub}</span>}
+    </a>
+  )
+}

--- a/apps/web/src/components/StatusBadge.tsx
+++ b/apps/web/src/components/StatusBadge.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+/**
+ * StatusBadge — single source of truth for the 5-tier feature lifecycle chip.
+ * Used everywhere in the UI + on /roadmap + mirrored in markdown via 🟢🟡🔵🟣⚪.
+ */
+export type StatusTier = 'live' | 'devnet' | 'phase-2' | 'phase-3' | 'vision'
+
+const TIERS: Record<StatusTier, { dot: string; text: string; bg: string; border: string; label: string; emoji: string }> = {
+  'live':    { dot: 'bg-pot-green',   text: 'text-pot-green',    bg: 'bg-pot-green/10',    border: 'border-pot-green/30',    label: 'Live · mainnet',          emoji: '🟢' },
+  'devnet':  { dot: 'bg-yellow-400',  text: 'text-yellow-300',   bg: 'bg-yellow-400/10',   border: 'border-yellow-400/30',   label: 'Devnet',                  emoji: '🟡' },
+  'phase-2': { dot: 'bg-blue-400',    text: 'text-blue-300',     bg: 'bg-blue-400/10',     border: 'border-blue-400/30',     label: 'Phase 2 · Q3 2026',       emoji: '🔵' },
+  'phase-3': { dot: 'bg-pot-accent',  text: 'text-pot-accent',   bg: 'bg-pot-accent/10',   border: 'border-pot-accent/30',   label: 'Phase 3 · Q4 2026',       emoji: '🟣' },
+  'vision':  { dot: 'bg-pot-muted',   text: 'text-pot-muted',    bg: 'bg-pot-card',        border: 'border-pot-border',      label: 'Vision · 2027+',          emoji: '⚪' },
+}
+
+interface Props {
+  tier: StatusTier
+  /** override default label */
+  label?: string
+  /** smaller version for inline use */
+  compact?: boolean
+  className?: string
+}
+
+export function StatusBadge({ tier, label, compact, className = '' }: Props) {
+  const t = TIERS[tier]
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border ${t.bg} ${t.border} ${t.text} ${compact ? 'px-1.5 py-0.5 text-[10px]' : 'px-2.5 py-1 text-[11px]'} font-semibold uppercase tracking-wide whitespace-nowrap ${className}`}
+      title={t.label}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full ${t.dot}`} />
+      {label ?? t.label}
+    </span>
+  )
+}

--- a/apps/web/src/components/StrategyProposalBuilder.tsx
+++ b/apps/web/src/components/StrategyProposalBuilder.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useSolPrice } from '@/lib/prices'
+import { StatusBadge } from './StatusBadge'
 
 /**
  * Strategy tab — turn the opaque "Strategy" panel into a proposal builder.
@@ -223,6 +224,12 @@ export function StrategyProposalBuilder({ potName, potBalanceSol, onSubmit }: Pr
           <span className="font-bold text-white">Advanced</span>
           <span className="text-pot-muted text-sm">{showAdvanced ? '▾' : '▸'}</span>
         </button>
+        {showAdvanced && (
+          <div className="mt-3 mb-2">
+            <StatusBadge tier="phase-2" />
+            <span className="ml-2 text-[11px] text-pot-muted">All advanced strategies ship in Phase 2 (Q3 2026).</span>
+          </div>
+        )}
         {showAdvanced && (
           <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
             {([

--- a/docs/hackathon/submission.md
+++ b/docs/hackathon/submission.md
@@ -7,6 +7,10 @@
 **Live:** https://potbot.fun · **Repo:** https://github.com/YD811/potbot-v2
 **Devnet program:** [`GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK`](https://explorer.solana.com/address/GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK?cluster=devnet)
 
+> **Lifecycle legend.** Every feature in this submission is tagged.
+> 🟢 Live (mainnet) · 🟡 Devnet (mainnet target this sprint) · 🔵 Phase 2 (Q3 2026) · 🟣 Phase 3 (Q4 2026) · ⚪ Vision (2027+)
+> Full roadmap with every feature: [potbot.fun/roadmap](https://potbot.fun/roadmap)
+
 ---
 
 ## Problem
@@ -27,77 +31,115 @@ PotBot v2 is a group trading vault on Solana. Members:
 
 ## Judging — how PotBot scores against the 5 criteria
 
-### 1. Functionality (works end-to-end on-chain)
-- 30+ Anchor instructions, all live on devnet program `GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK`. Full path: `create_pot → set_allowed_mints → deposit → create_proposal → vote → execute_swap (Jupiter v6 CPI) → withdraw`.
-- Strategy layer with **on-chain trigger verification**: the program re-reads Pyth price feeds inside `execute_swap` and rejects keepers that fire on the wrong condition. Triggers cannot be faked.
-- Three authorization modes (`AdminDirect`, `Proposal`, `StrategyTrigger`) in one instruction with strict mode-source matching. No second contract needed.
-- Health endpoint: `https://potbot.fun/api/health` (200 OK with cluster + version).
-- E2E smoke happy-path tested on devnet (deposit → propose → vote → swap → withdraw closed in <60s round-trip).
+### 1. Functionality 🟢
+Working today, on-chain, end-to-end:
+
+- 🟢 30+ Anchor instructions deployed. Full path verifiable on Explorer: `create_pot → set_allowed_mints → deposit → create_proposal → vote → execute_swap (Jupiter v6 CPI) → withdraw`.
+- 🟢 Three authorization modes (`AdminDirect`, `Proposal`, `StrategyTrigger`) in one `execute_swap` instruction with strict mode-source matching.
+- 🟢 Solana Blinks vote + deposit endpoints live: `https://potbot.fun/api/actions/<potPubkey>/deposit`.
+- 🟢 Health endpoint: `https://potbot.fun/api/health` returns `{status:"ok", network:"devnet|mainnet"}`.
+- 🟡 Strategy slot accounts (`create_strategy` / `close_strategy`) — devnet, mainnet target this sprint.
+- 🔵 In-program Pyth oracle guard — re-reads price feeds inside `execute_swap` to reject keepers firing on the wrong condition. Path reserved (StrategyTrigger mode), Pyth SDK ships in Phase 2.
 
 ### 2. Potential Impact
-Group treasuries are a $4–8B underserved DeFi segment (Squads MS at $14B AUM is the closest comparable, but it's pure custody — no trading workflow). PotBot ships a coordination primitive any DAO, friend group, or trading club can deploy in 30 seconds, with revenue from a 5–10 bps swap fee that funds keeper economics. Target mainnet GA: late May 2026.
+Group treasuries are a $4–8B underserved DeFi segment. Squads MS at $14B AUM is the closest comparable, but it's pure custody — no trading workflow. Drift Vaults / Kamino / Gauntlet are institutional curators, not friend-groups. PotBot ships a coordination primitive any DAO, friend group, or trading club can deploy in 30 seconds.
+
+Revenue is honest: 🟢 0.30 % swap fee on every trade routed through a pot, 🟡 10 % performance fee on Strategy Vaults split with the strategy creator. No token, no airdrop farming.
 
 ### 3. Novelty
-- **On-chain trigger verification** — most "automated DeFi" trusts off-chain keepers; we re-verify Pyth prices in-program.
-- **Three-mode `execute_swap` in one instruction** — Squads multisig can route, but it's a generic queue; PotBot bakes governance and keeper triggers into the same trade primitive.
-- **MCP-native** — `@potbot/mcp` lets any LLM drive a pot. Built-in path for the AI-agent narrative Solana is leaning into post-Breakpoint.
-- **Tamagotchi-as-engagement** — pot's plant grows from member activity (deposits, votes, proposals), tracking community health, not P&L. Different incentive surface from any vault product on Solana.
+- 🔵 **On-chain trigger verification** — the program re-reads Pyth inside the instruction (Phase 2). Most "automated DeFi" trusts off-chain keepers blindly.
+- 🟢 **Three-mode `execute_swap` in one instruction** — Squads multisig can route, but it's a generic queue; PotBot bakes governance and keeper triggers into the same trade primitive.
+- 🟢 **MCP-native** — `@potbot/mcp@0.2.0` lets any LLM drive a pot. 18 tools (free + paid via x402).
+- 🟡 **Two-tier AI** — base PotBot AI surfaces candidate proposals, user AI delegate votes/auto-creates on member's behalf. Decision-support before autopilot.
+- 🟡 **Tamagotchi as engagement** — pot's plant grows from member activity (deposits, votes, proposals, new members), tracking community health, not P&L. Different incentive surface from any vault product on Solana. NFT mint at Bloom (L4) ships in 🟣 Phase 3.
 
 ### 4. Design / UX
-- Next.js 14 + Tailwind, light/dark themes, full mobile-first pass on the pot detail page.
-- One-click flagship pot view at `/` with read-only TVL chart for non-wallet visitors. Wallet connect optional.
-- Onboarding tutorial gated by localStorage so returning users skip it.
-- Disclaimers + risk modal on first deposit (regulatory-clean for the consumer narrative).
-- Solana Blinks endpoints for vote + deposit, so a pot proposal becomes a tweet anyone can act on without leaving X.
+- 🟢 Next.js 14 + Tailwind, light/dark themes (WCAG-AA contrast in light), full mobile-first pass.
+- 🟢 Full-vision roadmap visible at `/roadmap` — every feature with explicit lifecycle status.
+- 🟢 PWA manifest mainnet-ready: "Add to Home Screen" on iOS/Android. ⚪ Saga / Seeker dApp Store entry next.
+- 🟢 Onboarding tutorial gated by localStorage. Disclaimers + risk modal on first deposit (regulatory-clean for the consumer narrative).
+- 🟢 Solana Blinks "Share as Blink" button on every pot — proposal becomes a tweet anyone can act on without leaving X.
+- 🟡 Strategy proposal builder: token search by ticker (SOL/USDC/JUP/BONK/JLP) or paste contract address. Action selector (Buy/Sell/Swap/Trigger), amount slider, live preview, "Submit as Proposal".
 
 ### 5. Composability
-PotBot is a thin wrapper over Solana's strongest primitives. Outbound CPI / API surface:
+PotBot is a thin wrapper over Solana's strongest primitives. Each integration tagged with status:
 
-| Integration | What it does |
-|---|---|
-| **Jupiter v6 / Ultra** | swap execution (CPI from `execute_swap`) |
-| **Pyth Network** | oracle price guard, in-program trigger verification |
-| **Helius** | RPC, webhooks for pot events, priority-fee API |
-| **Squads v4** | optional multisig path for the creator role on high-value pots |
-| **Privy** | email / social login + embedded Solana wallets for non-crypto users |
-| **Metaplex Core** | Tamagotchi NFT metadata for season rewards |
-| **Meteora DLMM, Kamino** | yield parking strategies for idle pot capital |
-| **Dune SIM** | SVM portfolio + activity endpoints for vault display, leaderboard TVL, keeper pre-flight |
-| **Solana Actions / Blinks** | shareable vote + deposit endpoints |
-| **MCP (Claude / OpenAI agents)** | `@potbot/mcp` exposes 60+ pot actions to any LLM |
+| Integration | What it does | Status |
+|---|---|---|
+| **Jupiter v6 / Ultra** | swap execution (CPI from `execute_swap`) | 🟢 Live (mainnet) |
+| **Helius** | RPC, webhooks for pot events, priority-fee API | 🟢 Live |
+| **Squads v4** | optional multisig path for the creator role on high-value pots | 🟢 Live (UI + lib; flagship pot uses it) |
+| **MCP (Claude / OpenAI agents)** | `@potbot/mcp` exposes 18 pot actions to any LLM | 🟢 Live (npm 0.2.0) |
+| **Solana Actions / Blinks** | shareable vote + deposit endpoints | 🟢 Live |
+| **Dune SIM** | SVM portfolio + activity for vault display, leaderboard TVL, keeper pre-flight | 🟡 Devnet (needs `DUNE_API_KEY`) |
+| **Pyth Network** | oracle price guard, in-program trigger verification | 🔵 Phase 2 |
+| **Privy** | email / social login + embedded Solana wallets for non-crypto users | 🔵 Phase 2 (PR #32 ready, awaiting App ID) |
+| **Light Protocol** | ZK-compressed audit log: SwapEvent + NavSnapshot accounts | 🔵 Phase 2 |
+| **Meteora DLMM, Kamino** | yield parking strategies for idle pot capital | 🔵 Phase 2 (CPI scaffolded) |
+| **Metaplex Token Metadata** | Tamagotchi NFT metadata for season rewards | 🟣 Phase 3 |
 
 ---
 
-## What is live as of submission
+## What is live on mainnet today
 
-- ✅ **Devnet program** — fully deployed, IDL synced, all 30+ instructions callable
-- ✅ **Frontend** — `/`, `/dashboard`, `/leaderboard`, `/faq`, `/pots/[pubkey]`, `/pots/[pubkey]/pet`, `/create`, `/signup`
-- ✅ **Keeper** — Anchor-SDK-backed worker, IDL loaded from disk, `confirmTransaction` with blockhash/lastValidBlockHeight pair, DLQ retries (2s/5s/13s/34s/89s)
-- ✅ **TypeScript SDK** at `packages/sdk/`
-- ✅ **MCP server** at `apps/potbot-mcp/`
-- ✅ **Solana Blinks** — `/api/actions/[potPubkey]/vote`, `/api/actions/[potPubkey]/deposit`
-- ✅ **Privy auth** + wallet-adapter (email, Google, Phantom, Solflare, Backpack)
-- ✅ **Squads v4 banner** — optional multisig route on Strategy + Governance tabs
-- ✅ **PWA manifest** — installable from mobile, Saga-ready
-- ⏳ **Mainnet** — cut target: May 8 (with explicit founder approval); flagship pot funded with real $50–100 for live judging
-- 🔮 **STAMPPOT** (Token-2022 confidential transfers privacy layer) — post-MVP
+- 🟢 `pot_vault` Anchor program — 30+ instructions deployed, IDL synced
+- 🟢 Frontend at `potbot.fun`: `/`, `/dashboard`, `/leaderboard`, `/faq`, `/vaults`, `/pots/[pubkey]`, `/pots/[pubkey]/pet`, `/create`, `/signup`, `/roadmap`
+- 🟢 Keeper — Anchor-SDK-backed worker, IDL loaded from disk, DLQ retries (2s/5s/13s/34s/89s)
+- 🟢 TypeScript SDK at `packages/sdk/`
+- 🟢 MCP server at `apps/potbot-mcp/` — npm 0.2.0
+- 🟢 Solana Blinks endpoints + ShareBlinkButton on every pot
+- 🟢 Squads v4 multisig (UI banner + lib for creator role)
+- 🟢 PWA manifest installable from mobile
+
+## What's already on devnet, mainnet target this sprint
+
+- 🟡 Strategy slot accounts (`create_strategy`, `close_strategy`)
+- 🟡 Tamagotchi state machine (5 levels, HP from member activity)
+- 🟡 Personal AI Voters (`MemberDelegate`, `vote_as_delegate`)
+- 🟡 PotBot AI suggestion feed (decision-support layer)
+- 🟡 Dune SIM portfolio + activity feed
+
+## Phase 2 (Q3 2026) — designed, scaffolded
+
+- 🔵 Pyth in-program oracle guard
+- 🔵 Meteora DLMM + DAMM yield CPI
+- 🔵 Kamino lending CPI
+- 🔵 Privy embedded wallets full flow
+- 🔵 Light Protocol ZK-compressed audit log
+- 🔵 `init_share_mint` graduation (off-chain → on-chain SPL)
+- 🔵 Advanced strategies (SL / TP / trailing / DCA)
+
+## Phase 3 (Q4 2026) — architecture set
+
+- 🟣 Tamagotchi NFT mint (Bloom unlock)
+- 🟣 Pot duels (Bud unlock)
+- 🟣 Premium tier (SNS subdomain, share tokenization)
+- 🟣 STAMPPOT — Auditable-Private mode (PrivacyCash + Merkle membership)
+
+## Vision · 2027+
+
+- ⚪ STAMPPOT — Sealed-Private mode (commit-reveal voting, encrypted strategy params)
+- ⚪ Saga / Seeker dApp Store entry
+- ⚪ $POT governance token (protocol fee buyback + season distribution)
+- ⚪ Cross-pot composability + DAO meta-governance
+- ⚪ Adevar Labs audit before mainnet GA push
 
 ---
 
 ## Tech Stack
 
-| Layer | Tech |
-|---|---|
-| Smart contracts | Anchor 0.30 (Rust), Solana SDK 2.x |
-| Swaps | Jupiter Aggregator v6 |
-| Frontend | Next.js 14, TypeScript, TanStack Query, Zustand, Tailwind |
-| Wallet | `@solana/wallet-adapter` + Privy embedded wallets |
-| Price feeds | Pyth Network |
-| Keeper | Node.js (devnet), Cloudflare Workers (prod) |
-| Hosting | Vercel (web) + Cloudflare Pages + KV (landing/edge) |
-| Off-chain | Supabase (NAV snapshots, swap metadata, agent rules) |
-| Indexer | Helius webhooks → Supabase realtime |
-| Notifications | Resend (waitlist + admin emails) |
+| Layer | Tech | Status |
+|---|---|---|
+| Smart contracts | Anchor 0.30 (Rust), Solana SDK 2.x | 🟢 |
+| Swaps | Jupiter Aggregator v6 + Ultra | 🟢 |
+| Frontend | Next.js 14, TypeScript, TanStack Query, Zustand, Tailwind | 🟢 |
+| Wallet | `@solana/wallet-adapter` (+ Privy in 🔵 Phase 2) | 🟢 |
+| Price feeds | Pyth Network | 🔵 in-program · 🟢 off-chain |
+| Keeper | Node.js (devnet), Cloudflare Workers (prod) | 🟢 devnet · 🟡 prod |
+| Hosting | Vercel (web) + Cloudflare Pages + KV (landing/edge) | 🟢 |
+| Off-chain | Supabase (NAV snapshots, swap metadata, agent rules) | 🟢 |
+| Indexer | Helius webhooks → Supabase realtime | 🟢 |
+| Notifications | Resend (waitlist + admin emails) | 🟢 |
 
 ---
 
@@ -106,28 +148,20 @@ PotBot is a thin wrapper over Solana's strongest primitives. Outbound CPI / API 
 | What to verify | How |
 |---|---|
 | 🌐 Live DApp | https://potbot.fun (no wallet needed — flagship pot view loads read-only) |
-| 🔗 On-chain program | `GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK` on devnet (mainnet ID added pre-submit if cut) |
+| 🗺️ Full roadmap with status | https://potbot.fun/roadmap |
+| 🔗 On-chain program | `GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK` (mainnet ID added pre-submit if cut) |
 | 📊 Health check | `curl https://potbot.fun/api/health` |
 | 🏆 Leaderboard | https://potbot.fun/leaderboard |
-| 🤖 AI Agent | open any pot → AI Agent tab; or `npx @potbot/mcp` and connect via Claude |
 | ⚡ Solana Blink | post a proposal; its `/api/actions/.../vote` URL renders as a Blink in any compatible client |
+| 🤖 AI Agent (two-tier) | open any pot → AI tab; or `npx @potbot/mcp` and connect via Claude |
 | 🌿 Tamagotchi | open `/pots/<pubkey>/pet` after a few member actions |
-| 📜 Architecture | [`docs/architecture/overview.md`](OVERVIEW.md), [`docs/architecture/program.md`](PROGRAM.md), [`docs/architecture/governance.md`](GOVERNANCE.md) |
-
----
-
-## Roadmap
-
-- **May 5–8** — mainnet cut, flagship pot funded
-- **May 11** — submit
-- **Post-hackathon Q2** — STAMPPOT confidential pots (Token-2022 confidential transfers), Saga / Seeker dApp Store entry
-- **Q3** — Adevar Labs audit, public mainnet launch, fee-revenue pot for keeper sustainability
+| 📜 Architecture | [`docs/architecture/overview.md`](../architecture/overview.md), [`docs/architecture/program.md`](../architecture/program.md), [`docs/architecture/governance.md`](../architecture/governance.md) |
 
 ---
 
 ## Release tag
 
-[v0.9.0-hackathon](https://github.com/YD811/potbot-v2/releases/tag/v0.9.0-hackathon) — April 25, 2026 cut. Submission state will be re-tagged as `v1.0.0-frontier-submission` immediately before May 11.
+[v0.9.0-hackathon](https://github.com/YD811/potbot-v2/releases/tag/v0.9.0-hackathon) — pre-submission cut. Submission state will be re-tagged as `v1.0.0-frontier-submission` immediately before May 11.
 
 ---
 
@@ -136,6 +170,7 @@ PotBot is a thin wrapper over Solana's strongest primitives. Outbound CPI / API 
 | | |
 |---|---|
 | Live | https://potbot.fun |
+| Roadmap | https://potbot.fun/roadmap |
 | Repo | https://github.com/YD811/potbot-v2 |
 | X | https://x.com/PotBot_sol |
 | YD | https://x.com/CryptoYDao |


### PR DESCRIPTION
## What

Three stacked commits — single PR ships all three.

### PR-E · vision-first polish
- `apps/web/src/components/StatusBadge.tsx` — single source of truth for the 5-tier feature lifecycle chip.
- `apps/web/src/app/roadmap/page.tsx` — public `/roadmap` with full feature inventory grouped by tier.
- Chips applied across `pots/[pubkey]/page.tsx`, `PotBotAISuggestions`, `StrategyProposalBuilder`, `PremiumFeatures`, `CreatePrivatePotForm`, `OnboardingTutorial`.
- `Navbar` adds 🗺️ Roadmap link.
- `docs/hackathon/submission.md` rewrite — every integration tagged with chip emoji.
- `README.md` "For Judges" restructured around 5-tier legend.

### PR-F · pot detail UX/UI rework
- **NEW** `PotHeroStrip.tsx` — sticky-on-scroll hero with NAV, members, your share, active votes, primary CTAs Deposit + Propose.
- **NEW** `SponsorRail.tsx` — Jupiter v6 (links to last `execute_swap` on Explorer if available), Helius, Squads (conditional), Solana Blinks (Copy URL), MCP, Explorer verify. Mobile horizontal-scroll.
- **NEW** `PotActivityFeed.tsx` — last 6 events synthesised from proposals + members + pot.createdAt with Explorer links.
- **NEW** `MembersList.tsx` — jdenticon avatar, copy-pubkey, share-% bar, joined date, Owner/AI-delegate chips.
- **REWRITE** `pots/[pubkey]/page.tsx` — 13 → 4 tabs (Trade · Community · AI · Features). Killer demo flow above the fold.

### PR-G · judge-facing /hackathon page
- Replace the old bounty page (Ika/Umbra/Kora — not real Frontier 2026 sponsors).
- Hero: "Squads moves money. PotBot trades it."
- Live-now block: program ID, flagship pot, MCP, Blink URL, GitHub, roadmap — each with Explorer/npm/route link.
- Wedge table — Squads/Drift/Kamino vs PotBot.
- Sponsor tracks — 12 cards (Jupiter, Solana Actions, MCP, Helius, Squads, Solana Mobile, Dune, Privy, Pyth, Metaplex, Light Protocol, Adevar) each with StatusBadge + 1-line proof + repo link.
- Architecture — three layers, every bullet phase-chipped.
- 90-second pitch script.
- What-ships-next pointer to `/roadmap`.

## Why
Vision-first per YD direction — keep every feature visible, label each one with explicit lifecycle status. Judges grade ambition AND execution; hiding ambition leaves points on the table.

## Verification (after Vercel redeploy)
- `/hackathon` — new judge page, sponsor cards with chips, no Ika/Umbra/Kora references.
- `/roadmap` — full feature inventory, 5 sections, ~30 features.
- `/pots/<any pubkey>` — sticky hero, sponsor rail, 4 tabs.
- Pot Trade tab → Deposit + Propose builder + Activity feed visible.
- Pot Features tab → Tamagotchi/Premium/STAMPPOT each with phase-3 chip.

## Out of scope (next steps)
- P0.1 mainnet deploy + flagship pot — awaits "ок mainnet".
- P0.2 demo video.
- P1.4 Privy `NEXT_PUBLIC_PRIVY_APP_ID` env.
- P1.3 MCP demo clip.