### PR TITLE
feat(ux): PR-H — Season modal + /vaults One-Pot hero + /for-agents + pot polish + nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ secrets/
 *.secret
 *.key
 *.tsbuildinfo
+
+# Local-only strategy memos and deploy bundles
+_local/
+_deploy/
+POTBOT_OPUS/

--- a/apps/web/src/app/for-agents/page.tsx
+++ b/apps/web/src/app/for-agents/page.tsx
@@ -6,55 +6,46 @@ const TOOLS = [
   {
     name: 'list_vaults',
     desc: 'List all PotBot Strategy Vaults with performance metrics',
-    example: '{ "sort": "pnl", "limit": 10, "strategy": "Trend" }',
     returns: 'vaults[] with TVL, PnL, APY, members, win rate',
   },
   {
     name: 'get_vault_analytics',
     desc: 'Get NAV, PnL, APY, and positions for a vault',
-    example: '{ "vault_pubkey": "PotXALPHA..." }',
     returns: 'nav_usd, nav_sol, pnl_pct, apy_pct, win_rate, sharpe, members, trades',
   },
   {
     name: 'get_token_prices',
     desc: 'Current prices via Jupiter Price API v2',
-    example: '{ "tokens": ["SOL", "USDC", "BONK"] }',
     returns: 'price_usd per token (with mint + source)',
   },
   {
     name: 'create_swap_proposal',
     desc: 'Draft a token-swap governance proposal in a vault',
-    example: '{ "vault_pubkey": "PotXALPHA...", "from_token": "SOL", "to_token": "USDC", "amount_pct": 30, "reason": "Take profit" }',
     returns: 'draft proposal + dApp signing link',
   },
   {
     name: 'vote_on_proposal',
     desc: 'Vote YES or NO on a governance proposal',
-    example: '{ "vault_pubkey": "PotXALPHA...", "proposal_id": 3, "approve": true }',
     returns: 'vote payload + dApp signing link',
   },
   {
     name: 'join_strategy_vault',
     desc: 'Join a strategy vault (returns entry-fee details and dApp link)',
-    example: '{ "vault_pubkey": "PotXALPHA...", "user_wallet": "XYZ...", "referrer_wallet": "ABC..." }',
     returns: 'entry fee, strategy, current members, vault URL',
   },
   {
     name: 'get_yield_rates',
     desc: 'Current DeFi yield rates: Kamino, Marginfi, Drift, Jito',
-    example: '{ "risk_level": "low" }',
     returns: 'protocol, APY range, TVL, asset, risk for each opportunity',
   },
   {
     name: 'get_leaderboard',
     desc: 'Top performing vaults ranked by a chosen metric',
-    example: '{ "metric": "apy", "limit": 5 }',
     returns: 'ranked vaults[] with rank + all performance fields',
   },
   {
     name: 'get_agent_rules',
     desc: 'Inspect AI automation rules for a vault',
-    example: '{ "vault_pubkey": "PotXALPHA..." }',
     returns: 'rules array with triggers, actions, cooldowns',
   },
 ]
@@ -91,95 +82,111 @@ const CLAUDE_CONFIG = `{
   }
 }`
 
+const CARD = 'bg-pot-card border border-pot-border rounded-2xl p-4 sm:p-5'
+
 export default function ForAgentsPage() {
   return (
-    <div className="min-h-screen overflow-x-hidden" style={{ background: '#0D1117' }}>
-      {/* Hero */}
-      <div className="border-b" style={{ borderColor: '#1A2332' }}>
-        <div className="max-w-5xl mx-auto px-6 py-16">
-          <div className="flex items-center gap-3 mb-4">
-            <span className="text-4xl">🤖</span>
-            <span
-              className="text-xs font-mono px-2 py-1 rounded"
-              style={{ background: '#14F19522', color: '#14F195', border: '1px solid #14F19544' }}
-            >
-              MCP NATIVE
-            </span>
-          </div>
-          <h1 className="text-4xl font-bold text-white mb-4">
-            PotBot for AI Agents
-          </h1>
-          <p className="text-xl mb-8 break-words" style={{ color: '#9CA3AF' }}>
-            PotBot exposes its entire vault infrastructure as an MCP server.
-            Any AI agent — Claude, GPT, custom — can list vaults, analyze performance,
-            create governance proposals, and configure automation + delegated voting rules.
-          </p>
-          <div className="flex flex-wrap gap-4">
-            <a
-              href="https://github.com/YD811/potbot-v2/tree/main/apps/potbot-mcp"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-primary"
-            >
-              View MCP Server Source →
-            </a>
-            <Link href="/vaults" className="btn-secondary">
-              Explore Vaults
-            </Link>
-          </div>
-        </div>
+    <div className="min-h-screen">
+      {/* Breadcrumb */}
+      <div className="max-w-5xl mx-auto px-3 sm:px-6 py-3 text-xs text-pot-muted">
+        <Link href="/" className="hover:text-white transition">Home</Link>
+        <span className="mx-1.5">/</span>
+        <span className="text-white font-semibold">For AI Agents</span>
       </div>
 
+      {/* Hero */}
+      <section className="max-w-5xl mx-auto px-3 sm:px-6 pt-4 sm:pt-8 pb-10">
+        <div className="flex items-center gap-3 mb-3 flex-wrap">
+          <span className="text-3xl sm:text-4xl">🤖</span>
+          <span className="text-[10px] font-bold tracking-wider px-2 py-1 rounded-md bg-pot-green/15 border border-pot-green/30 text-pot-green uppercase">
+            MCP native
+          </span>
+          <span className="text-[10px] font-bold tracking-wider px-2 py-1 rounded-md bg-pot-accent/15 border border-pot-accent/30 text-pot-accent uppercase">
+            x402 ready
+          </span>
+        </div>
+        <h1 className="text-3xl sm:text-5xl font-black text-white mb-3 leading-tight">
+          PotBot for AI Agents
+        </h1>
+        <p className="text-sm sm:text-lg text-pot-muted max-w-2xl">
+          PotBot exposes its entire vault infrastructure as an MCP server. Any AI agent — Claude, GPT, custom — can list vaults, analyze performance, create governance proposals, and configure automation + delegated voting rules.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a
+            href="https://www.npmjs.com/package/@potbot/mcp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-4 py-2 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold text-sm transition"
+          >
+            📦 @potbot/mcp on npm
+          </a>
+          <a
+            href="https://github.com/YD811/potbot-v2/tree/main/apps/potbot-mcp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-4 py-2 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold text-sm transition"
+          >
+            View source →
+          </a>
+          <Link
+            href="/vaults"
+            className="px-4 py-2 rounded-xl bg-pot-card border border-pot-border hover:border-pot-accent/40 text-white font-bold text-sm transition"
+          >
+            Explore Vaults
+          </Link>
+        </div>
+      </section>
 
-      <div className="max-w-5xl mx-auto px-6 pt-8">
-        <div className="card" style={{ borderColor: '#14F19544' }}>
-          <p className="text-sm font-mono mb-2" style={{ color: '#14F195' }}>Release Update</p>
-          <p className="text-sm mb-3 break-words" style={{ color: '#E5E7EB' }}>
-            @potbot/mcp@0.2.0 is now live on npm with HTTP+SSE+x402 transport support, including
-            two binaries: <code>potbot-mcp</code> (stdio) and <code>potbot-mcp-http</code> (HTTP).
+      {/* Release banner */}
+      <section className="max-w-5xl mx-auto px-3 sm:px-6 pb-8">
+        <div className={`${CARD} border-pot-green/30`}>
+          <p className="text-xs font-mono mb-2 text-pot-green">Release update</p>
+          <p className="text-sm text-white mb-3 break-words">
+            <code className="text-pot-accent">@potbot/mcp@0.2.0</code> is live on npm with HTTP+SSE+x402 transport, including two binaries: <code className="text-pot-accent">potbot-mcp</code> (stdio) and <code className="text-pot-accent">potbot-mcp-http</code> (HTTP).
           </p>
-          <ul className="text-xs space-y-1" style={{ color: '#9CA3AF' }}>
-            <li>• Tag <code>mcp-v0.2.0</code> published successfully via CI.</li>
-            <li>• npm latest now points to <code>0.2.0</code> (versions: 0.1.0, 0.2.0).</li>
-            <li>• Package size increased from 11.5 kB to 81.2 kB due to the new <code>http.ts</code> module.</li>
+          <ul className="text-xs space-y-1 text-pot-muted">
+            <li>• Tag <code className="text-pot-green">mcp-v0.2.0</code> published via CI.</li>
+            <li>• npm latest now points to <code className="text-pot-green">0.2.0</code>.</li>
+            <li>• Package size: 11.5 kB → 81.2 kB (new <code className="text-pot-green">http.ts</code> module).</li>
           </ul>
           <div className="mt-4 flex flex-wrap gap-3 text-xs">
-            <a href="https://www.npmjs.com/package/@potbot/mcp" target="_blank" rel="noopener noreferrer" style={{ color: '#14F195' }}>npm package ↗</a>
-            <a href="https://github.com/YD811/potbot-v2/releases/tag/mcp-v0.2.0" target="_blank" rel="noopener noreferrer" style={{ color: '#14F195' }}>release tag ↗</a>
-            <a href="https://github.com/YD811/potbot-v2/actions/runs/24932500756" target="_blank" rel="noopener noreferrer" style={{ color: '#14F195' }}>CI run ↗</a>
+            <a href="https://www.npmjs.com/package/@potbot/mcp" target="_blank" rel="noopener noreferrer" className="text-pot-green hover:underline">npm package ↗</a>
+            <a href="https://github.com/YD811/potbot-v2/releases/tag/mcp-v0.2.0" target="_blank" rel="noopener noreferrer" className="text-pot-green hover:underline">release tag ↗</a>
           </div>
         </div>
-      </div>
+      </section>
 
-      <div className="max-w-5xl mx-auto px-6 py-12 space-y-16">
+      {/* Body */}
+      <div className="max-w-5xl mx-auto px-3 sm:px-6 pb-16 space-y-12">
 
         {/* Quick Start */}
         <section>
-          <h2 className="text-2xl font-bold text-white mb-6">Quick Start</h2>
-          <div className="space-y-4">
-            <div className="card">
-              <p className="text-sm font-mono mb-2" style={{ color: '#14F195' }}>1. Install the MCP server</p>
-              <pre className="text-sm overflow-x-auto max-w-full whitespace-pre p-3 rounded bg-pot-dark border border-pot-border" style={{ color: '#E5E7EB' }}>
-                {'npm install -g @potbot/mcp'}
+          <h2 className="text-xl sm:text-2xl font-bold text-white mb-5">Quick start</h2>
+          <div className="space-y-3">
+            <div className={CARD}>
+              <p className="text-xs font-mono mb-2 text-pot-green">1. Install the MCP server</p>
+              <pre className="text-xs sm:text-sm font-mono p-3 rounded-lg bg-pot-dark border border-pot-border text-white whitespace-pre-wrap break-words overflow-x-auto">
+{`npm install -g @potbot/mcp`}
               </pre>
             </div>
-            <div className="card">
-              <p className="text-sm font-mono mb-2" style={{ color: '#14F195' }}>2. Add to claude_desktop_config.json</p>
-              <pre className="text-sm overflow-x-auto max-w-full whitespace-pre p-3 rounded bg-pot-dark border border-pot-border" style={{ color: '#E5E7EB' }}>{CLAUDE_CONFIG}</pre>
+            <div className={CARD}>
+              <p className="text-xs font-mono mb-2 text-pot-green">2. Add to claude_desktop_config.json</p>
+              <pre className="text-xs sm:text-sm font-mono p-3 rounded-lg bg-pot-dark border border-pot-border text-white whitespace-pre-wrap break-words overflow-x-auto">
+{CLAUDE_CONFIG}
+              </pre>
             </div>
-            <div className="card">
-              <p className="text-sm font-mono mb-2" style={{ color: '#14F195' }}>3. Ask Claude to interact with vaults</p>
+            <div className={CARD}>
+              <p className="text-xs font-mono mb-2 text-pot-green">3. Ask Claude to interact with vaults</p>
               <div className="space-y-2">
                 {[
                   'List all PotBot vaults and show their 30-day returns',
                   'Find the best SOL yield opportunities under low risk',
                   'Set up a DCA rule: buy 500 USDC worth of SOL every 24 hours',
                   'Create a proposal to swap 10% of the vault to JitoSOL for yield',
-                ].map(prompt => (
+                ].map((prompt) => (
                   <div
                     key={prompt}
-                    className="text-sm px-3 py-2 rounded"
-                    style={{ background: '#111827', color: '#9CA3AF', fontStyle: 'italic' }}
+                    className="text-sm px-3 py-2 rounded-lg bg-pot-dark text-pot-muted italic break-words"
                   >
                     &ldquo;{prompt}&rdquo;
                   </div>
@@ -191,27 +198,16 @@ export default function ForAgentsPage() {
 
         {/* Tools */}
         <section>
-          <h2 className="text-2xl font-bold text-white mb-2">Available Tools</h2>
-          <p className="mb-6" style={{ color: '#6B7280' }}>
-            9 tools covering the full vault lifecycle
-          </p>
-          <div className="space-y-3">
-            {TOOLS.map(tool => (
-              <div key={tool.name} className="card">
-                <div className="flex items-start gap-4 flex-wrap sm:flex-nowrap">
-                  <code
-                    className="text-sm font-mono sm:shrink-0 break-all"
-                    style={{ color: '#9945FF' }}
-                  >
-                    {tool.name}
-                  </code>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-white mb-1">{tool.desc}</p>
-                    <p className="text-xs" style={{ color: '#6B7280' }}>
-                      Returns: {tool.returns}
-                    </p>
-                  </div>
-                </div>
+          <h2 className="text-xl sm:text-2xl font-bold text-white mb-1">Available tools</h2>
+          <p className="text-sm text-pot-muted mb-5">9 tools covering the full vault lifecycle</p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {TOOLS.map((tool) => (
+              <div key={tool.name} className={CARD}>
+                <code className="text-sm font-mono text-pot-accent break-all block mb-1.5">{tool.name}</code>
+                <p className="text-sm text-white mb-2">{tool.desc}</p>
+                <p className="text-xs text-pot-muted">
+                  <span className="text-pot-muted/70 font-semibold">Returns:</span> {tool.returns}
+                </p>
               </div>
             ))}
           </div>
@@ -219,26 +215,26 @@ export default function ForAgentsPage() {
 
         {/* AI Agent Rules */}
         <section>
-          <h2 className="text-2xl font-bold text-white mb-2">AI Agent Automation</h2>
-          <p className="mb-6" style={{ color: '#6B7280' }}>
-            Configure rules that run every 60 seconds. When a trigger fires, the agent
-            creates and can vote on governance actions based on user preferences. By default, members vote manually,
-            but users can enable delegated AI voting in bot settings for predefined decision policies.
+          <h2 className="text-xl sm:text-2xl font-bold text-white mb-2">AI Agent automation</h2>
+          <p className="text-sm text-pot-muted mb-5">
+            Configure rules that run every 60 seconds. When a trigger fires, the agent creates and can vote on governance actions based on user preferences. Members vote manually by default, but users can enable delegated AI voting for predefined decision policies.
           </p>
-          <div className="card">
-            <p className="text-sm font-mono mb-3" style={{ color: '#14F195' }}>Example: Buy SOL when price drops</p>
-            <pre className="text-sm overflow-x-auto max-w-full whitespace-pre p-3 rounded bg-pot-dark border border-pot-border" style={{ color: '#E5E7EB' }}>{EXAMPLE_RULE}</pre>
+          <div className={CARD}>
+            <p className="text-xs font-mono mb-3 text-pot-green">Example — buy SOL when price drops</p>
+            <pre className="text-xs sm:text-sm font-mono p-3 rounded-lg bg-pot-dark border border-pot-border text-white whitespace-pre-wrap break-words overflow-x-auto">
+{EXAMPLE_RULE}
+            </pre>
           </div>
           <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
             {[
-              { trigger: 'price_below', label: 'Price Alert', desc: 'Trigger when SOL/BTC/token hits a threshold' },
-              { trigger: 'time_interval', label: 'DCA Timer', desc: 'Buy on a fixed schedule (hourly, daily, weekly)' },
-              { trigger: 'pnl_above', label: 'Take Profit', desc: 'Propose sell when vault PnL reaches target' },
-            ].map(item => (
-              <div key={item.trigger} className="card min-w-0" style={{ borderColor: '#9945FF44' }}>
+              { trigger: 'price_below', label: 'Price alert', desc: 'Trigger when SOL/BTC/token hits a threshold' },
+              { trigger: 'time_interval', label: 'DCA timer', desc: 'Buy on a fixed schedule (hourly, daily, weekly)' },
+              { trigger: 'pnl_above', label: 'Take profit', desc: 'Propose sell when vault PnL reaches target' },
+            ].map((item) => (
+              <div key={item.trigger} className={CARD}>
                 <p className="text-sm font-bold text-white mb-1">{item.label}</p>
-                <p className="text-xs" style={{ color: '#6B7280' }}>{item.desc}</p>
-                <code className="text-xs mt-2 block" style={{ color: '#9945FF' }}>{item.trigger}</code>
+                <p className="text-xs text-pot-muted mb-2">{item.desc}</p>
+                <code className="text-xs text-pot-accent">{item.trigger}</code>
               </div>
             ))}
           </div>
@@ -246,42 +242,44 @@ export default function ForAgentsPage() {
 
         {/* Governance Safety */}
         <section>
-          <h2 className="text-2xl font-bold text-white mb-2">Governance Safety</h2>
-          <p className="mb-6" style={{ color: '#6B7280' }}>
-            AI agents can act as delegates for governance voting when the user opts in.
-            Users choose manual or delegated mode in bot settings, and all decisions remain transparent on-chain.
+          <h2 className="text-xl sm:text-2xl font-bold text-white mb-2">Governance safety</h2>
+          <p className="text-sm text-pot-muted mb-5">
+            AI agents can act as delegates for governance voting when the user opts in. Users choose manual or delegated mode in bot settings, and all decisions remain transparent on-chain.
           </p>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             {[
               { icon: '🤖', title: 'Agent proposes', desc: 'AI detects opportunity and creates on-chain proposal' },
               { icon: '🗳️', title: 'Vote mode', desc: 'Manual member voting or delegated AI voting based on user preference' },
               { icon: '⚡', title: 'Jupiter executes', desc: 'Passed proposals execute via Jupiter swap CPI' },
-            ].map(step => (
-              <div key={step.title} className="card text-center">
+            ].map((step) => (
+              <div key={step.title} className={`${CARD} text-center`}>
                 <div className="text-3xl mb-3">{step.icon}</div>
                 <p className="font-bold text-white mb-1">{step.title}</p>
-                <p className="text-sm" style={{ color: '#6B7280' }}>{step.desc}</p>
+                <p className="text-sm text-pot-muted">{step.desc}</p>
               </div>
             ))}
           </div>
         </section>
 
         {/* Footer CTA */}
-        <section className="text-center py-8">
-          <p className="text-lg text-white mb-6">
+        <section className="text-center py-4 sm:py-8">
+          <p className="text-base sm:text-lg text-white mb-5">
             Ready to build AI-powered DeFi strategies?
           </p>
-          <div className="flex justify-center gap-4 flex-wrap">
+          <div className="flex justify-center gap-3 flex-wrap">
             <a
               href="https://github.com/YD811/potbot-v2"
               target="_blank"
               rel="noopener noreferrer"
-              className="btn-primary"
+              className="px-5 py-3 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold text-sm transition"
             >
-              GitHub Repository
+              GitHub repository
             </a>
-            <Link href="/create" className="btn-secondary">
-              Create a Vault
+            <Link
+              href="/create"
+              className="px-5 py-3 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold text-sm transition"
+            >
+              Create a vault
             </Link>
           </div>
         </section>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -70,6 +70,7 @@ const THEME_BOOTSTRAP = `
 
 const FOOTER_LINKS = [
   { label: 'FAQ',         href: '/faq' },
+  { label: 'Roadmap',     href: '/roadmap' },
   { label: 'Leaderboard', href: '/leaderboard' },
   { label: 'Hackathon',   href: '/hackathon' },
   { label: 'For Agents',  href: '/for-agents' },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -25,23 +25,6 @@ const YIELD_LABELS: Record<number, string> = {
   6: 'JLP Hedge 🛡️',
 }
 
-const HackathonButton = () => (
-  <a
-    href="/hackathon"
-    style={{
-      position: 'fixed', bottom: 24, right: 24, zIndex: 50,
-      background: 'linear-gradient(135deg, #7048E8, #5a3acf)',
-      color: '#fff', fontWeight: 700, fontSize: 13,
-      padding: '10px 18px', borderRadius: 100,
-      textDecoration: 'none', boxShadow: '0 4px 24px #7048E840',
-      display: 'flex', alignItems: 'center', gap: 8,
-      border: '1px solid #9d6fff40',
-    }}
-  >
-    🏆 Hackathon
-  </a>
-)
-
 export default function DashboardPage() {
   const { publicKey, connected } = useWallet()
   const { data: pots, isLoading } = usePots()
@@ -83,19 +66,12 @@ export default function DashboardPage() {
      P0.4: show flagship ONE POT read-only at the top BEFORE marketing content,
      so judges and unconnected visitors immediately see a live pot, not a "Demo Mode" banner. */
   if (!connected) {
-    return (
-      <>
-        <LandingPage />
-        <HackathonButton />
-      </>
-    )
+    return <LandingPage />
   }
 
   /* ── Dashboard (connected) ── */
   return (
     <div>
-      <HackathonButton />
-
       {/* Stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
         <div className="card p-4 text-center glow-green">

--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -438,6 +438,15 @@ export default function PotPage() {
 
   return (
     <div className="min-h-screen bg-pot-dark pb-12">
+      {/* Breadcrumb — keeps user oriented */}
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 pt-3 pb-1 text-xs text-pot-muted">
+        <Link href="/" className="hover:text-white transition">Home</Link>
+        <span className="mx-1.5">/</span>
+        <Link href="/vaults" className="hover:text-white transition">Vaults</Link>
+        <span className="mx-1.5">/</span>
+        <span className="text-white truncate inline-block max-w-[200px] sm:max-w-xs align-middle">{pot.name}</span>
+      </div>
+
       {/* Sticky hero strip */}
       <PotHeroStrip
         emoji={pot.emoji}
@@ -592,7 +601,7 @@ export default function PotPage() {
               </div>
 
               <div className="space-y-4">
-                <PotActivityFeed pot={pot} proposals={proposals} members={members} cluster={CLUSTER} />
+                <PotActivityFeed pot={pot} proposals={proposals} members={members} cluster={CLUSTER} limit={3} />
 
                 <div className="bg-pot-card border border-pot-border rounded-2xl p-4 space-y-2">
                   <div className="flex items-center gap-2">
@@ -628,34 +637,40 @@ export default function PotPage() {
               </details>
             </section>
 
-            {/* ── Holdings preview ── shares + P&L + portfolio collapsed by default */}
-            <section className="space-y-3">
-              <div className="flex items-center gap-2">
-                <h2 className="text-lg font-bold text-white">📊 Holdings</h2>
-              </div>
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <div className="lg:col-span-2"><SharesPanel potPubkey={pubkey} /></div>
-                <div><PnLDashboard potPubkey={pubkey} vaultBalanceSol={pot.balance} /></div>
-              </div>
-              {vaultPda && (
-                <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
-                  <summary className="cursor-pointer text-sm text-white font-semibold">
-                    🔎 Vault portfolio (live, Dune SIM)
-                  </summary>
-                  <div className="mt-4">
-                    <VaultPortfolio vaultPda={vaultPda} potName={pot.name} />
-                  </div>
-                </details>
-              )}
-              <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
-                <summary className="cursor-pointer text-sm text-white font-semibold">
-                  🪙 Manage shares (withdraw)
+            {/* ── Holdings & details ── hidden behind toggle to keep Trade tab tight.
+                 Member-only: non-members don't need shares/withdraw UI on the main page. */}
+            {canManage && (
+              <details className="bg-pot-card/40 border border-pot-border rounded-2xl">
+                <summary className="cursor-pointer px-5 py-4 text-sm text-white font-semibold flex items-center justify-between">
+                  <span>📊 Your holdings &amp; portfolio</span>
+                  <span className="text-pot-muted text-xs">expand ▾</span>
                 </summary>
-                <div className="mt-4">
-                  <SharesTab potPubkey={pubkey} canWithdraw={canWithdraw} />
+                <div className="px-5 pb-5 space-y-4">
+                  <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                    <div className="lg:col-span-2"><SharesPanel potPubkey={pubkey} /></div>
+                    <div><PnLDashboard potPubkey={pubkey} vaultBalanceSol={pot.balance} /></div>
+                  </div>
+                  {vaultPda && (
+                    <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
+                      <summary className="cursor-pointer text-xs text-white font-semibold">
+                        🔎 Vault portfolio (live, Dune SIM)
+                      </summary>
+                      <div className="mt-4">
+                        <VaultPortfolio vaultPda={vaultPda} potName={pot.name} />
+                      </div>
+                    </details>
+                  )}
+                  <details className="bg-pot-card/50 border border-pot-border rounded-2xl p-4">
+                    <summary className="cursor-pointer text-xs text-white font-semibold">
+                      🪙 Manage shares (withdraw)
+                    </summary>
+                    <div className="mt-4">
+                      <SharesTab potPubkey={pubkey} canWithdraw={canWithdraw} />
+                    </div>
+                  </details>
                 </div>
               </details>
-            </section>
+            )}
 
             <CreateProposalModal
               open={proposalModalOpen}

--- a/apps/web/src/app/vaults/page.tsx
+++ b/apps/web/src/app/vaults/page.tsx
@@ -1,360 +1,296 @@
-'use client';
+'use client'
 
-import React, { useState, useMemo } from 'react';
-import Link from 'next/link';
-import { usePots } from '@/hooks/usePots';
-import { useSolPrice } from '@/lib/prices';
-import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics';
-import { OnePotBanner } from '@/components/OnePotBanner';
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { usePots } from '@/hooks/usePots'
+import { useSolPrice } from '@/lib/prices'
+import { useVaultAnalyticsBatch } from '@/hooks/useAnalytics'
+import { usePot } from '@/hooks/usePots'
+import { calculateTamaStats } from '@/lib/tamagotchi/stats'
+import { StatusBadge } from '@/components/StatusBadge'
 
-// ─────────────────────────────────────────────────────────────────
-// Demo data — shown when the on-chain program isn't deployed yet
-// ─────────────────────────────────────────────────────────────────
-const DEMO_VAULTS = [
-  { pubkey: 'alpha_dca_001', name: 'Alpha Squad DCA', emoji: '🎯', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'influencer', creatorHandle: '@CryptoYDao', memberCount: 127, aumUsd: 48200, pnl30d: 12.4, tamagotchiLevel: 2, tamagotchiEmoji: '🐥', entryFeeUsd: 5, performanceFeeBps: 1000, isAiAgent: false, apy30d: 0, isDemo: true },
-  { pubkey: 'sol_bull_002', name: 'SOL Bull Market Fund', emoji: '🐂', strategyType: 'trend_following', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Sensei', memberCount: 89, aumUsd: 31400, pnl30d: 8.7, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 10, performanceFeeBps: 1500, isAiAgent: false, apy30d: 0, isDemo: true },
-  { pubkey: 'ai_dca_bot_003', name: 'Autonomous DCA Engine', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'conservative', creatorType: 'ai_agent', creatorHandle: 'DCA Bot #7', memberCount: 312, aumUsd: 127000, pnl30d: 6.2, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 500, isAiAgent: true, apy30d: 0, isDemo: true },
-  { pubkey: 'degen_mode_004', name: 'Degen Mode', emoji: '🎰', strategyType: 'degen', riskLevel: 'degen', creatorType: 'trader', creatorHandle: 'Moon_Bro', memberCount: 45, aumUsd: 12800, pnl30d: 34.1, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 20, performanceFeeBps: 2000, isAiAgent: false, apy30d: 0, isDemo: true },
-  { pubkey: 'yield_dao_005', name: 'Yield Farmers DAO', emoji: '🌾', strategyType: 'yield', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Y-DAO', memberCount: 203, aumUsd: 89500, pnl30d: 4.1, tamagotchiLevel: 3, tamagotchiEmoji: '🦅', entryFeeUsd: 0, performanceFeeBps: 800, isAiAgent: false, apy30d: 0, isDemo: true },
-  { pubkey: 'ai_treasury_006', name: 'AI Treasury Manager', emoji: '🤖', strategyType: 'ai_dca', riskLevel: 'balanced', creatorType: 'ai_agent', creatorHandle: 'Treasury AI v1', memberCount: 567, aumUsd: 234000, pnl30d: 9.8, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 700, isAiAgent: true, apy30d: 0, isDemo: true },
-  { pubkey: 'contra_007', name: 'Contrarian Club', emoji: '🔄', strategyType: 'mean_reversion', riskLevel: 'balanced', creatorType: 'trader', creatorHandle: 'Zig_Zag', memberCount: 67, aumUsd: 22100, pnl30d: 5.3, tamagotchiLevel: 1, tamagotchiEmoji: '🐣', entryFeeUsd: 5, performanceFeeBps: 1200, isAiAgent: false, apy30d: 0, isDemo: true },
-  { pubkey: 'diamond_008', name: 'Diamond Hands DAO', emoji: '💎', strategyType: 'hodl', riskLevel: 'conservative', creatorType: 'community', creatorHandle: 'Diamond DAO', memberCount: 891, aumUsd: 445000, pnl30d: 18.2, tamagotchiLevel: 4, tamagotchiEmoji: '🐉', entryFeeUsd: 0, performanceFeeBps: 300, isAiAgent: false, apy30d: 0, isDemo: true },
-];
+const ONE_POT_PUBKEY =
+  process.env.NEXT_PUBLIC_ONE_POT_PUBKEY ?? 'DEMO1111111111111111111111111111111111111111'
+const CLUSTER: 'mainnet-beta' | 'devnet' =
+  (process.env.NEXT_PUBLIC_SOLANA_CLUSTER as 'mainnet-beta' | 'devnet') ?? 'devnet'
 
-// Map on-chain yieldStrategy → display strategyType
-const YIELD_TO_STRATEGY: Record<string | number, string> = {
-  0: 'hodl',            none: 'hodl',
-  1: 'yield',           conservative: 'yield',
-  2: 'ai_dca',          balanced: 'ai_dca',
-  3: 'trend_following', aggressive: 'trend_following',
-  4: 'degen',           jlp: 'degen',
+const TAMA_EMOJI: Record<number, string> = { 1: '🌱', 2: '🌿', 3: '🪴', 4: '🌳', 5: '🌲' }
+const TAMA_NAME: Record<number, string> = {
+  1: 'Seedling', 2: 'Sprout', 3: 'Bud', 4: 'Bloom', 5: 'Mature Tree',
 }
 
-const STRATEGY_COLORS: Record<string, string> = {
-  ai_dca: '#9945FF',
-  trend_following: '#14F195',
-  mean_reversion: '#F59E0B',
-  hodl: '#3B82F6',
-  degen: '#EF4444',
-  yield: '#10B981',
-};
-
-const STRATEGY_LABELS: Record<string, string> = {
-  ai_dca: '🤖 AI DCA',
-  trend_following: '📈 Trend',
-  mean_reversion: '🔄 Mean Rev',
-  hodl: '💎 HODL',
-  degen: '🎰 Degen',
-  yield: '🌾 Yield',
-};
+const STRATEGY_RULES = [
+  { icon: '⚖️', label: '70% SOL / 30% USDC baseline allocation' },
+  { icon: '🤖', label: 'AI Agent proposes rebalances when SOL moves ±10% from 7-day MA' },
+  { icon: '⏱️', label: '24h voting window · 50% quorum · 60% approval threshold' },
+  { icon: '🔒', label: 'Max 20% of treasury per single swap — hard-coded in the contract' },
+  { icon: '📖', label: 'All rules visible on the pot page under the Trade tab' },
+]
 
 export default function VaultsPage() {
-  const [selectedStrategy, setSelectedStrategy] = useState('all');
-  const [creatorFilter, setCreatorFilter] = useState('all');
-  const [sortBy, setSortBy] = useState('returns');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [search, setSearch] = useState('')
+  const [sortBy, setSortBy] = useState<'tvl' | 'members' | 'recent'>('tvl')
 
-  // ── Live data ────────────────────────────────────────────────────────────
-  const { data: pots = [], isLoading: potsLoading } = usePots();
-  const { price: solPrice } = useSolPrice();
+  const { data: pots = [], isLoading: potsLoading } = usePots()
+  const { price: solPrice } = useSolPrice()
+  const { data: onePot } = usePot(ONE_POT_PUBKEY)
 
-  // Batch-fetch analytics for all visible pots
-  const livePubkeys = useMemo(() => pots.map((p: any) => p.pubkey), [pots]);
-  const { dataMap: analyticsMap, isLoading: analyticsLoading } = useVaultAnalyticsBatch(livePubkeys);
+  // Pull batch analytics for the rest
+  const livePubkeys = useMemo(() => pots.map((p: any) => p.pubkey), [pots])
+  const { dataMap: analyticsMap } = useVaultAnalyticsBatch(livePubkeys)
 
-  const isLiveData = pots.length > 0;
+  const otherVaults = useMemo(() => {
+    return pots
+      .filter((p: any) => p.pubkey !== ONE_POT_PUBKEY)
+      .filter((p: any) => p.name?.toLowerCase().includes(search.toLowerCase()) ||
+                          p.pubkey.toLowerCase().includes(search.toLowerCase()))
+      .sort((a: any, b: any) => {
+        if (sortBy === 'tvl')     return (b.balance ?? 0) - (a.balance ?? 0)
+        if (sortBy === 'members') return (b.memberCount ?? 0) - (a.memberCount ?? 0)
+        return (b.createdAt ?? 0) - (a.createdAt ?? 0)
+      })
+  }, [pots, search, sortBy])
 
-  // ── Map real pots → vault card shape ─────────────────────────────────────
-  const liveVaults = useMemo(() => {
-    const solUsd = solPrice ?? 150; // fallback price if not yet loaded
-    return pots.map((pot: any) => {
-      const analytics = analyticsMap[pot.pubkey];
-      const aumUsd = analytics?.navUsd ?? (pot.balance * solUsd);
-      const pnl30d = analytics?.pnlPct ?? 0;
-      const apy30d = analytics?.apy30d ?? 0;
-      return {
-        pubkey:           pot.pubkey,
-        name:             pot.name,
-        emoji:            pot.emoji || '🪴',
-        strategyType:     YIELD_TO_STRATEGY[pot.yieldStrategy] ?? 'ai_dca',
-        riskLevel:        'balanced',
-        creatorType:      'community',
-        creatorHandle:    `${pot.pubkey.slice(0, 4)}…${pot.pubkey.slice(-4)}`,
-        memberCount:      pot.memberCount,
-        aumUsd,
-        pnl30d:           Number(pnl30d.toFixed(2)),
-        apy30d:           Number(apy30d.toFixed(1)),
-        tamagotchiLevel:  pot.tamagotchiLevel,
-        tamagotchiEmoji:  pot.tamagotchiEmoji,
-        entryFeeUsd:      0,
-        performanceFeeBps: 0,
-        isAiAgent:        false,
-        isDemo:           false,
-      };
-    });
-  }, [pots, analyticsMap, solPrice]);
+  const onePotBalanceUsd = onePot && solPrice ? onePot.balance * solPrice : null
+  const onePotAny = onePot as any
 
-  // Use live vaults if on-chain program is active, otherwise demo data
-  const allVaults = isLiveData ? liveVaults : DEMO_VAULTS;
-
-  // ── Filtering & sorting ──────────────────────────────────────────────────
-  const filteredAndSortedVaults = useMemo(() => {
-    let filtered = allVaults.filter((vault) => {
-      const matchesStrategy = selectedStrategy === 'all' || vault.strategyType === selectedStrategy;
-      const matchesCreator = creatorFilter === 'all'
-        || (creatorFilter === 'ai_agents' && vault.isAiAgent)
-        || (creatorFilter === 'human' && !vault.isAiAgent);
-      const matchesSearch =
-        vault.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        vault.creatorHandle.toLowerCase().includes(searchQuery.toLowerCase());
-      return matchesStrategy && matchesCreator && matchesSearch;
-    });
-    return filtered.sort((a, b) => {
-      if (sortBy === 'returns') return b.pnl30d - a.pnl30d;
-      if (sortBy === 'aum')     return b.aumUsd - a.aumUsd;
-      if (sortBy === 'members') return b.memberCount - a.memberCount;
-      return 0;
-    });
-  }, [allVaults, selectedStrategy, creatorFilter, sortBy, searchQuery]);
-
-  // ── Aggregate stats ─────────────────────────────────────────────────────
-  const totalAum     = allVaults.reduce((s, v) => s + v.aumUsd, 0);
-  const avgReturn    = allVaults.length > 0
-    ? (allVaults.reduce((s, v) => s + v.pnl30d, 0) / allVaults.length).toFixed(1)
-    : '0.0';
-  const totalMembers = allVaults.reduce((s, v) => s + v.memberCount, 0);
+  const tamaStats = onePot
+    ? calculateTamaStats({
+        tradeVolume: onePotAny.totalVolume ?? 0,
+        memberCount: onePotAny.memberCount ?? 0,
+        winRate: 0.5,
+        yieldApy: 0,
+        ageSeconds: 86400,
+      })
+    : null
+  const tamaLevel = tamaStats ? Math.max(1, Math.min(5, Math.floor(tamaStats.hp / 20) + 1)) : 1
 
   return (
-    <div style={{ minHeight: '100vh', fontFamily: 'Geist, sans-serif', color: 'var(--c-text)' }}>
-      {/* Page header — NOT sticky (global <Navbar/> in layout.tsx already is;
-          two sticky headers at top:0 caused z-fighting and the global nav
-          disappearing on scroll). */}
-      <div style={{ borderBottom: '1px solid var(--c-border)', padding: '12px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-          <Link href="/" style={{ color: 'var(--c-muted)', textDecoration: 'none', fontSize: '14px' }}>← Back</Link>
-          <h1 style={{ margin: 0, fontSize: '18px', fontWeight: '600' }}>⚡ PotBot Vaults</h1>
-          {/* Live / Demo badge */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--c-muted)' }}>
-            <span style={{ width: '6px', height: '6px', borderRadius: '50%', backgroundColor: isLiveData ? '#14F195' : '#F59E0B', animation: isLiveData ? 'pulse 2s infinite' : 'none' }} />
-            <span style={{ color: isLiveData ? '#14F195' : '#F59E0B' }}>{isLiveData ? 'Live data' : 'Devnet preview'}</span>
+    <div className="min-h-screen">
+      {/* Page header — small breadcrumb + create CTA */}
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-4 flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 text-xs text-pot-muted">
+          <Link href="/" className="hover:text-white transition">Home</Link>
+          <span>/</span>
+          <span className="text-white font-semibold">Vaults</span>
+        </div>
+        <Link
+          href="/create"
+          className="px-4 py-2 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold text-sm transition"
+        >
+          + Create Vault
+        </Link>
+      </div>
+
+      {/* ════════════════════ ONE POT HERO ════════════════════ */}
+      <section className="max-w-[1400px] mx-auto px-3 sm:px-6 mb-10">
+        <div className="relative overflow-hidden rounded-3xl border border-pot-green/30 bg-gradient-to-br from-pot-green/10 via-pot-card to-pot-accent/10 p-5 sm:p-8">
+          {/* Status header */}
+          <div className="flex items-center gap-2 flex-wrap mb-4">
+            <span className="px-2 py-0.5 rounded-full bg-pot-green/20 text-pot-green text-[10px] font-bold uppercase tracking-wider">
+              ⭐ Featured
+            </span>
+            <StatusBadge tier={CLUSTER === 'mainnet-beta' ? 'live' : 'devnet'} compact />
+            <span className="text-[11px] text-pot-muted">Public flagship pot · open to anyone</span>
           </div>
-        </div>
-        <Link href="/create" style={{ backgroundColor: '#14F195', color: '#0D1117', border: 'none', padding: '8px 16px', borderRadius: '6px', fontWeight: '600', fontSize: '14px', textDecoration: 'none' }}>+ Create Vault</Link>
-      </div>
 
-      {/* ── ONE POT featured banner — first concrete example for new visitors ── */}
-      <div style={{ maxWidth: '1400px', margin: '24px auto 0', padding: '0 24px' }}>
-        <OnePotBanner />
-      </div>
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 sm:gap-8 items-center">
+            {/* Left — name + emoji + plant */}
+            <div className="lg:col-span-3 min-w-0">
+              <div className="flex items-start gap-4 sm:gap-5 mb-4">
+                <div className="text-5xl sm:text-7xl shrink-0">{onePot?.emoji ?? '🪴'}</div>
+                <div className="min-w-0">
+                  <h1 className="text-2xl sm:text-4xl font-black text-white leading-tight">
+                    {onePot?.name ?? 'PotBot ONE'}
+                  </h1>
+                  <p className="text-sm sm:text-base text-pot-muted mt-1">
+                    The flagship public pot. Deposit, propose a Jupiter swap, vote, watch it execute on-chain.
+                  </p>
+                  {tamaStats && (
+                    <div className="mt-3 flex items-center gap-2 text-xs text-pot-muted">
+                      <span className="text-lg">{TAMA_EMOJI[tamaLevel]}</span>
+                      <span className="text-white font-semibold">{TAMA_NAME[tamaLevel]}</span>
+                      <span>· HP {tamaStats.hp}/100</span>
+                    </div>
+                  )}
+                </div>
+              </div>
 
-      {/* Devnet-preview banner — honest framing until mainnet cut. */}
-      {!isLiveData && (
-        <div style={{ maxWidth: '1400px', margin: '16px auto 0', padding: '12px 16px', backgroundColor: '#F59E0B1A', border: '1px solid #F59E0B40', borderRadius: '8px', fontSize: '13px', color: 'var(--c-text)', display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
-          <span style={{ fontSize: '16px' }}>⚠️</span>
-          <span>
-            <strong>Devnet preview.</strong> The vaults below are demonstrative —
-            real performance data reports after mainnet launch (target: May 2026).
-            You can still create your own pot on devnet today to explore the full flow.
-          </span>
-        </div>
-      )}
-
-      {/* Stats strip */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '16px', padding: '24px', borderBottom: '1px solid var(--c-border)', maxWidth: '1400px', margin: '0 auto' }}>
-        <StatCard label="Total AUM" value={totalAum >= 1_000_000 ? `$${(totalAum/1_000_000).toFixed(1)}M` : `$${(totalAum/1000).toFixed(0)}K`} loading={potsLoading} />
-        <StatCard label="Active Vaults" value={String(allVaults.length)} loading={potsLoading} />
-        <StatCard label="Total Members" value={totalMembers.toLocaleString()} loading={potsLoading} />
-        {/* Don't show "+0.0%" — replace with honest placeholder until mainnet. */}
-        <StatCard
-          label="Avg PnL (30d)"
-          value={isLiveData && Number(avgReturn) !== 0 ? `${Number(avgReturn) >= 0 ? '+' : ''}${avgReturn}%` : '—'}
-          loading={potsLoading}
-          color="#14F195"
-        />
-      </div>
-
-      {/* AI Agents banner */}
-      <div style={{ margin: '24px auto', maxWidth: '1400px', padding: '20px 24px', backgroundColor: '#9945FF', borderRadius: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <div style={{ fontSize: '14px' }}>🤖 PotBot is MCP-native — AI agents can autonomously allocate treasury across vaults</div>
-        <Link href="/for-agents" style={{ color: '#0D1117', textDecoration: 'none', fontWeight: '600', fontSize: '14px', whiteSpace: 'nowrap' }}>For AI Agents →</Link>
-      </div>
-
-      {/* Filters */}
-      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '24px', display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
-        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-          {['all', 'ai_dca', 'trend_following', 'mean_reversion', 'hodl', 'degen', 'yield'].map((strategy) => (
-            <button key={strategy} onClick={() => setSelectedStrategy(strategy)} style={{ padding: '6px 12px', borderRadius: '20px', border: '1px solid var(--c-border)', backgroundColor: selectedStrategy === strategy ? '#14F195' : 'transparent', color: selectedStrategy === strategy ? '#0D1117' : 'var(--c-text)', fontSize: '13px', cursor: 'pointer', fontWeight: selectedStrategy === strategy ? '600' : '400' }}>
-              {strategy === 'all' ? 'All' : STRATEGY_LABELS[strategy]}
-            </button>
-          ))}
-        </div>
-        <div style={{ display: 'flex', gap: '16px', marginLeft: 'auto' }}>
-          <select value={creatorFilter} onChange={(e) => setCreatorFilter(e.target.value)} style={{ backgroundColor: 'var(--c-card)', border: '1px solid var(--c-border)', color: 'var(--c-text)', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer' }}>
-            <option value="all">All Types</option>
-            <option value="ai_agents">AI Agents Only</option>
-            <option value="human">Human Traders</option>
-          </select>
-          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} style={{ backgroundColor: 'var(--c-card)', border: '1px solid var(--c-border)', color: 'var(--c-text)', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', cursor: 'pointer' }}>
-            <option value="returns">Best Returns</option>
-            <option value="aum">Biggest AUM</option>
-            <option value="members">Most Members</option>
-          </select>
-          <input type="text" placeholder="Search vaults..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} style={{ backgroundColor: 'var(--c-card)', border: '1px solid var(--c-border)', color: 'var(--c-text)', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', minWidth: '200px' }} />
-        </div>
-      </div>
-
-      {/* Vault grid */}
-      {potsLoading ? (
-        <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '0 24px 40px', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px' }}>
-          {[1,2,3,4,5,6].map(i => (
-            <div key={i} style={{ backgroundColor: 'var(--c-card)', border: '1px solid var(--c-border)', borderRadius: '8px', height: '220px', animation: 'pulse 2s infinite' }} />
-          ))}
-        </div>
-      ) : (
-        <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '0 24px 40px', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px' }}>
-          {filteredAndSortedVaults.map((vault) => (
-            <VaultCard
-              key={vault.pubkey}
-              vault={vault}
-              analyticsLoading={analyticsLoading && !vault.isDemo}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Strategy legend */}
-      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '40px 24px', borderTop: '1px solid var(--c-border)' }}>
-        <h2 style={{ fontSize: '20px', fontWeight: '700', marginBottom: '24px' }}>Strategy Types</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '16px' }}>
-          {[
-            { key: 'ai_dca',          label: '🤖 AI DCA',           desc: 'Automated dollar-cost averaging using AI signals' },
-            { key: 'trend_following', label: '📈 Trend Following',   desc: 'Ride momentum based on technical indicators' },
-            { key: 'mean_reversion',  label: '🔄 Mean Reversion',    desc: 'Capitalize on price swings back to average' },
-            { key: 'hodl',            label: '💎 HODL',              desc: 'Long-term buy and hold strategy' },
-            { key: 'degen',           label: '🎰 Degen',             desc: 'High-risk, high-reward experimental strategies' },
-            { key: 'yield',           label: '🌾 Yield Farming',     desc: 'Maximize yield through DeFi protocols' },
-          ].map((s) => (
-            <div key={s.key} style={{ backgroundColor: 'var(--c-card)', border: `1px solid ${STRATEGY_COLORS[s.key]}`, borderRadius: '8px', padding: '16px' }}>
-              <div style={{ fontWeight: '600', fontSize: '14px', marginBottom: '8px' }}>{s.label}</div>
-              <div style={{ fontSize: '13px', color: 'var(--c-muted)' }}>{s.desc}</div>
+              {/* Strategy rules */}
+              <div className="bg-pot-dark/60 border border-pot-border rounded-2xl p-4 sm:p-5 space-y-2">
+                <div className="text-[11px] font-bold uppercase tracking-wider text-pot-green mb-1">
+                  How this pot trades
+                </div>
+                {STRATEGY_RULES.map((r) => (
+                  <div key={r.label} className="flex items-start gap-2 text-xs sm:text-sm">
+                    <span className="shrink-0">{r.icon}</span>
+                    <span className="text-white/90 leading-snug">{r.label}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
 
-// ── VaultCard ────────────────────────────────────────────────────────────────
-
-function StatCard({ label, value, loading, color }: { label: string; value: string; loading?: boolean; color?: string }) {
-  return (
-    <div style={{ backgroundColor: 'var(--c-card)', padding: '16px', borderRadius: '8px', border: '1px solid var(--c-border)' }}>
-      <div style={{ fontSize: '12px', color: 'var(--c-muted)', marginBottom: '8px' }}>{label}</div>
-      {loading ? (
-        <div style={{ height: '28px', width: '60px', backgroundColor: 'var(--c-border)', borderRadius: '4px' }} />
-      ) : (
-        <div style={{ fontSize: '20px', fontWeight: '700', color: color ?? 'var(--c-text)' }}>{value}</div>
-      )}
-    </div>
-  );
-}
-
-function VaultCard({ vault, analyticsLoading }: { vault: any; analyticsLoading: boolean }) {
-  const pnlColor = vault.pnl30d >= 0 ? '#14F195' : '#EF4444';
-  const apyColor = '#9945FF';
-
-  return (
-    <Link
-      href={vault.isDemo ? '#' : `/pots/${vault.pubkey}`}
-      style={{ textDecoration: 'none' }}
-    >
-      <div style={{ backgroundColor: 'var(--c-card)', border: '1px solid var(--c-border)', borderRadius: '8px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px', cursor: 'pointer', transition: 'border-color 0.15s', position: 'relative' }}>
-        {/* Demo badge — corner ribbon so it's obvious this isn't a real vault yet. */}
-        {vault.isDemo && (
-          <span style={{ position: 'absolute', top: '8px', right: '8px', backgroundColor: '#F59E0B', color: '#0D1117', fontSize: '9px', fontWeight: '700', padding: '2px 6px', borderRadius: '4px', letterSpacing: '0.5px' }}>
-            DEMO
-          </span>
-        )}
-
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <span style={{ fontSize: '24px' }}>{vault.emoji}</span>
-            <div style={{ fontWeight: '600', fontSize: '14px', color: 'var(--c-text)' }}>{vault.name}</div>
-          </div>
-          <span style={{ fontSize: '20px' }}>{vault.tamagotchiEmoji}</span>
-        </div>
-
-        {/* Strategy badge */}
-        <div style={{ display: 'inline-block', padding: '4px 10px', borderRadius: '4px', backgroundColor: STRATEGY_COLORS[vault.strategyType] ?? '#9945FF', color: '#0D1117', fontSize: '12px', fontWeight: '600', width: 'fit-content' }}>
-          {STRATEGY_LABELS[vault.strategyType] ?? vault.strategyType}
-        </div>
-
-        {/* Creator */}
-        <div style={{ fontSize: '13px', color: 'var(--c-muted)' }}>
-          {vault.isAiAgent ? '🤖 ' : '@'}{vault.creatorHandle}
-        </div>
-
-        {/* Stats grid */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(80px, 1fr))', gap: '8px', fontSize: '12px' }}>
-          <div>
-            <div style={{ color: 'var(--c-muted)', marginBottom: '4px' }}>Members</div>
-            <div style={{ fontWeight: '600', color: 'var(--c-text)' }}>{vault.memberCount}</div>
-          </div>
-          <div>
-            <div style={{ color: 'var(--c-muted)', marginBottom: '4px' }}>AUM</div>
-            {analyticsLoading ? (
-              <div style={{ height: '16px', width: '40px', backgroundColor: 'var(--c-border)', borderRadius: '3px' }} />
-            ) : (
-              <div style={{ fontWeight: '600', color: 'var(--c-text)' }}>
-                {vault.aumUsd >= 1_000 ? `$${(vault.aumUsd/1_000).toFixed(1)}K` : `$${vault.aumUsd.toFixed(0)}`}
+            {/* Right — metrics + CTAs */}
+            <div className="lg:col-span-2 space-y-3">
+              <Stat label="TVL" value={onePot ? `${onePot.balance.toFixed(2)} SOL` : '—'} sub={onePotBalanceUsd ? `$${onePotBalanceUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}` : undefined} accent="green" />
+              <div className="grid grid-cols-2 gap-3">
+                <Stat label="Members" value={String(onePot?.memberCount ?? 0)} />
+                <Stat label="Trades" value={String(onePotAny?.tradeCount ?? 0)} />
               </div>
-            )}
-          </div>
-          <div>
-            <div style={{ color: 'var(--c-muted)', marginBottom: '4px' }}>PnL</div>
-            {analyticsLoading ? (
-              <div style={{ height: '16px', width: '40px', backgroundColor: 'var(--c-border)', borderRadius: '3px' }} />
-            ) : (
-              <div style={{ fontWeight: '600', color: pnlColor }}>
-                {vault.pnl30d >= 0 ? '+' : ''}{vault.pnl30d}%
+
+              <div className="flex flex-col gap-2 pt-2">
+                <Link
+                  href={`/pots/${ONE_POT_PUBKEY}`}
+                  className="w-full px-5 py-3 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold text-sm sm:text-base text-center transition"
+                >
+                  💰 Open & deposit
+                </Link>
+                <Link
+                  href={`/pots/${ONE_POT_PUBKEY}#propose-section`}
+                  className="w-full px-5 py-3 rounded-xl bg-pot-accent hover:bg-pot-accent/90 text-white font-bold text-sm sm:text-base text-center transition"
+                >
+                  🗳️ See active proposals
+                </Link>
               </div>
-            )}
+            </div>
           </div>
         </div>
+      </section>
 
-        {/* APY row (live data only) */}
-        {!vault.isDemo && vault.apy30d > 0 && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
-            <span style={{ color: 'var(--c-muted)' }}>APY 30d:</span>
-            <span style={{ fontWeight: '700', color: apyColor }}>{vault.apy30d.toFixed(1)}%</span>
+      {/* ════════════════════ OTHER PUBLIC VAULTS ════════════════════ */}
+      <section className="max-w-[1400px] mx-auto px-3 sm:px-6 pb-12">
+        <div className="flex items-end justify-between gap-3 mb-4 flex-wrap">
+          <div>
+            <h2 className="text-xl sm:text-2xl font-bold text-white">More public vaults</h2>
+            <p className="text-xs text-pot-muted mt-0.5">
+              {potsLoading ? 'Loading…' : `${otherVaults.length} active pot${otherVaults.length === 1 ? '' : 's'}`}
+            </p>
           </div>
-        )}
-
-        {/* Mini chart bars (decorative) */}
-        <div style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height: '24px', marginTop: '4px' }}>
-          {[40, 60, 35, 70, 50, 80, 65].map((height, i) => (
-            <div
-              key={i}
-              style={{ flex: 1, height: `${height}%`, backgroundColor: pnlColor, borderRadius: '2px', opacity: 0.6 }}
+          <div className="flex items-center gap-2 flex-wrap">
+            <input
+              type="search"
+              placeholder="Search…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="px-3 py-1.5 rounded-lg bg-pot-card border border-pot-border text-sm text-white placeholder:text-pot-muted focus:outline-none focus:border-pot-accent w-40"
             />
-          ))}
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as any)}
+              className="px-3 py-1.5 rounded-lg bg-pot-card border border-pot-border text-sm text-white focus:outline-none focus:border-pot-accent"
+            >
+              <option value="tvl">Biggest TVL</option>
+              <option value="members">Most members</option>
+              <option value="recent">Recently created</option>
+            </select>
+          </div>
         </div>
 
-        {/* Fee info */}
-        <div style={{ fontSize: '12px', color: 'var(--c-muted)', marginTop: '4px' }}>
-          {vault.entryFeeUsd === 0 ? 'Free entry' : `$${vault.entryFeeUsd} entry`}
-          {vault.performanceFeeBps > 0 && ` · ${(vault.performanceFeeBps / 100).toFixed(1)}% perf fee`}
-        </div>
-
-        {/* CTA */}
-        {!vault.isDemo && (
-          <div style={{ marginTop: '8px', padding: '8px 12px', borderRadius: '6px', border: 'none', fontWeight: '600', fontSize: '13px', backgroundColor: '#14F195', color: '#0D1117', textAlign: 'center' }}>
-            View Vault →
+        {potsLoading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {[0, 1, 2, 3, 4, 5].map((i) => (
+              <div key={i} className="bg-pot-card border border-pot-border rounded-2xl p-5 animate-pulse h-32" />
+            ))}
+          </div>
+        ) : otherVaults.length === 0 ? (
+          <div className="bg-pot-card border border-pot-border rounded-2xl p-8 text-center">
+            <div className="text-3xl mb-2">🌱</div>
+            <p className="text-white font-semibold mb-1">No other public pots yet</p>
+            <p className="text-pot-muted text-sm mb-4">Be first — create one in 30 seconds.</p>
+            <Link
+              href="/create"
+              className="inline-block px-4 py-2 rounded-xl bg-pot-green hover:bg-pot-green/90 text-pot-dark font-bold text-sm transition"
+            >
+              + Create Vault
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {otherVaults.map((p: any) => {
+              const balanceUsd = solPrice ? p.balance * solPrice : null
+              const analytics = analyticsMap[p.pubkey]
+              return (
+                <Link
+                  key={p.pubkey}
+                  href={`/pots/${p.pubkey}`}
+                  className="bg-pot-card border border-pot-border hover:border-pot-accent/40 rounded-2xl p-4 transition group"
+                >
+                  <div className="flex items-start gap-3 mb-3">
+                    <div className="text-3xl shrink-0">{p.emoji ?? '🪴'}</div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-white font-bold truncate group-hover:text-pot-accent transition">
+                        {p.name ?? 'Unnamed pot'}
+                      </p>
+                      <p className="text-[10px] text-pot-muted font-mono truncate">
+                        {p.pubkey.slice(0, 6)}…{p.pubkey.slice(-6)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    <Mini label="TVL" value={`${(p.balance ?? 0).toFixed(2)}◎`} />
+                    <Mini label="Members" value={String(p.memberCount ?? 0)} />
+                    <Mini label="Trades" value={String(p.tradeCount ?? 0)} />
+                  </div>
+                  {analytics?.pnlPct != null && analytics.pnlPct !== 0 && (
+                    <div className={`mt-2 text-[11px] font-semibold ${analytics.pnlPct >= 0 ? 'text-pot-green' : 'text-red-400'}`}>
+                      {analytics.pnlPct >= 0 ? '+' : ''}{analytics.pnlPct.toFixed(1)}% (30d)
+                    </div>
+                  )}
+                </Link>
+              )
+            })}
           </div>
         )}
-      </div>
-    </Link>
-  );
+      </section>
+
+      {/* ════════════════════ AI agents banner — slim ════════════════════ */}
+      <section className="max-w-[1400px] mx-auto px-3 sm:px-6 pb-12">
+        <Link
+          href="/for-agents"
+          className="block bg-pot-card border border-pot-accent/30 hover:border-pot-accent/60 rounded-2xl p-4 sm:p-5 transition"
+        >
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex items-center gap-3 min-w-0">
+              <span className="text-2xl shrink-0">🤖</span>
+              <div className="min-w-0">
+                <p className="text-white font-semibold text-sm sm:text-base">PotBot is MCP-native</p>
+                <p className="text-xs text-pot-muted">Any AI agent — Claude, GPT — can list vaults, propose swaps, vote.</p>
+              </div>
+            </div>
+            <span className="text-pot-accent text-xs font-bold shrink-0">For AI Agents →</span>
+          </div>
+        </Link>
+      </section>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string
+  value: string
+  sub?: string
+  accent?: 'green'
+}) {
+  const valueClass = accent === 'green' ? 'text-pot-green' : 'text-white'
+  return (
+    <div className="bg-pot-dark/60 border border-pot-border rounded-2xl px-4 py-3">
+      <div className="text-[10px] uppercase tracking-wider text-pot-muted font-bold">{label}</div>
+      <div className={`text-xl sm:text-2xl font-black tabular-nums ${valueClass} mt-0.5`}>{value}</div>
+      {sub && <div className="text-[11px] text-pot-muted tabular-nums">{sub}</div>}
+    </div>
+  )
+}
+
+function Mini({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-pot-dark/60 rounded-lg px-2 py-1.5">
+      <div className="text-[9px] uppercase tracking-wider text-pot-muted">{label}</div>
+      <div className="text-xs font-bold text-white tabular-nums">{value}</div>
+    </div>
+  )
 }

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -72,9 +72,9 @@ function LivePriceTicker() {
 
 const NAV_LINKS = [
   { href: '/',            label: 'Home' },
-  { href: '/leaderboard', label: '🏆 Leaderboard' },
   { href: '/vaults',      label: '⚡ Vaults' },
-  { href: '/roadmap',     label: '🗺️ Roadmap' },
+  { href: '/leaderboard', label: '🏆 Leaderboard' },
+  { href: '/hackathon',   label: '🏆 Hackathon' },
   { href: '/create',      label: '+ Create' },
 ]
 

--- a/apps/web/src/components/PotActivityFeed.tsx
+++ b/apps/web/src/components/PotActivityFeed.tsx
@@ -50,7 +50,7 @@ function formatRelative(ts: number) {
   return new Date(ts).toLocaleDateString()
 }
 
-export function PotActivityFeed({ pot, proposals, members, cluster = 'devnet', limit = 6 }: Props) {
+export function PotActivityFeed({ pot, proposals, members, cluster = 'devnet', limit = 3 }: Props) {
   const events: Event[] = useMemo(() => {
     const out: Event[] = []
     const explorerSuffix = cluster === 'mainnet-beta' ? '' : '?cluster=devnet'

--- a/apps/web/src/components/SeasonPrizePoolModal.tsx
+++ b/apps/web/src/components/SeasonPrizePoolModal.tsx
@@ -1,23 +1,60 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
 /**
  * Season 1 Prize Pool — "How it works" modal.
- * Reused from /leaderboard SeasonPrizeCard and the Navbar Season 1 ticker.
+ *
+ * Rendered via React Portal to document.body so position:fixed is always
+ * viewport-relative — any transform/backdrop-filter on an ancestor (Navbar,
+ * tab content, etc.) won't shift the modal off-center.
  */
 export function SeasonPrizePoolModal({ onClose }: { onClose: () => void }) {
-  return (
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    // Lock body scroll while modal is open
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    // Esc closes modal
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+
+    return () => {
+      document.body.style.overflow = prev
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  if (!mounted) return null
+
+  const modal = (
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center p-4"
       onClick={onClose}
-      style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+      style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="season-modal-title"
     >
       <div
-        className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card p-6 sm:p-8 shadow-2xl"
+        className="w-full max-w-md rounded-3xl border border-pot-border bg-pot-card p-6 sm:p-8 shadow-2xl max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-lg font-bold text-white">🏆 Season 1 Prize Pool</h2>
-          <button onClick={onClose} className="text-pot-muted hover:text-white transition text-xl" aria-label="Close">×</button>
+          <h2 id="season-modal-title" className="text-lg font-bold text-white">🏆 Season 1 Prize Pool</h2>
+          <button
+            onClick={onClose}
+            className="text-pot-muted hover:text-white transition text-2xl leading-none w-8 h-8 flex items-center justify-center"
+            aria-label="Close"
+          >
+            ×
+          </button>
         </div>
 
         <div className="space-y-4 text-sm">
@@ -42,7 +79,7 @@ export function SeasonPrizePoolModal({ onClose }: { onClose: () => void }) {
           {/* Ranking formula */}
           <div>
             <h3 className="text-xs font-semibold text-pot-muted uppercase tracking-wide mb-2">Ranking Formula</h3>
-            <div className="p-3 rounded-xl bg-pot-dark border border-pot-border font-mono text-xs text-pot-green">
+            <div className="p-3 rounded-xl bg-pot-dark border border-pot-border font-mono text-xs text-pot-green break-all">
               Season Score = volume × members × pet_health
             </div>
             <p className="text-xs text-pot-muted mt-2 leading-relaxed">
@@ -63,10 +100,15 @@ export function SeasonPrizePoolModal({ onClose }: { onClose: () => void }) {
           </div>
         </div>
 
-        <button onClick={onClose} className="btn-secondary w-full mt-5 text-sm py-2.5">
+        <button
+          onClick={onClose}
+          className="w-full mt-5 text-sm py-2.5 rounded-xl bg-pot-border hover:bg-pot-accent/20 text-white font-semibold transition"
+        >
           Close
         </button>
       </div>
     </div>
   )
+
+  return createPortal(modal, document.body)
 }

--- a/apps/web/src/components/SponsorRail.tsx
+++ b/apps/web/src/components/SponsorRail.tsx
@@ -3,18 +3,18 @@
 import { useState } from 'react'
 
 /**
- * SponsorRail — horizontal rail of sponsor / integration chips on /pots/[pubkey].
+ * SponsorRail — slim horizontal rail of sponsor / integration chips.
  *
  * Lifts the killer claim ("real Jupiter v6 CPI from a vault PDA") above the
- * fold for hackathon judges. Each chip = (a) name, (b) what it does in this
- * pot, (c) link to verifiable proof. Mobile: horizontal scroll, no clipping.
+ * fold for hackathon judges. No "Powered by" label, no indicator dots —
+ * just emoji + name + sub-line. Compact (py-1.5).
  *
  * Sources of truth:
  * - Jupiter CPI happens in pot_vault::execute_swap. Any swap proposal that
  *   resolved to executed has an Explorer tx — we point to the most recent.
  * - Helius RPC is wired in apps/web/src/lib/rpc.ts via NEXT_PUBLIC_HELIUS_RPC.
  * - Squads is conditional — only shown if creator is a multisig vault.
- * - Solana Blink — opens an X intent pre-filled with the deposit Action URL.
+ * - Solana Blink — copies the Action URL to clipboard.
  * - MCP — links to the npm package.
  */
 
@@ -52,13 +52,9 @@ export function SponsorRail({
   }
 
   return (
-    <div className="border-b border-pot-border bg-pot-card/30">
-      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-2.5">
-        <div className="flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <span className="text-[10px] uppercase tracking-wider text-pot-muted shrink-0 mr-1">
-            Powered by
-          </span>
-
+    <div className="border-b border-pot-border/50 bg-pot-card/20">
+      <div className="max-w-[1400px] mx-auto px-3 sm:px-6 py-1.5">
+        <div className="flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <Chip
             href={
               lastSwapTx
@@ -71,59 +67,47 @@ export function SponsorRail({
                 ? 'View last on-chain swap on Solana Explorer'
                 : 'Jupiter v6 CPI — pot_vault::execute_swap'
             }
-            label="🪐 Jupiter v6"
-            sub={lastSwapTx ? 'last tx ↗' : 'CPI'}
+            label="🪐 Jupiter"
           />
-
           <Chip
             href="https://www.helius.dev/"
             color="amber"
             title="Helius RPC + webhooks"
             label="⚡ Helius"
-            sub="RPC"
           />
-
           {squadsManaged && (
             <Chip
               href={`https://app.squads.so/squads/${potPubkey}`}
               color="blue"
               title="This pot is owned by a Squads v4 multisig"
-              label="🛡 Squads v4"
-              sub="multisig"
+              label="🛡 Squads"
             />
           )}
-
           <Chip
             href="https://docs.dialect.to/documentation/actions/blinks"
             color="green"
-            title="Solana Actions endpoint — vote / deposit straight from a tweet"
+            title="Solana Actions endpoint"
             label="⚡ Blinks"
-            sub="actions"
           />
-
           <button
             type="button"
             onClick={copyBlink}
             title="Copy this pot's Blink URL"
-            className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border border-pot-border bg-pot-card hover:border-pot-green/50 text-[11px] text-white transition"
+            className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-md border border-pot-border bg-pot-card hover:border-pot-green/50 text-[11px] text-pot-muted hover:text-white transition"
           >
-            🔗 {copied ? 'Copied!' : 'Copy Blink URL'}
+            {copied ? '✓ copied' : '🔗 Copy Blink'}
           </button>
-
           <Chip
             href="https://www.npmjs.com/package/@potbot/mcp"
             color="purple"
-            title="@potbot/mcp on npm — Claude/GPT can manage this pot"
+            title="@potbot/mcp on npm"
             label="🤖 MCP"
-            sub="agent api"
           />
-
           <Chip
             href={`https://explorer.solana.com/address/${potPubkey}${explorerSuffix}`}
             color="muted"
             title="Verify this pot on Solana Explorer"
             label="🔍 Explorer"
-            sub="verify"
           />
         </div>
       </div>
@@ -136,20 +120,18 @@ function Chip({
   color,
   title,
   label,
-  sub,
 }: {
   href: string
   color: 'green' | 'amber' | 'blue' | 'purple' | 'muted'
   title: string
   label: string
-  sub?: string
 }) {
-  const palette: Record<typeof color, { border: string; text: string; bg: string; hover: string }> = {
-    green:  { border: 'border-pot-green/30',  text: 'text-pot-green',  bg: 'bg-pot-green/5',  hover: 'hover:border-pot-green/60' },
-    amber:  { border: 'border-amber-500/30',  text: 'text-amber-300',  bg: 'bg-amber-500/5',  hover: 'hover:border-amber-500/60' },
-    blue:   { border: 'border-blue-500/30',   text: 'text-blue-300',   bg: 'bg-blue-500/5',   hover: 'hover:border-blue-500/60' },
-    purple: { border: 'border-pot-accent/30', text: 'text-pot-accent', bg: 'bg-pot-accent/5', hover: 'hover:border-pot-accent/60' },
-    muted:  { border: 'border-pot-border',    text: 'text-pot-muted',  bg: 'bg-pot-card',     hover: 'hover:border-pot-muted/60' },
+  const palette: Record<typeof color, { border: string; text: string; hover: string }> = {
+    green:  { border: 'border-pot-green/25',  text: 'text-pot-green',  hover: 'hover:border-pot-green/60' },
+    amber:  { border: 'border-amber-500/25',  text: 'text-amber-300',  hover: 'hover:border-amber-500/60' },
+    blue:   { border: 'border-blue-500/25',   text: 'text-blue-300',   hover: 'hover:border-blue-500/60' },
+    purple: { border: 'border-pot-accent/25', text: 'text-pot-accent', hover: 'hover:border-pot-accent/60' },
+    muted:  { border: 'border-pot-border',    text: 'text-pot-muted',  hover: 'hover:border-pot-muted/60' },
   }
   const c = palette[color]
   return (
@@ -158,10 +140,9 @@ function Chip({
       target="_blank"
       rel="noopener noreferrer"
       title={title}
-      className={`shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border ${c.border} ${c.bg} ${c.hover} ${c.text} text-[11px] font-semibold transition whitespace-nowrap`}
+      className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-md border ${c.border} ${c.hover} ${c.text} text-[11px] font-medium transition whitespace-nowrap`}
     >
-      <span>{label}</span>
-      {sub && <span className="opacity-60 text-[10px] font-medium">· {sub}</span>}
+      {label}
     </a>
   )
 }


### PR DESCRIPTION
## What

YD UX review pass. 5 user-flagged issues + 4 R-list quick wins.

### Fixes
1. **Season 1 modal** renders via React Portal (`createPortal(document.body)`). Body scroll locks while open. Esc closes. Was rendering inside Navbar — any ancestor `transform`/`backdrop-filter` shifted it off-center.
2. **/vaults** rebuilt around the flagship pot. Hero card with emoji, name, plant, strategy rules, TVL/Members/Trades stats, Open & Deposit / See proposals CTAs. Below: compact "More public vaults" grid with search + sort. Slim AI-agent banner at the bottom.
3. **/for-agents** — every inline hex color (#0D1117, #1A2332, #14F195, #9CA3AF, #6B7280, #9945FF) replaced with pot-* tokens. All cards use one `CARD` constant. JSON `<pre>` blocks become `whitespace-pre-wrap break-words` so they wrap on mobile.
4. **Pot detail polish**:
   - SponsorRail loses "POWERED BY" label + indicator dots in chips. Padding `py-2.5 → py-1.5`. Chips are emoji + name only.
   - Trade tab shorter: Holdings preview (shares + P&L + portfolio + manage) collapses behind a single member-only toggle. Non-members do not see it at all.
   - PotActivityFeed default `limit=3` (was 6).
   - Breadcrumb added: Home / Vaults / pot-name.
5. **/roadmap → footer**, **/hackathon → nav**.

### R-list quick wins
- R1: floating bottom-right HackathonButton removed from home — link is in nav now.
- R6: breadcrumbs added on `/pots/<pubkey>`, `/vaults`, `/for-agents`.
- R12: `.gitignore` excludes `_local/`, `_deploy/`, `POTBOT_OPUS/`.

## Verification (after Vercel redeploy)
- Click 🌱 Season 1: The Garden in Navbar → modal centers cleanly.
- `/vaults` → ONE POT hero card visible at top, list of other pots below.
- `/for-agents` → all cards match site theme; on iPhone 13 Mini (375px) the Claude config JSON wraps instead of overflowing.
- `/pots/<pubkey>` → no "POWERED BY" label, sponsor chips slimmer, Trade tab is ~40% shorter, breadcrumb above hero.
- Navbar has no Roadmap link; footer has Roadmap between FAQ and Leaderboard.
- Home page has no floating Hackathon button; Hackathon is in main nav.

## Out of scope (next steps)
- P0.1 mainnet deploy (awaits ок mainnet).
- R-list deeper items (R3 onboarding, R4 FAQ honest Q&A, R5 /create live preview, R7 per-pot OG image, R8 leaderboard formula tooltip, R10 sitemap.xml, R11 inline GIF demo on /hackathon).