### PR TITLE
[codex] Improve Frontier UX positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Built for [Solana Frontier 2026](https://colosseum.com/frontier) · [@PotBot_sol
 **No wallet needed** — `potbot.fun` shows a live flagship pot in read-only mode at the top of `/vaults`.
 
 > Lifecycle legend used everywhere on this repo and the site:
-> 🟢 Live (mainnet) · 🟡 Devnet · 🔵 Phase 2 Q3 2026 · 🟣 Phase 3 Q4 2026 · ⚪ Vision
+> 🟢 Live/verifiable · 🟡 Devnet · 🔵 Phase 2 Q3 2026 · 🟣 Phase 3 Q4 2026 · ⚪ Vision
 
-### Live now (mainnet · Explorer-verifiable) 🟢
+### Live now (devnet · Explorer-verifiable) 🟡
 
-- `pot_vault` Anchor program with 30+ instructions: deposit, propose, vote, `execute_swap` via Jupiter v6 CPI, withdraw.
+- `pot_vault` Anchor program on devnet with 30+ instructions: deposit, propose, vote, `execute_swap` via Jupiter v6 CPI, withdraw.
 - Solana Blinks endpoints — `/api/actions/<potPubkey>/{deposit,vote}` — render as cards in Phantom / Backpack / X.
 - MCP server `@potbot/mcp@0.2.0` on npm — 18 tools, HTTP+SSE+stdio transports.
 - Squads v4 multisig path for the creator role on high-value pots.
@@ -189,7 +189,7 @@ Integrates **x402 micropayments** — agents pay per API call (0.001 USDC/reques
 | MarginFi | Lending/borrowing yield |
 | Metaplex Core | NFT Strategy Shares for Full Bloom+ vaults |
 | MagicBlock | Private USDC referral payouts (confidential transfers via MCP) |
-| Privy | Embedded wallet — join vaults by email, no Phantom needed |
+| Privy | Phase 2: embedded wallet — join vaults by email, no Phantom needed |
 | MoonPay | Fiat on-ramp on vault join page |
 | Pyth / Switchboard | Price oracle fallback |
 
@@ -306,7 +306,7 @@ potbot-v2/
 | NFT | Metaplex Core (Strategy Shares) |
 | Frontend | Next.js 14 · TypeScript · Tailwind CSS |
 | State | Zustand · TanStack Query v5 |
-| Wallets | Phantom · Privy (embedded) · WalletConnect |
+| Wallets | Phantom today · Privy embedded wallets in Phase 2 |
 | Backend | Hono.js · Node.js · PostgreSQL · Redis |
 | MCP | solana-agent-kit · @modelcontextprotocol/sdk |
 | Payments | x402 (AI micropayments) · MagicBlock (private) |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
-    "sonner": "^2.0.7",
     "tailwindcss": "^3.4.4",
     "zustand": "^4.5.4"
   },

--- a/apps/web/src/app/api/admin/send-email/route.ts
+++ b/apps/web/src/app/api/admin/send-email/route.ts
@@ -9,9 +9,9 @@ import { renderEmail, renderEmailPlainText } from '@/lib/email-template'
  *
  * Body:
  *   {
- *     "subject":    "PotBot mainnet is live 🚀",
+ *     "subject":    "PotBot devnet is live",
  *     "preheader":  "Founding members, your early access has landed.",
- *     "headline":   "Mainnet is live",
+ *     "headline":   "Devnet is live",
  *     "body":       "<p>You asked to be first…</p>",
  *     "ctaLabel":   "Open PotBot",
  *     "ctaUrl":     "https://potbot.fun",

--- a/apps/web/src/app/create/page.tsx
+++ b/apps/web/src/app/create/page.tsx
@@ -77,6 +77,10 @@ export default function CreatePotPage() {
   // separate concern enforced in `handleSubmit` and on the submit button.
   const formValid = nameOk && minDepositOk && lockupOk
   const canSubmit = formValid && !!publicKey && !createPot.isPending
+  const tradeGov = GOV_LEVELS.find((g) => g.value === form.tradeLevel) ?? GOV_LEVELS[0]
+  const withdrawGov = GOV_LEVELS.find((g) => g.value === form.withdrawLevel) ?? GOV_LEVELS[0]
+  const yieldStrategy = YIELD_STRATEGIES.find((s) => s.value === form.yieldStrategy) ?? YIELD_STRATEGIES[0]
+  const previewName = form.name.trim() || 'Amsterdam Alpha'
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -104,12 +108,17 @@ export default function CreatePotPage() {
   // about to create. Connect is only required on final Submit (see below).
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <h1 className="text-3xl font-bold text-white mb-2">Create a New POT</h1>
-      <p className="text-pot-muted mb-8">
-        Set up your collective trading vault. You&apos;ll be the first member
-        and authority.
-      </p>
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-white mb-2">Create an AI strategy POT</h1>
+        <p className="text-pot-muted max-w-2xl">
+          Configure the vault your group will see: custody, deposits, voting rules,
+          and the AI proposal surface. Wallet is only needed for the final deploy transaction.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-6 items-start">
+        <div className="min-w-0">
 
       {/* Wallet banner — only shown when form is otherwise valid but wallet
           is missing, so the user isn't nagged until the very last step. */}
@@ -467,6 +476,77 @@ export default function CreatePotPage() {
           </div>
         )}
       </form>
+        </div>
+
+        <aside className="lg:sticky lg:top-28 space-y-4">
+          <div className="rounded-2xl border border-pot-green/30 bg-gradient-to-br from-pot-green/10 via-pot-card to-pot-accent/10 p-5">
+            <div className="flex items-start justify-between gap-3 mb-4">
+              <div className="min-w-0">
+                <div className="text-[11px] font-bold uppercase tracking-wider text-pot-green">
+                  Live preview
+                </div>
+                <h2 className="mt-1 text-xl font-black text-white truncate">
+                  {form.emoji} {previewName}
+                </h2>
+                <p className="mt-1 text-xs text-pot-muted">
+                  {form.isPublic ? 'Public vault · anyone can join' : 'Private vault · invite flow'}
+                </p>
+              </div>
+              <span className="rounded-full border border-pot-border bg-pot-dark px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-pot-muted">
+                Devnet
+              </span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              <PreviewStat label="Min deposit" value={`${form.minDeposit || 0} SOL`} />
+              <PreviewStat label="Lockup" value={form.lockupDays === 0 ? 'None' : `${form.lockupDays}d`} />
+              <PreviewStat label="Trade vote" value={tradeGov.label} />
+              <PreviewStat label="Withdraw vote" value={withdrawGov.label} />
+            </div>
+
+            <div className="rounded-xl border border-pot-border bg-pot-dark/70 p-4 space-y-3">
+              <div>
+                <div className="text-[11px] font-bold uppercase tracking-wider text-pot-muted">
+                  Demo flow
+                </div>
+                <p className="mt-1 text-sm text-white">
+                  AI drafts proposals. Members vote. The program executes only after rules pass.
+                </p>
+              </div>
+              <div className="space-y-2">
+                {[
+                  'Deposit SOL and mint shares',
+                  `AI monitors ${yieldStrategy.label.toLowerCase()} strategy`,
+                  `${tradeGov.label} approval gates each swap`,
+                  'Jupiter execution creates Explorer proof',
+                ].map((item) => (
+                  <div key={item} className="flex items-start gap-2 text-xs text-pot-muted">
+                    <span className="mt-0.5 h-1.5 w-1.5 rounded-full bg-pot-green shrink-0" />
+                    <span>{item}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-pot-border bg-pot-card/70 p-4 text-xs text-pot-muted">
+            <div className="font-bold text-white mb-2">Recommended for Frontier</div>
+            <p className="leading-relaxed">
+              Use Public, Majority trade governance, no lockup, and a small minimum deposit.
+              This gives judges the shortest path to deposit, vote, and verify execution.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+function PreviewStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-pot-border bg-pot-dark/70 p-3">
+      <div className="text-[10px] uppercase tracking-wider text-pot-muted">{label}</div>
+      <div className="mt-1 truncate text-sm font-bold text-white">{value}</div>
     </div>
   )
 }

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -54,11 +54,11 @@ const FAQ_DATA: FAQCategory[] = [
     items: [
       {
         q: 'How does PotBot make money?',
-        a: 'PotBot charges a 0.5% fee on every swap executed through a pot. There are no subscription fees, no fees on deposits or withdrawals, and no fees if your pot doesn\'t trade.',
+        a: 'PotBot charges a 0.30% protocol fee on every swap executed through a pot. There are no subscription fees, no fees on deposits or withdrawals, and no fees if your pot doesn\'t trade.',
       },
       {
         q: 'Where do the fees go?',
-        a: 'Of the 0.5% swap fee: 59% to the protocol treasury, 20% to the referrer of the depositing user, 20% to development and operations, and 1% to the Season Trading Competition Treasury.',
+        a: 'Of the 0.30% swap fee: 59% goes to the protocol treasury, 20% to the referrer of the depositing user, 20% to development and operations, and 1% to the Season Trading Competition Treasury.',
       },
       {
         q: 'How do members earn?',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -8,6 +8,14 @@
     @apply bg-pot-dark text-white;
   }
 
+  a,
+  button,
+  input,
+  select,
+  textarea {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pot-green focus-visible:ring-offset-2 focus-visible:ring-offset-pot-dark;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
   }
@@ -28,19 +36,22 @@
   .btn-primary {
     @apply rounded-xl bg-pot-green px-6 py-2.5 font-semibold text-pot-dark
            transition hover:brightness-110 active:scale-[0.98]
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pot-green focus-visible:ring-offset-2 focus-visible:ring-offset-pot-dark
            disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-secondary {
     @apply rounded-xl border border-pot-border bg-pot-card px-6 py-2.5
            font-medium text-white transition hover:border-pot-muted
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pot-accent focus-visible:ring-offset-2 focus-visible:ring-offset-pot-dark
            active:scale-[0.98];
   }
 
   .input {
     @apply w-full rounded-xl border border-pot-border bg-pot-dark px-4 py-3
            text-white placeholder:text-pot-muted
-           focus:border-pot-green focus:outline-none focus:ring-1 focus:ring-pot-green/50;
+           focus:border-pot-green focus:outline-none focus:ring-1 focus:ring-pot-green/50
+           focus-visible:ring-2 focus-visible:ring-pot-green focus-visible:ring-offset-2 focus-visible:ring-offset-pot-dark;
   }
 
   .glow-green {
@@ -91,7 +102,11 @@
   --c-border: #1A2332;
   --c-border-2: #24324A;
   --c-text: #ffffff;
+  --c-text-soft: #e8edf2;
   --c-muted: #8B9BB4;
+  --c-brand-green: #14f195;
+  --c-brand-accent: #9945ff;
+  --c-surface-shadow: rgba(0, 0, 0, 0.45);
 }
 
 html[data-theme="light"] {
@@ -111,13 +126,27 @@ html[data-theme="light"] {
   --c-border: #e5e7eb;
   --c-border-2: #d1d5db;
   --c-text: #0d1117;
+  --c-text-soft: #1f2937;
   --c-muted: #1f2937;
+  --c-brand-green: #067a46;
+  --c-brand-accent: #6d28d9;
+  --c-surface-shadow: rgba(15, 23, 42, 0.12);
 }
 
 /* ── Body & scrollbar ── */
 html[data-theme="light"] body {
   background-color: var(--pot-bg) !important;
   color: var(--pot-ink) !important;
+}
+html[data-theme="light"] a:focus-visible,
+html[data-theme="light"] button:focus-visible,
+html[data-theme="light"] input:focus-visible,
+html[data-theme="light"] select:focus-visible,
+html[data-theme="light"] textarea:focus-visible,
+html[data-theme="light"] .btn-primary:focus-visible,
+html[data-theme="light"] .btn-secondary:focus-visible,
+html[data-theme="light"] .input:focus-visible {
+  --tw-ring-offset-color: var(--pot-bg) !important;
 }
 html[data-theme="light"] ::-webkit-scrollbar-track { background: var(--pot-bg) !important; }
 html[data-theme="light"] ::-webkit-scrollbar-thumb { background: var(--pot-border-strong) !important; }

--- a/apps/web/src/app/hackathon/page.tsx
+++ b/apps/web/src/app/hackathon/page.tsx
@@ -84,7 +84,7 @@ const TRACKS: Track[] = [
     sponsor: 'Privy',
     emoji: '🪪',
     what: 'Email / social login → 60-second onboarding for non-crypto users.',
-    proof: 'PR #32 on the GitHub repo. Awaiting `NEXT_PUBLIC_PRIVY_APP_ID` env to ship to mainnet.',
+    proof: 'Implementation branch exists, but PR #32 was closed without merge. Phase 2 until env setup, review, and merge are complete.',
     proofHref: 'https://github.com/YD811/potbot-v2/pull/32',
     tier: 'phase-2',
   },
@@ -256,7 +256,9 @@ export default function HackathonPage() {
       <section className="px-4 sm:px-6 pb-12">
         <div className="max-w-[1100px] mx-auto bg-pot-card border border-pot-green/30 rounded-3xl p-6 sm:p-8">
           <div className="flex items-center gap-3 mb-5 flex-wrap">
-            <h2 className="text-xl sm:text-2xl font-bold text-white">🟢 Live now — judge can verify</h2>
+            <h2 className="text-xl sm:text-2xl font-bold text-white">
+              {CLUSTER === 'mainnet-beta' ? '🟢 Live now — judge can verify' : '🟡 Devnet live — judge can verify'}
+            </h2>
             <StatusBadge tier={CLUSTER === 'mainnet-beta' ? 'live' : 'devnet'} compact />
           </div>
 
@@ -279,7 +281,7 @@ export default function HackathonPage() {
             ) : (
               <LiveCard
                 title="Flagship pot"
-                value="(awaiting mainnet deploy)"
+                value="(devnet flagship not configured)"
                 hrefLabel="See devnet pots →"
                 href="/vaults"
               />
@@ -446,7 +448,7 @@ export default function HackathonPage() {
               Solana Blinks turn any proposal into a tweet anyone can vote on. MCP lets Claude/GPT manage a pot. The on-chain `execute_swap` instruction is mode-aware — Admin / Proposal / AI-trigger — and matches mode-source strictly.
             </PitchStep>
             <PitchStep range="80–90s" headline="Ask">
-              Mainnet is live (or shipping this sprint). We want Colosseum to ship the privacy layer (Token-2022 confidential transfers) and the Saga / Seeker dApp Store entry.
+              The devnet product is live today, with mainnet planned after the final safety pass. We want Colosseum to help turn AI-governed strategy vaults into a production business.
             </PitchStep>
           </ol>
         </div>
@@ -457,7 +459,7 @@ export default function HackathonPage() {
         <div className="max-w-[1100px] mx-auto bg-gradient-to-br from-pot-accent/10 to-pot-green/5 border border-pot-accent/30 rounded-3xl p-6 sm:p-8 text-center">
           <h2 className="text-2xl sm:text-3xl font-bold text-white mb-3">What ships next</h2>
           <p className="text-pot-muted max-w-xl mx-auto mb-5 text-sm sm:text-base">
-            Privy embedded wallets, Pyth in-program oracle guard, Meteora &amp; Kamino yield CPIs, Light Protocol ZK audit log, Tamagotchi NFT mint, STAMPPOT privacy mode. Each phase tagged on the public roadmap.
+            Privy embedded wallets, Pyth in-program oracle guard, Meteora &amp; Kamino yield CPIs, Light Protocol ZK audit log, Tamagotchi NFT mint, STAMPPOT privacy mode. Each phase is tagged on the public roadmap.
           </p>
           <Link
             href="/roadmap"

--- a/apps/web/src/app/roadmap/page.tsx
+++ b/apps/web/src/app/roadmap/page.tsx
@@ -20,8 +20,8 @@ interface Section {
 const SECTIONS: Section[] = [
   {
     tier: 'live',
-    title: 'Live · mainnet',
-    blurb: 'Working today. Verifiable on Solana Explorer. The judge clicks through and watches it run.',
+    title: 'Live / verifiable',
+    blurb: 'Working today. Network-specific pages show whether the proof is on devnet or mainnet. The judge clicks through and watches it run.',
     features: [
       { emoji: '🪴', name: 'pot_vault Anchor program', desc: '30+ instructions deployed: create_pot, deposit, withdraw, vote, execute_swap, pot_admin, treasury config.', doc: '/docs/architecture/program' },
       { emoji: '⚡', name: 'execute_swap with Jupiter v6 CPI', desc: 'Vault PDA signs the swap directly. Three modes (AdminDirect / Proposal / StrategyTrigger) in one instruction with strict mode-source matching.' },
@@ -54,7 +54,7 @@ const SECTIONS: Section[] = [
       { emoji: '🔐', name: 'Pyth in-program oracle guard', desc: 'execute_swap re-reads Pyth price feeds inside the instruction and rejects keepers that fire on the wrong condition. Triggers cannot be faked.' },
       { emoji: '🌾', name: 'Meteora DLMM + DAMM yield CPI', desc: 'Park idle pot capital in Meteora pools. CPI path scaffolded, yield_strategy field on PotAccount supports it.' },
       { emoji: '🏦', name: 'Kamino lending CPI', desc: 'Lending-based yield strategy as an alternative to Meteora. Same allocation surface.' },
-      { emoji: '✉️', name: 'Privy embedded wallets', desc: 'Email + social login + Solana auto-create wallet. PR #32 ready, awaiting Privy app ID.' },
+      { emoji: '✉️', name: 'Privy embedded wallets', desc: 'Email + social login + Solana auto-create wallet. Implementation branch exists, but the PR was not merged; ships after env setup and final review.' },
       { emoji: '🪶', name: 'Light Protocol ZK-compressed audit log', desc: 'SwapEvent + NavSnapshot compressed accounts cut rent ~5000× while keeping full on-chain audit trail.', doc: '/docs/architecture/architecture-onchain' },
       { emoji: '🪙', name: 'init_share_mint graduation', desc: 'Off-chain shares (Seedling) graduate to on-chain SPL mint at Sprout+. Members hold transferable, DeFi-composable share tokens.', doc: '/docs/architecture/etf-token-system' },
       { emoji: '🎯', name: 'Advanced strategies (SL / TP / trailing / DCA)', desc: 'Stop-loss, take-profit, trailing-stop, recurring DCA — all built on the existing proposal flow.' },

--- a/apps/web/src/components/CreatePrivatePotForm.tsx
+++ b/apps/web/src/components/CreatePrivatePotForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { PotSDK } from '@potbot/sdk';
-import { toast } from 'sonner';
+import toast from 'react-hot-toast';
 import { useRouter } from 'next/navigation';
 
 import { StatusBadge } from '@/components/StatusBadge'

--- a/apps/web/src/components/LandingPage.tsx
+++ b/apps/web/src/components/LandingPage.tsx
@@ -9,31 +9,37 @@ const FEATURES = [
   {
     icon: '🪴',
     title: 'Group Treasury (POT)',
+    status: 'Live on devnet',
     desc: 'Pool SOL with your group into a shared on-chain treasury. Every member holds SPL-tokenized shares proportional to NAV — no middleman, no custody risk.',
   },
   {
     icon: '🏛️',
     title: 'On-Chain Governance',
+    status: 'Live on devnet',
     desc: 'Every trade, withdrawal or strategy change requires a vote. Autocracy → Advisory → Majority → Supermajority → Consensus. Configure quorum, approval %, timelock.',
   },
   {
     icon: '🤖',
     title: 'AI Execution (BOT)',
+    status: 'Focus for Frontier',
     desc: 'Set IF/THEN rules — "if SOL drops 5%, buy 10%." The MCP-native agent creates proposals and executes after votes pass. Any LLM can drive it.',
   },
   {
     icon: '🆔',
     title: 'SNS Identity — .potbot.sol',
+    status: 'Next',
     desc: 'Every group gets a readable on-chain identity: amsterdam-alpha.potbot.sol. Reverse-lookup works across Solana apps. Agents get agent.{pot}.potbot.sol.',
   },
   {
     icon: '🌱',
     title: 'Money Tree evolution',
+    status: 'Gamified layer',
     desc: 'Your treasury grows 🌱 Seedling → 🌿 Sprout → 🍀 Bud → 🌾 Bloom → 🌺 Full Bloom → 🌳 Mature Tree. Higher levels unlock lower fees and perks.',
   },
   {
     icon: '🥷',
     title: 'Privacy layer (STAMPPOT)',
+    status: 'Later',
     desc: 'Optional per-pot: wrap deposits in PrivacyCash ZK proofs. Public governance, private balances. Transparent on demand.',
   },
 ]
@@ -90,7 +96,7 @@ function LiveVaultMockup() {
           className="absolute inset-0 pointer-events-none"
           style={{
             background:
-              'radial-gradient(ellipse at center, rgba(20,241,149,0.18) 0%, transparent 60%)',
+              'radial-gradient(ellipse at center, rgba(20,241,149,0.14) 0%, transparent 60%)',
             filter: 'blur(60px)',
           }}
         />
@@ -160,10 +166,10 @@ function LiveVaultMockup() {
           z-index: 1;
           border-radius: 20px;
           overflow: hidden;
-          background: #10151C;
-          border: 1px solid rgba(255,255,255,0.14);
+          background: var(--c-card);
+          border: 1px solid var(--c-border-2);
           box-shadow:
-            0 40px 80px rgba(0,0,0,0.45),
+            0 40px 80px var(--c-surface-shadow),
             0 0 0 1px rgba(20,241,149,0.08) inset;
           transform-style: preserve-3d;
           transform-origin: 50% 50%;
@@ -186,8 +192,8 @@ function LiveVaultMockup() {
         .potbot-mock-chrome {
           display: flex; align-items: center; gap: 8px;
           padding: 12px 16px;
-          background: #1A2028;
-          border-bottom: 1px solid rgba(255,255,255,0.07);
+          background: var(--c-card-2);
+          border-bottom: 1px solid var(--c-border);
         }
         .dot { width: 10px; height: 10px; border-radius: 50%; }
         .dot.r { background: #FF5F56; }
@@ -197,14 +203,14 @@ function LiveVaultMockup() {
           flex: 1; text-align: center;
           font-family: 'JetBrains Mono', ui-monospace, monospace;
           font-size: 11px;
-          color: rgba(255,255,255,0.45);
+          color: var(--c-muted);
         }
 
         .potbot-mock-body { padding: 24px; }
 
         .potbot-mock-vault {
-          background: #0D1117;
-          border: 1px solid rgba(255,255,255,0.07);
+          background: var(--c-bg);
+          border: 1px solid var(--c-border);
           border-radius: 14px;
           padding: 22px;
         }
@@ -219,12 +225,12 @@ function LiveVaultMockup() {
           display: flex; align-items: center; justify-content: center;
           font-size: 22px;
         }
-        .title { font-weight: 700; font-size: 15px; color: #fff; text-align: left; }
-        .sub { font-size: 11px; color: rgba(255,255,255,0.5); text-align: left; }
+        .title { font-weight: 700; font-size: 15px; color: var(--c-text); text-align: left; }
+        .sub { font-size: 11px; color: var(--c-muted); text-align: left; }
         .tvl {
           font-family: 'JetBrains Mono', ui-monospace, monospace;
           font-weight: 700; font-size: 18px;
-          color: #14F195;
+          color: var(--c-brand-green);
         }
 
         .stats {
@@ -232,25 +238,25 @@ function LiveVaultMockup() {
           gap: 10px; margin-bottom: 18px;
         }
         .stat {
-          background: #1A2028;
+          background: var(--c-card-2);
           border-radius: 10px;
           padding: 10px 12px;
           text-align: left;
         }
         .lbl {
-          font-size: 10px; color: rgba(255,255,255,0.4);
+          font-size: 10px; color: var(--c-muted);
           text-transform: uppercase; letter-spacing: 0.06em;
         }
         .val {
           font-family: 'JetBrains Mono', ui-monospace, monospace;
-          font-weight: 700; font-size: 14px; color: #fff;
+          font-weight: 700; font-size: 14px; color: var(--c-text);
           margin-top: 2px;
         }
-        .val.up { color: #14F195; }
+        .val.up { color: var(--c-brand-green); }
 
         .proposal {
-          background: #1A2028;
-          border: 1px solid rgba(255,255,255,0.07);
+          background: var(--c-card-2);
+          border: 1px solid var(--c-border);
           border-radius: 12px;
           padding: 14px;
         }
@@ -258,27 +264,27 @@ function LiveVaultMockup() {
           display: flex; align-items: center; justify-content: space-between;
           margin-bottom: 10px;
         }
-        .proposal-title { font-size: 13px; font-weight: 600; color: #fff; text-align: left; }
+        .proposal-title { font-size: 13px; font-weight: 600; color: var(--c-text); text-align: left; }
         .badge {
           font-size: 10px; padding: 3px 8px; border-radius: 6px;
-          background: rgba(20,241,149,0.1); color: #14F195;
+          background: rgba(20,241,149,0.1); color: var(--c-brand-green);
           font-weight: 700;
         }
         .bar {
-          height: 8px; background: #0D1117;
+          height: 8px; background: var(--c-bg);
           border-radius: 999px; overflow: hidden;
           margin-bottom: 8px;
         }
         .fill {
           height: 100%; width: 0;
-          background: linear-gradient(135deg, #14F195 0%, #9945FF 100%);
+          background: linear-gradient(135deg, var(--c-brand-green) 0%, var(--c-brand-accent) 100%);
           border-radius: 999px;
           animation: fill 2.2s cubic-bezier(0.2,0.8,0.2,1) forwards;
         }
         @keyframes fill { to { width: 72%; } }
         .vote-row {
           display: flex; justify-content: space-between;
-          font-size: 11px; color: rgba(255,255,255,0.5);
+          font-size: 11px; color: var(--c-muted);
         }
       `}</style>
     </section>
@@ -332,17 +338,17 @@ function AskClaudeChat() {
         .claude-chat {
           max-width: 640px;
           margin: 0 auto;
-          background: #10151C;
-          border: 1px solid rgba(255,255,255,0.1);
+          background: var(--c-card);
+          border: 1px solid var(--c-border);
           border-radius: 16px;
           overflow: hidden;
-          box-shadow: 0 30px 60px rgba(0,0,0,0.35);
+          box-shadow: 0 30px 60px var(--c-surface-shadow);
         }
         .claude-head {
           display: flex; align-items: center; justify-content: space-between;
           padding: 14px 18px;
-          background: linear-gradient(180deg, #1A2028 0%, #10151C 100%);
-          border-bottom: 1px solid rgba(255,255,255,0.07);
+          background: linear-gradient(180deg, var(--c-card-2) 0%, var(--c-card) 100%);
+          border-bottom: 1px solid var(--c-border);
         }
         .claude-brand { display: flex; align-items: center; gap: 12px; }
         .claude-logo {
@@ -351,15 +357,15 @@ function AskClaudeChat() {
           display: flex; align-items: center; justify-content: center;
           font-size: 18px; font-weight: 700;
         }
-        .claude-name { font-weight: 700; color: #fff; font-size: 14px; }
+        .claude-name { font-weight: 700; color: var(--c-text); font-size: 14px; }
         .claude-sub {
-          font-size: 11px; color: rgba(255,255,255,0.5);
+          font-size: 11px; color: var(--c-muted);
           font-family: 'JetBrains Mono', ui-monospace, monospace;
         }
         .claude-pill {
           font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
           padding: 3px 10px; border-radius: 999px;
-          background: rgba(20,241,149,0.12); color: #14F195;
+          background: rgba(20,241,149,0.12); color: var(--c-brand-green);
           text-transform: uppercase;
         }
         .claude-body {
@@ -377,21 +383,21 @@ function AskClaudeChat() {
           align-self: flex-end;
           background: rgba(153,69,255,0.12);
           border: 1px solid rgba(153,69,255,0.25);
-          color: #fff;
+          color: var(--c-text);
         }
         .bubble-claude {
           align-self: flex-start;
-          background: #1A2028;
-          border: 1px solid rgba(255,255,255,0.07);
-          color: #E8EDF2;
+          background: var(--c-card-2);
+          border: 1px solid var(--c-border);
+          color: var(--c-text-soft);
         }
         .claude-think {
-          font-size: 12px; color: rgba(255,255,255,0.55);
+          font-size: 12px; color: var(--c-muted);
           font-style: italic; margin-bottom: 10px;
         }
         .claude-tool {
-          background: #0D1117;
-          border: 1px solid rgba(255,255,255,0.07);
+          background: var(--c-bg);
+          border: 1px solid var(--c-border);
           border-radius: 10px;
           padding: 10px 12px;
           margin-bottom: 10px;
@@ -399,19 +405,19 @@ function AskClaudeChat() {
         .tool-label {
           display: inline-block; font-size: 10px; font-weight: 700;
           letter-spacing: 0.1em; text-transform: uppercase;
-          color: #9945FF; margin-bottom: 6px;
+          color: var(--c-brand-accent); margin-bottom: 6px;
         }
         .claude-tool code {
           display: block;
           font-family: 'JetBrains Mono', ui-monospace, monospace;
           font-size: 11.5px; line-height: 1.6;
-          color: #E8EDF2;
+          color: var(--c-text-soft);
           white-space: pre-wrap;
         }
-        .claude-tool .s { color: #14F195; }
+        .claude-tool .s { color: var(--c-brand-green); }
         .claude-tool .fn { color: #58A6FF; }
         .claude-result {
-          font-size: 13px; color: #14F195;
+          font-size: 13px; color: var(--c-brand-green);
           padding-top: 4px;
         }
       `}</style>
@@ -452,6 +458,29 @@ function WaitlistSection() {
   )
 }
 
+function FrontierFocusStrip() {
+  return (
+    <section className="max-w-6xl mx-auto px-4 pb-10">
+      <div className="card grid gap-4 p-4 sm:grid-cols-4 sm:p-5">
+        {[
+          { step: '01', title: 'Create a POT', desc: 'Name the vault and choose voting rules.' },
+          { step: '02', title: 'Pool SOL', desc: 'Members receive NAV-based shares.' },
+          { step: '03', title: 'AI proposes', desc: 'MCP rule drafts a Jupiter swap proposal.' },
+          { step: '04', title: 'Group executes', desc: 'Votes pass, program signs, swap settles.' },
+        ].map((item) => (
+          <div key={item.step} className="rounded-xl border border-pot-border bg-pot-dark/60 p-4">
+            <div className="text-[11px] font-bold uppercase tracking-wider text-pot-green">
+              {item.step}
+            </div>
+            <div className="mt-1 font-bold text-white">{item.title}</div>
+            <p className="mt-1 text-sm leading-snug text-pot-muted">{item.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 export default function LandingPage() {
   const { data: pots } = usePots()
   const { price: solPrice } = useSolPrice()
@@ -466,7 +495,7 @@ export default function LandingPage() {
     <div className="min-h-screen">
 
       {/* ── Hero ── */}
-      <section className="relative flex flex-col items-center text-center pt-16 pb-20 px-4 overflow-hidden">
+      <section className="relative flex flex-col items-center text-center pt-14 pb-12 px-4 overflow-hidden">
         {/* Glow background */}
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-1/4 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-pot-green/5 rounded-full blur-3xl" />
@@ -479,22 +508,22 @@ export default function LandingPage() {
             Built for Solana Frontier 2026 · Open source
           </div>
 
-          <div className="text-8xl mb-6 animate-float">🪴</div>
+          <div className="text-7xl mb-5 animate-float" aria-hidden="true">🪴</div>
 
           <h1 className="text-5xl sm:text-6xl font-black text-white leading-tight mb-4">
-            Group Treasury.<br />
-            <span className="text-pot-green">AI execution.</span><br />
-            <span className="text-pot-accent">Money tree that grows.</span>
+            Shared trading vaults<br />
+            <span className="text-pot-green">run by votes</span>{' '}
+            <span className="text-pot-accent">and AI proposals.</span>
           </h1>
 
           <p className="text-xl text-pot-muted max-w-2xl mx-auto mb-4 leading-relaxed">
-            <strong className="text-white">POT</strong> = on-chain group treasury.{' '}
-            <strong className="text-white">BOT</strong> = AI execution through MCP. 🪴 =
-            your money tree grows with every trade.
+            Launch a Solana vault for a group, pool funds without a custodian, let an
+            MCP agent draft trades, then execute only after the members vote.
           </p>
 
-          <p className="text-sm text-pot-muted/70 italic max-w-xl mx-auto mb-8">
-            For groups who'd rather decide together than argue in group chats.
+          <p className="text-sm text-pot-muted/70 max-w-xl mx-auto mb-8">
+            Frontier demo focus: create one public AI strategy vault, deposit, propose,
+            vote, and execute a Jupiter swap on devnet.
           </p>
 
           {/* CTA buttons — only 2: primary + Follow X. Browse / Leaderboard / Connect live further down the page where they belong. */}
@@ -552,6 +581,8 @@ export default function LandingPage() {
         </div>
       </section>
 
+      <FrontierFocusStrip />
+
       {/* ── Trust & Risk ── */}
       <section className="max-w-6xl mx-auto px-4 pb-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
@@ -591,7 +622,12 @@ export default function LandingPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {FEATURES.map((f) => (
             <div key={f.title} className="card p-6 hover:border-pot-green/20 transition-all group">
-              <div className="text-3xl mb-3 group-hover:animate-float">{f.icon}</div>
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div className="text-3xl group-hover:animate-float" aria-hidden="true">{f.icon}</div>
+                <span className="rounded-full border border-pot-border bg-pot-dark px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-pot-muted">
+                  {f.status}
+                </span>
+              </div>
               <h3 className="font-bold text-white text-lg mb-2">{f.title}</h3>
               <p className="text-pot-muted text-sm leading-relaxed">{f.desc}</p>
             </div>
@@ -736,7 +772,7 @@ export default function LandingPage() {
             <h3 className="font-bold text-white text-lg mb-2">How we earn</h3>
             <p className="text-pot-muted text-sm leading-relaxed">
               <strong className="text-white">0.30%</strong> fee on every swap routed
-              through a pot. <strong className="text-white">10% performance fee</strong>
+              through a pot. <strong className="text-white">10% performance fee</strong>{' '}
               on Strategy Vaults, split with the strategy creator. No token, no
               airdrop farming. If usage is zero, revenue is zero — honest unit
               economics.

--- a/apps/web/src/components/SeasonPrizePoolModal.tsx
+++ b/apps/web/src/components/SeasonPrizePoolModal.tsx
@@ -92,7 +92,7 @@ export function SeasonPrizePoolModal({ onClose }: { onClose: () => void }) {
           <div>
             <h3 className="text-xs font-semibold text-pot-muted uppercase tracking-wide mb-2">Prize Source</h3>
             <p className="text-xs text-pot-muted leading-relaxed">
-              1% of all protocol swap fees (0.5% × 1% = 0.005% per trade) flow into the
+              1% of all protocol swap fees (0.30% × 1% = 0.003% per trade) flow into the
               on-chain <code className="bg-pot-dark px-1 rounded text-pot-green">competition_treasury</code> PDA.
               Distribution is triggered by a permissioned admin instruction at season end,
               enforced by the smart contract rules above.

--- a/apps/web/src/components/SnsModal.tsx
+++ b/apps/web/src/components/SnsModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey } from '@solana/web3.js';
 import { PotSDK } from '@potbot/sdk';
-import { toast } from 'sonner';
+import toast from 'react-hot-toast';
 
 interface SnsModalProps {
   potPubkey: PublicKey;

--- a/apps/web/src/components/StatusBadge.tsx
+++ b/apps/web/src/components/StatusBadge.tsx
@@ -7,7 +7,7 @@
 export type StatusTier = 'live' | 'devnet' | 'phase-2' | 'phase-3' | 'vision'
 
 const TIERS: Record<StatusTier, { dot: string; text: string; bg: string; border: string; label: string; emoji: string }> = {
-  'live':    { dot: 'bg-pot-green',   text: 'text-pot-green',    bg: 'bg-pot-green/10',    border: 'border-pot-green/30',    label: 'Live · mainnet',          emoji: '🟢' },
+  'live':    { dot: 'bg-pot-green',   text: 'text-pot-green',    bg: 'bg-pot-green/10',    border: 'border-pot-green/30',    label: 'Live',                    emoji: '🟢' },
   'devnet':  { dot: 'bg-yellow-400',  text: 'text-yellow-300',   bg: 'bg-yellow-400/10',   border: 'border-yellow-400/30',   label: 'Devnet',                  emoji: '🟡' },
   'phase-2': { dot: 'bg-blue-400',    text: 'text-blue-300',     bg: 'bg-blue-400/10',     border: 'border-blue-400/30',     label: 'Phase 2 · Q3 2026',       emoji: '🔵' },
   'phase-3': { dot: 'bg-pot-accent',  text: 'text-pot-accent',   bg: 'bg-pot-accent/10',   border: 'border-pot-accent/30',   label: 'Phase 3 · Q4 2026',       emoji: '🟣' },

--- a/apps/web/src/components/TamagotchiNftModal.tsx
+++ b/apps/web/src/components/TamagotchiNftModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey } from '@solana/web3.js';
 import { PotSDK } from '@potbot/sdk';
-import { toast } from 'sonner';
+import toast from 'react-hot-toast';
 
 interface TamagotchiNftModalProps {
   potPubkey: PublicKey;

--- a/apps/web/src/components/TokenizeSharesModal.tsx
+++ b/apps/web/src/components/TokenizeSharesModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { PublicKey, Transaction } from '@solana/web3.js';
 import { PotSDK } from '@potbot/sdk';
-import { toast } from 'sonner';
+import toast from 'react-hot-toast';
 
 interface TokenizeSharesModalProps {
   potPubkey: PublicKey;

--- a/apps/web/src/lib/email-template.ts
+++ b/apps/web/src/lib/email-template.ts
@@ -7,9 +7,9 @@
  *
  * Usage:
  *   renderEmail({
- *     subject: "PotBot is live on mainnet",
+ *     subject: "PotBot devnet is live",
  *     preheader: "Founding members — your early access has landed.",
- *     headline: "Mainnet is live 🚀",
+ *     headline: "Devnet is live",
  *     body: "<p>You asked to be first. You are.</p>",
  *     ctaLabel: "Open PotBot",
  *     ctaUrl: "https://potbot.fun",

--- a/docs/hackathon/submission.md
+++ b/docs/hackathon/submission.md
@@ -8,7 +8,7 @@
 **Devnet program:** [`GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK`](https://explorer.solana.com/address/GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK?cluster=devnet)
 
 > **Lifecycle legend.** Every feature in this submission is tagged.
-> 🟢 Live (mainnet) · 🟡 Devnet (mainnet target this sprint) · 🔵 Phase 2 (Q3 2026) · 🟣 Phase 3 (Q4 2026) · ⚪ Vision (2027+)
+> 🟢 Live/verifiable · 🟡 Devnet (mainnet target after safety pass) · 🔵 Phase 2 (Q3 2026) · 🟣 Phase 3 (Q4 2026) · ⚪ Vision (2027+)
 > Full roadmap with every feature: [potbot.fun/roadmap](https://potbot.fun/roadmap)
 
 ---
@@ -66,21 +66,21 @@ PotBot is a thin wrapper over Solana's strongest primitives. Each integration ta
 
 | Integration | What it does | Status |
 |---|---|---|
-| **Jupiter v6 / Ultra** | swap execution (CPI from `execute_swap`) | 🟢 Live (mainnet) |
+| **Jupiter v6 / Ultra** | swap execution (CPI from `execute_swap`) | 🟡 Devnet |
 | **Helius** | RPC, webhooks for pot events, priority-fee API | 🟢 Live |
 | **Squads v4** | optional multisig path for the creator role on high-value pots | 🟢 Live (UI + lib; flagship pot uses it) |
 | **MCP (Claude / OpenAI agents)** | `@potbot/mcp` exposes 18 pot actions to any LLM | 🟢 Live (npm 0.2.0) |
 | **Solana Actions / Blinks** | shareable vote + deposit endpoints | 🟢 Live |
 | **Dune SIM** | SVM portfolio + activity for vault display, leaderboard TVL, keeper pre-flight | 🟡 Devnet (needs `DUNE_API_KEY`) |
 | **Pyth Network** | oracle price guard, in-program trigger verification | 🔵 Phase 2 |
-| **Privy** | email / social login + embedded Solana wallets for non-crypto users | 🔵 Phase 2 (PR #32 ready, awaiting App ID) |
+| **Privy** | email / social login + embedded Solana wallets for non-crypto users | 🔵 Phase 2 (implementation branch exists; PR #32 not merged) |
 | **Light Protocol** | ZK-compressed audit log: SwapEvent + NavSnapshot accounts | 🔵 Phase 2 |
 | **Meteora DLMM, Kamino** | yield parking strategies for idle pot capital | 🔵 Phase 2 (CPI scaffolded) |
 | **Metaplex Token Metadata** | Tamagotchi NFT metadata for season rewards | 🟣 Phase 3 |
 
 ---
 
-## What is live on mainnet today
+## What is live on devnet today
 
 - 🟢 `pot_vault` Anchor program — 30+ instructions deployed, IDL synced
 - 🟢 Frontend at `potbot.fun`: `/`, `/dashboard`, `/leaderboard`, `/faq`, `/vaults`, `/pots/[pubkey]`, `/pots/[pubkey]/pet`, `/create`, `/signup`, `/roadmap`


### PR DESCRIPTION
## Summary

- Refocuses the homepage around the clearest Frontier demo loop: AI proposes, members vote, program executes.
- Adds a live preview and judge-friendly guidance to `/create`.
- Aligns public copy around devnet/verifiable status, 0.30% protocol swap fee, and Privy as Phase 2 rather than shipped.
- Replaces missing `sonner` imports with the existing `react-hot-toast` dependency so local route rendering works.

## Validation

- Started local Next.js dev server on `http://127.0.0.1:3000`.
- Verified `200 OK` for `/`, `/create`, `/faq`, `/hackathon`, and `/roadmap`.
- `npm run type-check` still fails on pre-existing repo issues unrelated to this positioning pass, including Supabase builder `.catch` usage, IDL casts, SDK method mismatches, and missing `clsx` in `packages/ui`.

## Notes

- Left untracked `.claire/` untouched.