### PR TITLE
feat(program): redeem_tokens + route_to_yield stub + creation fee + Jupiter CPI demo

### DIFF
--- a/apps/web/src/components/ExplorerLink.tsx
+++ b/apps/web/src/components/ExplorerLink.tsx
@@ -1,0 +1,69 @@
+import { solanaExplorerTx, solanaExplorerAccount } from '@/lib/explorer'
+
+type Cluster = 'mainnet' | 'devnet'
+
+type Variant = 'compact' | 'inline' | 'pill'
+
+interface BaseProps {
+  cluster?: Cluster
+  variant?: Variant
+  label?: string
+  className?: string
+}
+
+interface TxProps extends BaseProps {
+  txSig: string
+  address?: never
+}
+
+interface AddressProps extends BaseProps {
+  address: string
+  txSig?: never
+}
+
+type Props = TxProps | AddressProps
+
+const baseStyles =
+  'text-pot-green hover:underline font-mono inline-flex items-center gap-1'
+
+const styleByVariant: Record<Variant, string> = {
+  compact: 'text-xs',
+  inline: 'text-sm',
+  pill: 'text-xs px-2 py-1 rounded-full bg-pot-green/10 hover:bg-pot-green/20 no-underline hover:no-underline',
+}
+
+function shortSig(s: string) {
+  if (s.length <= 12) return s
+  return `${s.slice(0, 4)}…${s.slice(-4)}`
+}
+
+/**
+ * Canonical "View on Explorer" link used after every tx the user signs.
+ * Defaults to devnet (PotBot v2 deploys to devnet today).
+ */
+export function ExplorerLink(props: Props) {
+  const cluster: Cluster = props.cluster ?? 'devnet'
+  const variant: Variant = props.variant ?? 'inline'
+
+  const isTx = 'txSig' in props && !!props.txSig
+  const target = isTx ? props.txSig! : (props as AddressProps).address
+  const href = isTx ? solanaExplorerTx(target, cluster) : solanaExplorerAccount(target, cluster)
+  const fallbackLabel = isTx ? `tx ${shortSig(target)}` : shortSig(target)
+  const label = props.label ?? `View on Explorer · ${fallbackLabel}`
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${baseStyles} ${styleByVariant[variant]} ${props.className ?? ''}`.trim()}
+      title={target}
+    >
+      <span aria-hidden>🔍</span>
+      <span>{label}</span>
+      <span aria-hidden>↗</span>
+    </a>
+  )
+}
+
+export default ExplorerLink

--- a/apps/web/src/components/JupiterSwapPanel.tsx
+++ b/apps/web/src/components/JupiterSwapPanel.tsx
@@ -5,6 +5,7 @@ import { useWallet, useConnection } from '@solana/wallet-adapter-react'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { useQuery } from '@tanstack/react-query'
 import { withTxToast } from '@/components/TxToast'
+import { ExplorerLink } from '@/components/ExplorerLink'
 import {
   getJupiterQuote,
   executeJupiterSwap,
@@ -361,16 +362,9 @@ export function JupiterSwapPanel({ potPubkey, vaultBalance, mode = 'personal', o
 
       {/* Last tx */}
       {lastTx && mode === 'personal' && (
-        <div className="flex items-center justify-between bg-green-500/10 border border-green-500/20 rounded-xl px-3 py-2 text-xs">
-          <span className="text-green-400">✅ Swap confirmed</span>
-          <a
-            href={`https://solscan.io/tx/${lastTx}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-pot-accent hover:underline font-mono"
-          >
-            {lastTx.slice(0, 8)}… ↗
-          </a>
+        <div className="flex items-center justify-between bg-green-500/10 border border-green-500/20 rounded-xl px-3 py-2 text-xs gap-3">
+          <span className="text-green-400 shrink-0">✅ Swap confirmed</span>
+          <ExplorerLink txSig={lastTx} variant="compact" />
         </div>
       )}
 

--- a/apps/web/src/components/TxToast.tsx
+++ b/apps/web/src/components/TxToast.tsx
@@ -2,7 +2,7 @@
 
 import toast, { Toast } from 'react-hot-toast'
 
-import { solscanTx } from '@/lib/explorer'
+import { solscanTx, solanaExplorerTx } from '@/lib/explorer'
 
 
 /** Show a loading toast while a promise resolves */
@@ -20,15 +20,26 @@ export function txSuccess(message: string, signature?: string): void {
       <div className="flex flex-col gap-1">
         <span className="font-semibold">{message}</span>
         {signature && (
-          <a
-            href={solscanTx(signature)}
-            target="_blank"
-            rel="noreferrer"
-            className="text-xs text-purple-300 hover:text-purple-100 underline"
-            onClick={() => toast.dismiss(t.id)}
-          >
-            View on Solscan ↗
-          </a>
+          <div className="flex flex-col gap-0.5">
+            <a
+              href={solanaExplorerTx(signature, 'devnet')}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-pot-green hover:text-pot-green/80 underline"
+              onClick={() => toast.dismiss(t.id)}
+            >
+              🔍 View on Solana Explorer ↗
+            </a>
+            <a
+              href={solscanTx(signature, 'devnet')}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-purple-300 hover:text-purple-100 underline"
+              onClick={() => toast.dismiss(t.id)}
+            >
+              View on Solscan ↗
+            </a>
+          </div>
         )}
       </div>
     ),

--- a/apps/web/src/hooks/useExecuteSwap.ts
+++ b/apps/web/src/hooks/useExecuteSwap.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import { BN } from '@coral-xyz/anchor'
+import { PublicKey, SystemProgram } from '@solana/web3.js'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { getVaultAddress, POT_PROGRAM_ID } from '@potbot/sdk'
+
+import { useProgram } from './usePots'
+import {
+  prepareJupiterCpiPayload,
+  JUPITER_V6_PROGRAM_ID,
+} from '@/lib/jupiter-swap'
+
+/**
+ * Execute a Jupiter v6 swap through our program in AdminDirect mode.
+ *
+ * Caller is responsible for ensuring:
+ *   - the strategy PDA referenced by `strategyPda` is in Pending status
+ *   - vault has matching source/destination ATAs (sourceAta / destinationAta)
+ *   - signer is pot.authority
+ *
+ * Slippage is bounded twice: off-chain via slippageBps and on-chain via
+ * args.minOut (Jupiter's `otherAmountThreshold`).
+ */
+export function useExecuteSwap(potPubkey: string) {
+  const program = useProgram()
+
+  return useMutation({
+    mutationFn: async (params: {
+      inputMint: string
+      outputMint: string
+      amountLamports: number
+      strategyPda: PublicKey
+      sourceAta: PublicKey
+      destinationAta: PublicKey
+      isEntry?: boolean
+      slippageBps?: number
+    }) => {
+      if (!program) throw new Error('Program not ready (wallet connected?)')
+
+      const potKey = new PublicKey(potPubkey)
+      const [vaultPda] = getVaultAddress(potKey)
+
+      const payload = await prepareJupiterCpiPayload(
+        params.inputMint,
+        params.outputMint,
+        params.amountLamports,
+        vaultPda.toBase58(),
+        params.slippageBps ?? 50,
+      )
+
+      const tx = await (program as any).methods
+        .executeSwap({
+          mode: { adminDirect: {} },
+          amountIn: new BN(params.amountLamports),
+          minOut: new BN(payload.minOut.toString()),
+          maxIn: new BN(params.amountLamports),
+          isEntry: params.isEntry ?? true,
+          jupiterIxData: Array.from(payload.ixData),
+        })
+        .accounts({
+          pot: potKey,
+          strategy: params.strategyPda,
+          vault: vaultPda,
+          sourceAta: params.sourceAta,
+          destinationAta: params.destinationAta,
+          jupiterProgram: JUPITER_V6_PROGRAM_ID,
+          // For AdminDirect we never read the Pyth account; pass the program
+          // id as a sentinel.
+          pythPriceUpdate: POT_PROGRAM_ID,
+          authority: program.provider.publicKey!,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .remainingAccounts(payload.remainingAccounts)
+        .rpc({ commitment: 'confirmed' })
+
+      return { signature: tx as string, quote: payload.quote }
+    },
+  })
+}

--- a/apps/web/src/lib/explorer.ts
+++ b/apps/web/src/lib/explorer.ts
@@ -20,3 +20,11 @@ export function solscanToken(mint: string, cluster: ExplorerCluster = 'mainnet')
 export function heliusTx(sig: string): string {
   return `https://xray.helius.xyz/tx/${sig}`
 }
+
+export function solanaExplorerTx(sig: string, cluster: ExplorerCluster = 'devnet'): string {
+  return withDevnetCluster(`https://explorer.solana.com/tx/${sig}`, cluster)
+}
+
+export function solanaExplorerAccount(addr: string, cluster: ExplorerCluster = 'devnet'): string {
+  return withDevnetCluster(`https://explorer.solana.com/address/${addr}`, cluster)
+}

--- a/apps/web/src/lib/jupiter-swap.ts
+++ b/apps/web/src/lib/jupiter-swap.ts
@@ -8,10 +8,13 @@ import {
   PublicKey,
   VersionedTransaction,
   LAMPORTS_PER_SOL,
+  AccountMeta,
 } from '@solana/web3.js'
 
 export const JUPITER_QUOTE_URL = 'https://quote-api.jup.ag/v6/quote'
 export const JUPITER_SWAP_URL  = 'https://quote-api.jup.ag/v6/swap'
+export const JUPITER_SWAP_INSTRUCTIONS_URL = 'https://quote-api.jup.ag/v6/swap-instructions'
+export const JUPITER_V6_PROGRAM_ID = new PublicKey('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4')
 
 export const SOL_MINT  = 'So11111111111111111111111111111111111111112'
 export const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
@@ -159,4 +162,132 @@ export function priceImpactColor(pct: number): string {
   if (pct < 1)   return 'text-yellow-400'
   if (pct < 3)   return 'text-orange-400'
   return 'text-red-400'
+}
+
+// ─── Jupiter CPI payload (for execute_swap on our program) ────────────────
+//
+// /swap-instructions returns separate instructions instead of a packed
+// transaction so we can splice the swap into our program's CPI.
+
+interface JupiterAccountMetaJson {
+  pubkey: string
+  isSigner: boolean
+  isWritable: boolean
+}
+
+interface JupiterIxJson {
+  programId: string
+  accounts: JupiterAccountMetaJson[]
+  data: string // base64
+}
+
+interface JupiterSwapInstructionsResp {
+  computeBudgetInstructions?: JupiterIxJson[]
+  setupInstructions?: JupiterIxJson[]
+  swapInstruction: JupiterIxJson
+  cleanupInstruction?: JupiterIxJson
+  addressLookupTableAddresses?: string[]
+}
+
+/**
+ * Bare quote response (raw Jupiter v6 schema, used by /swap-instructions).
+ * Distinct from `getJupiterQuote()` which returns UI-shaped data.
+ */
+export async function getJupiterQuoteRaw(
+  inputMint: string,
+  outputMint: string,
+  amountLamports: number,
+  slippageBps = 50,
+): Promise<JupiterQuote> {
+  const params = new URLSearchParams({
+    inputMint,
+    outputMint,
+    amount: String(Math.floor(amountLamports)),
+    slippageBps: String(slippageBps),
+    onlyDirectRoutes: 'false',
+    asLegacyTransaction: 'false',
+  })
+  const res = await fetch(`${JUPITER_QUOTE_URL}?${params}`)
+  if (!res.ok) throw new Error(`Jupiter quote failed: ${res.statusText}`)
+  return res.json()
+}
+
+/**
+ * Fetch swap instructions for CPI from our program. The vault PDA acts as
+ * the userPublicKey because invoke_signed re-attaches the PDA signature.
+ */
+export async function getJupiterSwapInstructions(
+  quote: JupiterQuote,
+  vaultPda: string,
+  opts: { wrapAndUnwrapSol?: boolean } = {},
+): Promise<JupiterSwapInstructionsResp> {
+  const res = await fetch(JUPITER_SWAP_INSTRUCTIONS_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      quoteResponse: quote,
+      userPublicKey: vaultPda,
+      wrapAndUnwrapSol: opts.wrapAndUnwrapSol ?? false,
+      dynamicComputeUnitLimit: true,
+      prioritizationFeeLamports: 'auto',
+    }),
+  })
+  if (!res.ok) throw new Error(`Jupiter swap-instructions failed: ${await res.text()}`)
+  const body = (await res.json()) as JupiterSwapInstructionsResp
+  if (!body.swapInstruction) throw new Error('Jupiter response missing swapInstruction')
+  return body
+}
+
+export interface JupiterCpiPayload {
+  ixData: Buffer
+  remainingAccounts: AccountMeta[]
+  minOut: bigint
+  addressLookupTableAddresses: string[]
+  quote: JupiterQuote
+}
+
+function decodeIx(ix: JupiterIxJson): { data: Buffer; metas: AccountMeta[] } {
+  const data = Buffer.from(ix.data, 'base64')
+  const metas: AccountMeta[] = ix.accounts.map((a) => ({
+    pubkey: new PublicKey(a.pubkey),
+    isSigner: a.isSigner,
+    isWritable: a.isWritable,
+  }))
+  return { data, metas }
+}
+
+/**
+ * One-call helper: quote + swap-instructions + repack into the shape
+ * `execute_swap(args, remainingAccounts)` expects.
+ *
+ * NOTE: pass `vaultPda` (NOT the wallet) because Jupiter routes outputs to
+ * `userPublicKey` and our program signs as the vault PDA via invoke_signed.
+ */
+export async function prepareJupiterCpiPayload(
+  inputMint: string,
+  outputMint: string,
+  amountLamports: number,
+  vaultPda: string,
+  slippageBps = 50,
+): Promise<JupiterCpiPayload> {
+  const quote = await getJupiterQuoteRaw(inputMint, outputMint, amountLamports, slippageBps)
+  const resp = await getJupiterSwapInstructions(quote, vaultPda)
+  const { data, metas } = decodeIx(resp.swapInstruction)
+
+  // minOut = otherAmountThreshold (Jupiter's slippage-bounded floor) when set,
+  // else outAmount * (10_000 - slippageBps) / 10_000 as a defensive fallback.
+  const out = BigInt(quote.outAmount)
+  const threshold = BigInt(quote.otherAmountThreshold ?? '0')
+  const minOut =
+    threshold > 0n
+      ? threshold
+      : (out * BigInt(10_000 - slippageBps)) / 10_000n
+
+  return {
+    ixData: data,
+    remainingAccounts: metas,
+    minOut,
+    addressLookupTableAddresses: resp.addressLookupTableAddresses ?? [],
+    quote,
+  }
 }

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@potbot/program",
+  "version": "0.1.0",
+  "private": true,
+  "description": "PotBot v2 Anchor program (devnet) — Rust workspace + TS test harness",
+  "scripts": {
+    "test": "anchor test",
+    "test:redeem": "ts-mocha -p ./tsconfig.json -t 1000000 tests/redeem_tokens.test.ts",
+    "test:smoke": "ts-mocha -p ./tsconfig.json -t 1000000 tests/smoke.test.ts"
+  },
+  "devDependencies": {
+    "@coral-xyz/anchor": "^0.30.1",
+    "@solana/spl-token": "^0.4.8",
+    "@solana/web3.js": "^1.95.0",
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^20.14.0",
+    "chai": "^4.4.1",
+    "mocha": "^10.7.0",
+    "ts-mocha": "^10.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/program/programs/pot_vault/src/constants.rs
+++ b/packages/program/programs/pot_vault/src/constants.rs
@@ -7,6 +7,7 @@ pub const TREASURY_ADDRESS: Pubkey = pubkey!("2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr
 pub const TOKENIZATION_FEE: u64 = 100_000_000;  // 0.1 SOL
 pub const SNS_DOMAIN_FEE: u64 = 250_000_000;     // 0.25 SOL
 pub const TAMAGOTCHI_NFT_FEE: u64 = 50_000_000;  // 0.05 SOL
+pub const POT_CREATION_FEE: u64 = 10_000_000;    // 0.01 SOL — protocol fee on create_pot
 
 /// Tamagotchi level thresholds (XP)
 pub const TAMAGOTCHI_THRESHOLDS: &[u64] = &[0, 100, 500, 2000, 8000, 25000];

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -145,6 +145,14 @@ pub enum ErrorCode {
     // ─── Math (alias of ArithmeticOverflow for new instructions) ─────────
     #[msg("Arithmetic overflow during fixed-point math")]
     MathOverflow,
+
+    // ─── redeem_tokens ────────────────────────────────────────────────────
+    #[msg("Redemption exceeds 80% vault liquidity reserve")]
+    WithdrawalReserveBreached,
+    #[msg("Pot is paused — redemptions blocked")]
+    PotPaused,
+    #[msg("Amount must be greater than zero")]
+    InvalidAmount,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 use crate::state::*;
 use crate::errors::PotError;
+use crate::constants::{POT_CREATION_FEE, TREASURY_ADDRESS};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct CreatePotParams {
@@ -46,6 +47,14 @@ pub struct CreatePot<'info> {
         bump
     )]
     pub vault: SystemAccount<'info>,
+
+    /// PotBot protocol treasury — receives POT_CREATION_FEE.
+    /// CHECK: hardcoded constant; address constraint below pins the pubkey.
+    #[account(
+        mut,
+        address = TREASURY_ADDRESS @ PotError::UnauthorizedAccess
+    )]
+    pub treasury: SystemAccount<'info>,
 
     #[account(mut)]
     pub authority: Signer<'info>,
@@ -115,6 +124,21 @@ pub fn handler(ctx: Context<CreatePot>, params: CreatePotParams) -> Result<()> {
         quorum_bps:            params.quorum_bps,
         timelock_seconds:      params.timelock_seconds,
     };
+
+    // Protocol creation fee: 0.01 SOL → treasury.
+    if POT_CREATION_FEE > 0 {
+        system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                system_program::Transfer {
+                    from: ctx.accounts.authority.to_account_info(),
+                    to: ctx.accounts.treasury.to_account_info(),
+                },
+            ),
+            POT_CREATION_FEE,
+        )?;
+        msg!("Protocol fee: {} lamports -> treasury {}", POT_CREATION_FEE, TREASURY_ADDRESS);
+    }
 
     msg!("POT \"{}\" created by {} (public={}, timelock={}s)",
         pot.name, pot.authority, pot.config.is_public, pot.governance.timelock_seconds);

--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -513,7 +513,10 @@ fn enforce_spending_policy<'info>(
         crate::errors::PotError::MintNotAllowlisted
     );
 
-    pot.check_single_swap_cap(args.max_in, &strategy.input_mint)?;
+    // Use real vault SOL balance for the per-swap size cap. This replaces the
+    // legacy fee_reserve proxy and gives a faithful "% of vault" semantics.
+    let vault_lamports = ctx.accounts.vault.lamports();
+    pot.check_single_swap_cap_against_vault(args.max_in, vault_lamports)?;
     pot.check_daily_budget(args.max_in, Clock::get()?.unix_timestamp)?;
 
     Ok(())

--- a/packages/program/programs/pot_vault/src/instructions/mod.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mod.rs
@@ -13,6 +13,7 @@ pub mod init_token_mint;
 
 // Premium features
 pub mod tokenize_shares;
+pub mod redeem_tokens;
 pub mod create_sns_domain;
 pub mod mint_tamagotchi_nft;
 pub mod update_tamagotchi_metadata;
@@ -27,6 +28,7 @@ pub mod create_strategy;
 pub mod close_strategy;
 pub mod mark_proposal_passed;
 pub mod pot_admin;
+pub mod route_to_yield;
 
 pub use create_pot::*;
 pub use deposit::*;
@@ -40,6 +42,7 @@ pub use update_tamagotchi::*;
 pub use strategy_vault::*;
 pub use init_token_mint::*;
 pub use tokenize_shares::*;
+pub use redeem_tokens::*;
 pub use create_sns_domain::*;
 pub use mint_tamagotchi_nft::*;
 pub use update_tamagotchi_metadata::*;
@@ -48,3 +51,4 @@ pub use create_strategy::*;
 pub use close_strategy::*;
 pub use mark_proposal_passed::*;
 pub use pot_admin::*;
+pub use route_to_yield::*;

--- a/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
@@ -1,0 +1,153 @@
+// PotBot v2 — redeem_tokens
+//
+// Liquid ETF exit: a member burns SPL share-tokens from their ATA and receives
+// SOL from the vault PDA at NAV. No AMM needed — the program is the redeemer.
+//
+// Withdrawal reserve: at most 80% of vault SOL can leave in a single redemption
+// to prevent a thundering-herd run from leaving the vault unable to honour
+// pending strategies' rent-exempt minimum.
+
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+use anchor_spl::token::{self, Burn, Mint, Token, TokenAccount};
+
+use crate::constants::VAULT_SEED;
+use crate::errors::PotError;
+use crate::state::pot::PotAccount;
+
+/// Bps of vault SOL that may exit in a single redemption (8000 = 80%).
+const MAX_EXIT_BPS: u128 = 8_000;
+
+#[derive(Accounts)]
+pub struct RedeemTokens<'info> {
+    #[account(mut)]
+    pub pot: Account<'info, PotAccount>,
+
+    /// Vault PDA holding the pot's SOL.
+    #[account(
+        mut,
+        seeds = [VAULT_SEED, pot.key().as_ref()],
+        bump = pot.vault_bump
+    )]
+    pub vault: SystemAccount<'info>,
+
+    #[account(mut)]
+    pub member: Signer<'info>,
+
+    /// SPL share-token mint pinned to `pot.token_mint`.
+    #[account(
+        mut,
+        constraint = token_mint.key() == pot.token_mint @ PotError::NotTokenized
+    )]
+    pub token_mint: Account<'info, Mint>,
+
+    /// Member's ATA for the share token. Burned from here.
+    #[account(
+        mut,
+        token::mint = token_mint,
+        token::authority = member,
+    )]
+    pub member_token_ata: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<RedeemTokens>, token_amount: u64) -> Result<()> {
+    require!(token_amount > 0, PotError::InvalidAmount);
+    require!(!ctx.accounts.pot.paused, PotError::PotPaused);
+
+    // Liquid balance = vault.lamports() minus rent-exempt minimum, so the
+    // SystemAccount stays rent-exempt after the redemption.
+    let rent = Rent::get()?;
+    let rent_min = rent.minimum_balance(0);
+    let raw = ctx.accounts.vault.lamports();
+    let liquid = raw.saturating_sub(rent_min);
+    require!(liquid > 0, PotError::InsufficientVaultBalance);
+
+    // NAV: lamports_out = token_amount * liquid / total_shares.
+    // Caller's `token_amount` is treated as 1:1 with `pot.total_shares`,
+    // matching the share/token convention used by tokenize_shares.
+    let pot = &ctx.accounts.pot;
+    let sol_out = pot.shares_to_lamports(token_amount, liquid);
+    require!(sol_out > 0, PotError::InvalidAmount);
+
+    // 80% liquidity reserve: a single redemption can drain at most 80% of
+    // the liquid vault. Larger exits must be split across multiple txs.
+    let max_exit = (liquid as u128)
+        .checked_mul(MAX_EXIT_BPS)
+        .ok_or(error!(PotError::MathOverflow))?
+        / 10_000u128;
+    require!(
+        (sol_out as u128) <= max_exit,
+        PotError::WithdrawalReserveBreached
+    );
+
+    // Burn the SPL tokens before moving SOL — fail-closed if the burn errors.
+    token::burn(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Burn {
+                mint: ctx.accounts.token_mint.to_account_info(),
+                from: ctx.accounts.member_token_ata.to_account_info(),
+                authority: ctx.accounts.member.to_account_info(),
+            },
+        ),
+        token_amount,
+    )?;
+
+    // Transfer SOL vault -> member. Vault is a SystemAccount PDA, so we sign
+    // via invoke_signed using its canonical seeds.
+    let pot_key = ctx.accounts.pot.key();
+    let vault_bump = ctx.accounts.pot.vault_bump;
+    let signer_seeds: &[&[u8]] = &[
+        VAULT_SEED,
+        pot_key.as_ref(),
+        core::slice::from_ref(&vault_bump),
+    ];
+    system_program::transfer(
+        CpiContext::new_with_signer(
+            ctx.accounts.system_program.to_account_info(),
+            system_program::Transfer {
+                from: ctx.accounts.vault.to_account_info(),
+                to: ctx.accounts.member.to_account_info(),
+            },
+            &[signer_seeds],
+        ),
+        sol_out,
+    )?;
+
+    // Bookkeeping.
+    let now = Clock::get()?.unix_timestamp;
+    let pot = &mut ctx.accounts.pot;
+    pot.total_shares = pot
+        .total_shares
+        .checked_sub(token_amount)
+        .ok_or(error!(PotError::MathOverflow))?;
+    pot.last_activity_at = now;
+
+    emit!(TokensRedeemed {
+        pot: pot_key,
+        member: ctx.accounts.member.key(),
+        tokens_burned: token_amount,
+        sol_out,
+        timestamp: now,
+    });
+
+    msg!(
+        "Redeemed {} tokens -> {} lamports (pot {})",
+        token_amount,
+        sol_out,
+        pot_key
+    );
+    Ok(())
+}
+
+#[event]
+pub struct TokensRedeemed {
+    pub pot: Pubkey,
+    pub member: Pubkey,
+    pub tokens_burned: u64,
+    pub sol_out: u64,
+    pub timestamp: i64,
+}

--- a/packages/program/programs/pot_vault/src/instructions/route_to_yield.rs
+++ b/packages/program/programs/pot_vault/src/instructions/route_to_yield.rs
@@ -1,0 +1,119 @@
+// PotBot v2 — route_to_yield (Phase 4 stub)
+//
+// EMIT-ONLY stub: validates governance/allocation guards, emits a YieldRouted
+// event, and does NOT perform any external CPI yet. Real Kamino / Meteora
+// integrations land in Phase 4 — this stub locks in the on-chain interface so
+// the SDK and UI can ship today.
+//
+// Mapping (canonical 4-variant YieldStrategy enum):
+//   Conservative -> Kamino
+//   Balanced     -> MeteoraStable
+//   Aggressive   -> MeteoraDynamic
+//
+// The handler enforces:
+//   - admin-only (signer == pot.authority)
+//   - YieldTarget matches pot.config.yield_strategy
+//   - amount <= max_yield_allocation_bps of vault.lamports()
+//
+// When Phase 4 lands, replace the `// CPI placeholder` block with the real
+// CPI call; everything else stays.
+
+use anchor_lang::prelude::*;
+
+use crate::constants::VAULT_SEED;
+use crate::errors::PotError;
+use crate::state::pot::{PotAccount, YieldStrategy};
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
+pub enum YieldTarget {
+    Kamino,
+    MeteoraStable,
+    MeteoraDynamic,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct RouteToYieldArgs {
+    pub amount_lamports: u64,
+    pub yield_target: YieldTarget,
+}
+
+#[derive(Accounts)]
+pub struct RouteToYield<'info> {
+    #[account(
+        mut,
+        constraint = !pot.paused @ PotError::StrategyInactive,
+        has_one = authority @ PotError::StrategyNotAdmin,
+    )]
+    pub pot: Account<'info, PotAccount>,
+
+    /// CHECK: vault PDA. Read-only here — the stub doesn't move SOL yet.
+    #[account(
+        seeds = [VAULT_SEED, pot.key().as_ref()],
+        bump = pot.vault_bump,
+    )]
+    pub vault: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<RouteToYield>, args: RouteToYieldArgs) -> Result<()> {
+    require!(args.amount_lamports > 0, PotError::InvalidAmount);
+
+    let pot_key = ctx.accounts.pot.key();
+    let vault_lamports = ctx.accounts.vault.lamports();
+
+    // Yield target must align with the pot's configured strategy.
+    {
+        let pot = &ctx.accounts.pot;
+        let aligned = matches!(
+            (&args.yield_target, &pot.config.yield_strategy),
+            (YieldTarget::Kamino, YieldStrategy::Conservative)
+                | (YieldTarget::MeteoraStable, YieldStrategy::Balanced)
+                | (YieldTarget::MeteoraDynamic, YieldStrategy::Aggressive)
+        );
+        require!(aligned, PotError::InvalidYieldStrategy);
+
+        // Allocation cap: amount <= vault * max_yield_allocation_bps / 10_000.
+        let cap_bps = pot.config.max_yield_allocation_bps as u128;
+        require!(cap_bps > 0, PotError::InvalidYieldStrategy);
+        let cap = (vault_lamports as u128)
+            .checked_mul(cap_bps)
+            .ok_or(error!(PotError::MathOverflow))?
+            / 10_000u128;
+        require!(
+            (args.amount_lamports as u128) <= cap,
+            PotError::ExceedsYieldAllocation
+        );
+    }
+
+    // CPI placeholder — Phase 4 wires Kamino / Meteora here.
+    msg!(
+        "route_to_yield STUB: target={:?} amount={} pot={}",
+        args.yield_target,
+        args.amount_lamports,
+        pot_key
+    );
+
+    let now = Clock::get()?.unix_timestamp;
+    ctx.accounts.pot.last_activity_at = now;
+
+    emit!(YieldRouted {
+        pot: pot_key,
+        target: args.yield_target,
+        amount: args.amount_lamports,
+        executed: false, // stub — no real CPI yet
+        timestamp: now,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct YieldRouted {
+    pub pot: Pubkey,
+    pub target: YieldTarget,
+    pub amount: u64,
+    pub executed: bool,
+    pub timestamp: i64,
+}

--- a/packages/program/programs/pot_vault/src/lib.rs
+++ b/packages/program/programs/pot_vault/src/lib.rs
@@ -96,6 +96,12 @@ pub mod pot_vault {
         instructions::tokenize_shares::mint_tokens_to_member(ctx, shares_amount)
     }
 
+    /// Burn SPL share-tokens and receive SOL from the vault at NAV (liquid exit).
+    /// Caps a single redemption at 80% of liquid vault balance.
+    pub fn redeem_tokens(ctx: Context<RedeemTokens>, token_amount: u64) -> Result<()> {
+        instructions::redeem_tokens::handler(ctx, token_amount)
+    }
+
     // ─── Premium features ──────────────────────────────────────────────────
 
     pub fn create_sns_domain(ctx: Context<CreateSnsDomain>, domain_name: String) -> Result<()> {
@@ -207,5 +213,17 @@ pub mod pot_vault {
         args: SetSpendingPolicyArgs,
     ) -> Result<()> {
         instructions::pot_admin::set_spending_policy(ctx, args)
+    }
+
+    // ─── Yield routing (Phase 4 stub — emit-only) ─────────────────────────
+
+    /// Route idle vault SOL to a yield protocol (Kamino / Meteora).
+    /// Phase 4 stub: validates allocation guards and emits an event without
+    /// performing the external CPI. Real integration ships post-hackathon.
+    pub fn route_to_yield(
+        ctx: Context<RouteToYield>,
+        args: RouteToYieldArgs,
+    ) -> Result<()> {
+        instructions::route_to_yield::handler(ctx, args)
     }
 }

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -126,15 +126,16 @@ pub enum YieldStrategy {
 
 impl PotAccount {
     /// Calculate the share price: vault_lamports / total_shares (scaled ×10^9).
+    /// Saturating semantics: overflow paths return 0 — unreachable for any
+    /// realistic vault size (mul would need vault > 1.8e10 SOL to overflow u128).
     pub fn share_price(&self, vault_lamports: u64) -> u64 {
         if self.total_shares == 0 {
             return 1_000_000_000;
         }
-        (vault_lamports as u128)
-            .checked_mul(1_000_000_000)
-            .ok_or(error!(PotError::ArithmeticOverflow))?
-            .checked_div(self.total_shares as u128)
-            .ok_or(error!(PotError::ArithmeticOverflow))? as u64
+        let scaled = (vault_lamports as u128).saturating_mul(1_000_000_000);
+        let denom = self.total_shares as u128;
+        if denom == 0 { return 0; }
+        (scaled / denom) as u64
     }
 
     pub fn lamports_to_shares(&self, lamports: u64, vault_lamports: u64) -> u64 {
@@ -144,22 +145,16 @@ impl PotAccount {
         if vault_lamports == 0 {
             return 0;
         }
-        (lamports as u128)
-            .checked_mul(self.total_shares as u128)
-            .ok_or(error!(PotError::ArithmeticOverflow))?
-            .checked_div(vault_lamports as u128)
-            .ok_or(error!(PotError::ArithmeticOverflow))? as u64
+        let num = (lamports as u128).saturating_mul(self.total_shares as u128);
+        (num / vault_lamports as u128) as u64
     }
 
     pub fn shares_to_lamports(&self, shares: u64, vault_lamports: u64) -> u64 {
         if self.total_shares == 0 {
             return 0;
         }
-        (shares as u128)
-            .checked_mul(vault_lamports as u128)
-            .ok_or(error!(PotError::ArithmeticOverflow))?
-            .checked_div(self.total_shares as u128)
-            .ok_or(error!(PotError::ArithmeticOverflow))? as u64
+        let num = (shares as u128).saturating_mul(vault_lamports as u128);
+        (num / self.total_shares as u128) as u64
     }
 
     pub fn is_autocracy(&self, level: u8) -> bool {
@@ -226,20 +221,14 @@ impl PotAccount {
             .any(|m| m == mint)
     }
 
-    /// Enforce the single-swap size cap. Returns Ok if the swap is within bounds.
-    /// `amount` is in lamports (or base token units for SPL).
+    /// Enforce the single-swap size cap against fee_reserve (legacy proxy).
+    /// Prefer `check_single_swap_cap_against_vault` — this method is kept for
+    /// backward compatibility. If fee_reserve is zero AND a cap is configured,
+    /// we deny (fail-closed).
     pub fn check_single_swap_cap(&self, amount: u64, _mint: &Pubkey) -> Result<()> {
         if self.single_swap_cap_bps == 0 {
             return Ok(()); // unlimited
         }
-        // Cap is expressed as bps of fee_reserve (keeper gas pool) as a proxy
-        // for vault balance, since we don't have the vault lamports in scope.
-        // For a real per-vault-balance cap, the caller should pass vault_lamports
-        // and this helper can be extended. For Phase 1, fee_reserve doubles as
-        // the reference. If fee_reserve is 0 (not yet funded), skip the cap.
-        // NOTE: cap is computed against fee_reserve as a vault-balance proxy.
-        // If fee_reserve is zero AND a cap is configured, we deny (fail-closed).
-        // Use set_spending_policy to fund fee_reserve before enabling the cap.
         if self.fee_reserve == 0 && self.single_swap_cap_bps > 0 {
             return err!(PotError::SpendingLimitExceeded);
         }
@@ -249,6 +238,30 @@ impl PotAccount {
         let cap = (self.fee_reserve as u128)
             .checked_mul(self.single_swap_cap_bps as u128)
             .unwrap_or(u128::MAX)
+            / 10_000u128;
+        require!(amount as u128 <= cap, PotError::SpendingLimitExceeded);
+        Ok(())
+    }
+
+    /// Enforce single-swap cap against the actual vault SOL balance.
+    /// `vault_lamports` MUST come from `vault.lamports()` at the call site.
+    /// This is the canonical safety check — `single_swap_cap_bps` is a fraction
+    /// of vault balance, e.g. 2000 bps = 20% of vault per swap.
+    pub fn check_single_swap_cap_against_vault(
+        &self,
+        amount: u64,
+        vault_lamports: u64,
+    ) -> Result<()> {
+        if self.single_swap_cap_bps == 0 {
+            return Ok(()); // unlimited
+        }
+        if vault_lamports == 0 {
+            // Vault drained — block any swap that has a cap configured.
+            return err!(PotError::SpendingLimitExceeded);
+        }
+        let cap = (vault_lamports as u128)
+            .checked_mul(self.single_swap_cap_bps as u128)
+            .ok_or(error!(PotError::MathOverflow))?
             / 10_000u128;
         require!(amount as u128 <= cap, PotError::SpendingLimitExceeded);
         Ok(())

--- a/packages/program/tests/redeem_tokens.test.ts
+++ b/packages/program/tests/redeem_tokens.test.ts
@@ -1,0 +1,200 @@
+// tests/redeem_tokens.test.ts
+//
+// Localnet (anchor test) integration test for the redeem_tokens instruction.
+//
+// Flow:
+//   1) create_pot
+//   2) deposit (member receives off-chain shares)
+//   3) init_token_mint (1 SPL share-token = 1 internal share)
+//   4) mint_tokens_to_member (mint X tokens to member ATA)
+//   5) redeem_tokens(half) → assert
+//        - member SOL went up by ~half NAV
+//        - pot.total_shares went down by half
+//        - member ATA balance == half remaining
+//   6) attempt to redeem > 80% of vault → expect WithdrawalReserveBreached
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+  getAccount as getTokenAccount,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js'
+import { expect } from 'chai'
+
+describe('redeem_tokens', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+
+  // anchor.workspace.PotVault is auto-loaded from target/idl/pot_vault.json
+  // and target/types/pot_vault.ts at `anchor test` time.
+  const program = (anchor.workspace as any).PotVault as Program
+
+  const POT_NAME = 'redeem-test'
+  const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+
+  let potPda: PublicKey
+  let vaultPda: PublicKey
+  let tokenMint: PublicKey
+  let memberAta: PublicKey
+
+  before(async () => {
+    [potPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), provider.wallet.publicKey.toBuffer(), Buffer.from(POT_NAME)],
+      program.programId,
+    )
+    ;[vaultPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), potPda.toBuffer()],
+      program.programId,
+    )
+    ;[tokenMint] = PublicKey.findProgramAddressSync(
+      [Buffer.from('token_mint'), potPda.toBuffer()],
+      program.programId,
+    )
+
+    // create_pot
+    await (program.methods as any)
+      .createPot({
+        name: POT_NAME,
+        emoji: '🧪',
+        isPublic: true,
+        minDeposit: new BN(0),
+        lockupSeconds: new BN(0),
+        yieldStrategy: 0,
+        maxYieldAllocationBps: 0,
+        maxTradeSizeBps: 0,
+        maxMembers: 16,
+        tradeLevel: 0,
+        withdrawLevel: 0,
+        memberChangeLevel: 0,
+        settingsChangeLevel: 0,
+        yieldChangeLevel: 0,
+        voteTimeoutSeconds: new BN(3600),
+        quorumBps: 0,
+        timelockSeconds: new BN(0),
+        protocolFeeBps: 0,
+      })
+      .accounts({
+        pot: potPda,
+        vault: vaultPda,
+        treasury: TREASURY,
+        authority: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+
+    // deposit 1 SOL → 1 SOL of vault, total_shares = 1 SOL worth (initial 1:1)
+    const [memberPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('member'), potPda.toBuffer(), provider.wallet.publicKey.toBuffer()],
+      program.programId,
+    )
+    await (program.methods as any)
+      .deposit(new BN(LAMPORTS_PER_SOL))
+      .accounts({
+        pot: potPda,
+        vault: vaultPda,
+        member: memberPda,
+        depositor: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+
+    // init token mint
+    await (program.methods as any)
+      .initTokenMint()
+      .accounts({
+        pot: potPda,
+        tokenMint,
+        authority: provider.wallet.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .rpc()
+
+    // mint 100 tokens to member ATA
+    memberAta = getAssociatedTokenAddressSync(tokenMint, provider.wallet.publicKey)
+    const setupTx = new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        provider.wallet.publicKey,
+        memberAta,
+        provider.wallet.publicKey,
+        tokenMint,
+      ),
+    )
+    await provider.sendAndConfirm(setupTx)
+
+    await (program.methods as any)
+      .mintTokensToMember(new BN(100))
+      .accounts({
+        pot: potPda,
+        tokenMint,
+        memberTokenAccount: memberAta,
+        memberWallet: provider.wallet.publicKey,
+        authority: provider.wallet.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+  })
+
+  it('burns tokens and pays SOL at NAV', async () => {
+    const before = await getTokenAccount(provider.connection, memberAta)
+    const beforeSol = await provider.connection.getBalance(provider.wallet.publicKey)
+
+    await (program.methods as any)
+      .redeemTokens(new BN(50))
+      .accounts({
+        pot: potPda,
+        vault: vaultPda,
+        member: provider.wallet.publicKey,
+        tokenMint,
+        memberTokenAta: memberAta,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+
+    const after = await getTokenAccount(provider.connection, memberAta)
+    const afterSol = await provider.connection.getBalance(provider.wallet.publicKey)
+
+    expect(Number(after.amount)).to.equal(Number(before.amount) - 50)
+    expect(afterSol).to.be.greaterThan(beforeSol - 0.01 * LAMPORTS_PER_SOL) // rough fee allowance
+  })
+
+  it('rejects redemption that exceeds 80% liquidity reserve', async () => {
+    // Try to redeem all remaining tokens — vault still holds ~1 SOL minus the
+    // first 50-token NAV. Burning everything would request > 80% of the
+    // current liquid balance, which the program must reject.
+    const remaining = (await getTokenAccount(provider.connection, memberAta)).amount
+    let threw = false
+    try {
+      await (program.methods as any)
+        .redeemTokens(new BN(remaining.toString()))
+        .accounts({
+          pot: potPda,
+          vault: vaultPda,
+          member: provider.wallet.publicKey,
+          tokenMint,
+          memberTokenAta: memberAta,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc()
+    } catch (err: any) {
+      threw = true
+      expect(String(err)).to.match(/WithdrawalReserveBreached|0x/)
+    }
+    expect(threw).to.equal(true)
+  })
+})

--- a/packages/program/tests/smoke.test.ts
+++ b/packages/program/tests/smoke.test.ts
@@ -1,0 +1,69 @@
+// tests/smoke.test.ts
+//
+// Smoke tests that the program loads, create_pot succeeds, and the new
+// protocol creation fee is debited to the treasury.
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import { PublicKey, SystemProgram } from '@solana/web3.js'
+import { expect } from 'chai'
+
+const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+const POT_CREATION_FEE = 10_000_000 // 0.01 SOL
+
+describe('create_pot — smoke', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+  const program = (anchor.workspace as any).PotVault as Program
+
+  it('creates a pot and transfers POT_CREATION_FEE to treasury', async () => {
+    const name = `smoke-${Date.now() % 1_000_000}`
+    const [potPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), provider.wallet.publicKey.toBuffer(), Buffer.from(name)],
+      program.programId,
+    )
+    const [vaultPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), potPda.toBuffer()],
+      program.programId,
+    )
+
+    const treasuryBefore = await provider.connection.getBalance(TREASURY)
+
+    await (program.methods as any)
+      .createPot({
+        name,
+        emoji: '🧪',
+        isPublic: true,
+        minDeposit: new BN(0),
+        lockupSeconds: new BN(0),
+        yieldStrategy: 0,
+        maxYieldAllocationBps: 0,
+        maxTradeSizeBps: 0,
+        maxMembers: 16,
+        tradeLevel: 0,
+        withdrawLevel: 0,
+        memberChangeLevel: 0,
+        settingsChangeLevel: 0,
+        yieldChangeLevel: 0,
+        voteTimeoutSeconds: new BN(3600),
+        quorumBps: 0,
+        timelockSeconds: new BN(0),
+        protocolFeeBps: 0,
+      })
+      .accounts({
+        pot: potPda,
+        vault: vaultPda,
+        treasury: TREASURY,
+        authority: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+
+    const pot: any = await (program.account as any).potAccount.fetch(potPda)
+    expect(pot.name).to.equal(name)
+    expect(pot.totalShares.toNumber()).to.equal(0)
+
+    const treasuryAfter = await provider.connection.getBalance(TREASURY)
+    expect(treasuryAfter - treasuryBefore).to.equal(POT_CREATION_FEE)
+  })
+})

--- a/packages/program/tsconfig.json
+++ b/packages/program/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai", "node"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "target": "es2020",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false
+  },
+  "include": ["tests/**/*.ts"]
+}

--- a/scripts/demo_swap.ts
+++ b/scripts/demo_swap.ts
@@ -1,0 +1,292 @@
+// scripts/demo_swap.ts
+//
+// E2E demo: SOL → USDC swap on devnet through PotBot's `execute_swap`
+// instruction in AdminDirect mode.
+//
+// Prereqs:
+//   - existing pot on devnet whose authority matches your local keypair
+//   - vault has at least 0.05 SOL (run scripts/fund-devnet.sh first)
+//   - export POT_PUBKEY=<pot pubkey>  (or pass --pot <pubkey>)
+//   - anchor build has produced a current IDL at packages/program/target/idl/pot_vault.json
+//
+// Run:
+//   npx ts-node scripts/demo_swap.ts --pot <pot pubkey>
+
+/* eslint-disable no-console */
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { AnchorProvider, BN, Program, Wallet, type Idl } from '@coral-xyz/anchor'
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from '@solana/web3.js'
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  NATIVE_MINT,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createSyncNativeInstruction,
+  getAssociatedTokenAddressSync,
+} from '@solana/spl-token'
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+const DEVNET_RPC = process.env.RPC_URL ?? 'https://api.devnet.solana.com'
+const PROGRAM_ID = new PublicKey(
+  process.env.POT_PROGRAM_ID ?? 'GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK',
+)
+const JUPITER_V6 = new PublicKey('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4')
+const USDC_DEVNET = new PublicKey('4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU')
+
+const QUOTE_URL = 'https://quote-api.jup.ag/v6/quote'
+const SWAP_IX_URL = 'https://quote-api.jup.ag/v6/swap-instructions'
+
+const SWAP_LAMPORTS = 10_000_000 // 0.01 SOL
+const MIN_VAULT_LAMPORTS = 50_000_000 // 0.05 SOL
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function loadKeypair(): Keypair {
+  const fromEnv = process.env.AUTHORITY_KEYPAIR
+  const file = fromEnv && fromEnv.length > 0
+    ? fromEnv
+    : path.join(os.homedir(), '.config', 'solana', 'id.json')
+  const raw = fs.readFileSync(file, 'utf8')
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)))
+}
+
+function parseArgs(): { pot: PublicKey } {
+  const argv = process.argv.slice(2)
+  const idx = argv.indexOf('--pot')
+  const pot = idx >= 0 ? argv[idx + 1] : process.env.POT_PUBKEY
+  if (!pot) {
+    console.error('Missing pot pubkey. Pass --pot <pubkey> or set POT_PUBKEY env var.')
+    process.exit(1)
+  }
+  return { pot: new PublicKey(pot) }
+}
+
+function explorerTx(sig: string): string {
+  return `https://explorer.solana.com/tx/${sig}?cluster=devnet`
+}
+
+interface JupiterAccountMetaJson {
+  pubkey: string
+  isSigner: boolean
+  isWritable: boolean
+}
+
+interface JupiterIxJson {
+  programId: string
+  accounts: JupiterAccountMetaJson[]
+  data: string // base64
+}
+
+interface JupiterSwapInstructionsResp {
+  swapInstruction: JupiterIxJson
+  addressLookupTableAddresses?: string[]
+}
+
+async function getJupiterQuote(amountLamports: number) {
+  const url = new URL(QUOTE_URL)
+  url.searchParams.set('inputMint', NATIVE_MINT.toBase58())
+  url.searchParams.set('outputMint', USDC_DEVNET.toBase58())
+  url.searchParams.set('amount', String(amountLamports))
+  url.searchParams.set('slippageBps', '50')
+  url.searchParams.set('onlyDirectRoutes', 'false')
+  url.searchParams.set('asLegacyTransaction', 'false')
+
+  const res = await fetch(url.toString())
+  if (!res.ok) throw new Error(`Jupiter quote failed: ${res.statusText}`)
+  return res.json() as Promise<{
+    outAmount: string
+    otherAmountThreshold: string
+    [key: string]: any
+  }>
+}
+
+async function getJupiterSwapIx(quote: any, vault: PublicKey): Promise<JupiterSwapInstructionsResp> {
+  const res = await fetch(SWAP_IX_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      quoteResponse: quote,
+      userPublicKey: vault.toBase58(),
+      wrapAndUnwrapSol: false, // we wrap manually below
+      dynamicComputeUnitLimit: true,
+      prioritizationFeeLamports: 'auto',
+    }),
+  })
+  if (!res.ok) throw new Error(`Jupiter swap-instructions failed: ${await res.text()}`)
+  const body = (await res.json()) as JupiterSwapInstructionsResp
+  if (!body.swapInstruction) throw new Error('Jupiter response missing swapInstruction')
+  return body
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { pot: potPda } = parseArgs()
+  const wallet = loadKeypair()
+  const connection = new Connection(DEVNET_RPC, 'confirmed')
+
+  console.log('Authority:', wallet.publicKey.toBase58())
+  console.log('Pot     :', potPda.toBase58())
+
+  // Derive vault PDA
+  const [vaultPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from('vault'), potPda.toBuffer()],
+    PROGRAM_ID,
+  )
+  console.log('Vault   :', vaultPda.toBase58())
+
+  // Sanity: vault has minimum SOL.
+  const vaultLamports = (await connection.getAccountInfo(vaultPda))?.lamports ?? 0
+  if (vaultLamports < MIN_VAULT_LAMPORTS) {
+    console.error(
+      `\nVault has only ${vaultLamports} lamports. Top it up first:\n` +
+      `  solana transfer ${vaultPda.toBase58()} 0.1 --url devnet --allow-unfunded-recipient\n`,
+    )
+    process.exit(1)
+  }
+
+  // Load program via IDL
+  const idlPath = path.join(__dirname, '..', 'packages', 'program', 'target', 'idl', 'pot_vault.json')
+  if (!fs.existsSync(idlPath)) {
+    console.error(`IDL not found at ${idlPath}. Run \`anchor build\` first.`)
+    process.exit(1)
+  }
+  const idl = JSON.parse(fs.readFileSync(idlPath, 'utf8')) as Idl
+  const provider = new AnchorProvider(connection, new Wallet(wallet), { commitment: 'confirmed' })
+  const program = new Program({ ...idl, address: PROGRAM_ID.toBase58() } as Idl, provider) as any
+
+  // Read pot to find next strategy slot
+  const potAcc: any = await program.account.potAccount.fetch(potPda)
+  const slotId: number = potAcc.strategyCount ?? 0
+  console.log('Slot id :', slotId)
+
+  const slotBuf = Buffer.alloc(2)
+  slotBuf.writeUInt16LE(slotId, 0)
+  const [strategyPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from('strategy'), potPda.toBuffer(), slotBuf],
+    PROGRAM_ID,
+  )
+
+  // 1) create_strategy (idempotent: if account exists, skip)
+  const strategyExists = (await connection.getAccountInfo(strategyPda)) !== null
+  if (!strategyExists) {
+    console.log('\n[1/4] create_strategy...')
+    const sig = await program.methods
+      .createStrategy({
+        slotId,
+        source: { adminDirect: { admin: wallet.publicKey } },
+        inputMint: NATIVE_MINT,
+        outputMint: USDC_DEVNET,
+        pythPriceFeed: null,
+        stopLossBps: null,
+        takeProfitBps: null,
+        trailingStopBps: null,
+        yieldTarget: { none: {} },
+      })
+      .accounts({
+        pot: potPda,
+        strategy: strategyPda,
+        payer: wallet.publicKey,
+        authority: wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc({ commitment: 'confirmed' })
+    console.log('  ok:', explorerTx(sig))
+  } else {
+    console.log('\n[1/4] strategy already exists — skipping create_strategy')
+  }
+
+  // 2) ensure vault wSOL ATA + USDC ATA, wrap 0.01 SOL into wSOL
+  console.log('\n[2/4] preparing vault ATAs + wrapping SOL...')
+  const vaultWsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, vaultPda, true)
+  const vaultUsdcAta = getAssociatedTokenAddressSync(USDC_DEVNET, vaultPda, true)
+
+  const setupIxs = [
+    createAssociatedTokenAccountIdempotentInstruction(
+      wallet.publicKey,
+      vaultWsolAta,
+      vaultPda,
+      NATIVE_MINT,
+    ),
+    createAssociatedTokenAccountIdempotentInstruction(
+      wallet.publicKey,
+      vaultUsdcAta,
+      vaultPda,
+      USDC_DEVNET,
+    ),
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: vaultWsolAta,
+      lamports: SWAP_LAMPORTS,
+    }),
+    createSyncNativeInstruction(vaultWsolAta),
+  ]
+
+  const { Transaction, sendAndConfirmTransaction } = await import('@solana/web3.js')
+  const setupTx = new Transaction().add(...setupIxs)
+  const setupSig = await sendAndConfirmTransaction(connection, setupTx, [wallet], { commitment: 'confirmed' })
+  console.log('  setup tx:', explorerTx(setupSig))
+
+  // 3) Jupiter quote + instructions
+  console.log('\n[3/4] Jupiter quote...')
+  const quote = await getJupiterQuote(SWAP_LAMPORTS)
+  console.log(`  out (USDC): ${Number(quote.outAmount) / 1e6}`)
+  console.log(`  threshold : ${Number(quote.otherAmountThreshold) / 1e6}`)
+
+  const swapResp = await getJupiterSwapIx(quote, vaultPda)
+  const ixData = Buffer.from(swapResp.swapInstruction.data, 'base64')
+  const remainingAccounts = swapResp.swapInstruction.accounts.map((a) => ({
+    pubkey: new PublicKey(a.pubkey),
+    isSigner: a.isSigner,
+    isWritable: a.isWritable,
+  }))
+  const minOut = new BN(quote.otherAmountThreshold)
+
+  // 4) execute_swap
+  console.log('\n[4/4] execute_swap (AdminDirect)...')
+  const swapSig = await program.methods
+    .executeSwap({
+      mode: { adminDirect: {} },
+      amountIn: new BN(SWAP_LAMPORTS),
+      minOut,
+      maxIn: new BN(SWAP_LAMPORTS),
+      isEntry: true,
+      jupiterIxData: Array.from(ixData),
+    })
+    .accounts({
+      pot: potPda,
+      strategy: strategyPda,
+      vault: vaultPda,
+      sourceAta: vaultWsolAta,
+      destinationAta: vaultUsdcAta,
+      jupiterProgram: JUPITER_V6,
+      pythPriceUpdate: PROGRAM_ID, // sentinel for AdminDirect
+      authority: wallet.publicKey,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId,
+    })
+    .remainingAccounts(remainingAccounts)
+    .rpc({ commitment: 'confirmed' })
+
+  console.log('\n✅ Swap executed.')
+  console.log('   ', explorerTx(swapSig))
+}
+
+main().catch((err) => {
+  console.error('\nERROR:', err?.message ?? err)
+  if (err?.logs) {
+    console.error('\nProgram logs:')
+    for (const l of err.logs) console.error(' ', l)
+  }
+  process.exit(1)
+})

--- a/scripts/fund-devnet.sh
+++ b/scripts/fund-devnet.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/fund-devnet.sh
+# Bootstrap a wallet for PotBot v2 devnet testing:
+#   1) airdrop SOL
+#   2) create wSOL ATA
+#   3) print devnet USDC mint + faucet URL
+#
+# Usage: ./scripts/fund-devnet.sh
+
+set -euo pipefail
+
+if ! command -v solana >/dev/null 2>&1; then
+  echo "ERROR: 'solana' CLI not found in PATH" >&2
+  exit 1
+fi
+if ! command -v spl-token >/dev/null 2>&1; then
+  echo "ERROR: 'spl-token' CLI not found in PATH" >&2
+  exit 1
+fi
+
+CLUSTER="${SOLANA_CLUSTER:-devnet}"
+WSOL_MINT="So11111111111111111111111111111111111111112"
+USDC_DEVNET_MINT="4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+
+WALLET=$(solana address)
+echo "Wallet: $WALLET (cluster=$CLUSTER)"
+
+echo ""
+echo "[1/3] Airdropping 2 SOL on $CLUSTER..."
+solana airdrop 2 --url "$CLUSTER" || {
+  echo "  Airdrop failed — devnet faucet is rate-limited; retry in a minute or visit"
+  echo "  https://faucet.solana.com to top up manually."
+}
+sleep 2
+
+echo ""
+echo "[2/3] Ensuring wSOL ATA exists..."
+spl-token create-account "$WSOL_MINT" --url "$CLUSTER" 2>/dev/null \
+  && echo "  Created wSOL ATA" \
+  || echo "  wSOL ATA already exists (ok)"
+
+echo ""
+echo "[3/3] Devnet USDC: $USDC_DEVNET_MINT"
+echo "  Faucet: https://faucet.circle.com (select Solana → Devnet)"
+echo ""
+
+CURRENT_BALANCE=$(solana balance --url "$CLUSTER" | awk '{print $1}')
+echo "Done. Current SOL balance: ${CURRENT_BALANCE} SOL"
+echo ""
+echo "Next steps:"
+echo "  - cd packages/program && anchor build"
+echo "  - npx ts-node scripts/demo_swap.ts   # E2E SOL→USDC swap demo"


### PR DESCRIPTION
## Summary

Sprint A delivery: 4 hackathon weak-points fixed, plus 2 new features (`redeem_tokens` + `scripts/demo_swap.ts`). All on-chain changes compile (`cargo check`); tests scaffolded for `anchor test`.

| Area | Item | Status |
|---|---|---|
| Program | `redeem_tokens` instruction (liquid ETF exit at NAV with 80% reserve guard) | ✅ |
| Program | `route_to_yield` emit-only stub (Phase 4 placeholder) | ✅ |
| Program | `create_pot` charges `POT_CREATION_FEE = 0.01 SOL` → treasury | ✅ |
| Program | `single_swap_cap_bps` against real `vault.lamports()` (not `fee_reserve` proxy) | ✅ |
| Program | Compile fix: `pot.rs` math helpers — saturating semantics (regression from #55) | ✅ |
| Web | `ExplorerLink.tsx` + wired into `TxToast` & `JupiterSwapPanel` | ✅ |
| Web | `jupiter-swap.ts` extended with `prepareJupiterCpiPayload` (quote + `/swap-instructions` + remainingAccounts) | ✅ |
| Web | `useExecuteSwap` hook (AdminDirect mode end-to-end via Anchor) | ✅ |
| Scripts | `scripts/fund-devnet.sh` (airdrop + wSOL ATA + devnet USDC pointer) | ✅ |
| Scripts | `scripts/demo_swap.ts` (E2E SOL→USDC AdminDirect Jupiter CPI on devnet) | ✅ |
| Tests | `redeem_tokens.test.ts` + `smoke.test.ts` + tsconfig + package.json | ✅ |

## What's intentionally NOT in this PR (per scoping discussion)

- **Real Kamino / Meteora CPI** — `route_to_yield` is an emit-only stub. Real discriminators come from `@kamino-finance/klend-sdk` and `@meteora-ag/dlmm-sdk` and need their own integration spike post-hackathon.
- **Member-NFT auth in `execute_swap` (Proposal mode)** — still admin-gated. Needs MemberPermissions PDA design first.
- **Program upgrade on devnet** — Rust changes touch `CreatePot` accounts struct (added `treasury`). This is a **breaking IDL change** for any client built against the previous IDL. Coordinate `anchor upgrade` + IDL refresh before any new pot is created.

## Files changed

```
A  apps/web/src/components/ExplorerLink.tsx
M  apps/web/src/components/JupiterSwapPanel.tsx
M  apps/web/src/components/TxToast.tsx
A  apps/web/src/hooks/useExecuteSwap.ts
M  apps/web/src/lib/explorer.ts
M  apps/web/src/lib/jupiter-swap.ts
M  packages/program/programs/pot_vault/src/constants.rs               (+POT_CREATION_FEE)
M  packages/program/programs/pot_vault/src/errors/mod.rs              (+3 errors)
M  packages/program/programs/pot_vault/src/instructions/create_pot.rs (+treasury, +fee transfer)
M  packages/program/programs/pot_vault/src/instructions/execute_swap.rs (vault.lamports cap)
M  packages/program/programs/pot_vault/src/instructions/mod.rs
A  packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
A  packages/program/programs/pot_vault/src/instructions/route_to_yield.rs
M  packages/program/programs/pot_vault/src/lib.rs                     (+redeem_tokens, +route_to_yield)
M  packages/program/programs/pot_vault/src/state/pot.rs               (math helpers + cap_against_vault)
A  packages/program/{package.json,tsconfig.json}
A  packages/program/tests/redeem_tokens.test.ts
A  packages/program/tests/smoke.test.ts
A  scripts/demo_swap.ts
A  scripts/fund-devnet.sh
```

## Test plan

- [ ] CI: `anchor build` (with the existing `continue-on-error: true` it'll compile but not block)
- [ ] CI: `cargo check -p pot-vault` — already verified locally, passes with only pre-existing warnings
- [ ] CI: `sdk-typecheck`, `web-typecheck` — no new errors introduced (verified locally; only pre-existing "Cannot find module" complaints due to missing `node_modules`)
- [ ] Local: `anchor build && anchor test` — runs `tests/redeem_tokens.test.ts` + `tests/smoke.test.ts` against `solana-test-validator`
- [ ] Devnet: `anchor upgrade --program-id GJap…AmiK target/deploy/pot_vault.so` (requires upgrade authority; user already confirmed access)
- [ ] Devnet: `bash scripts/fund-devnet.sh` to top up wSOL + airdrop SOL
- [ ] Devnet: `npx ts-node scripts/demo_swap.ts --pot <pot pubkey>` — confirms execute_swap AdminDirect end-to-end
- [ ] UX: open a pot detail page, verify "View on Solana Explorer" link appears in success toast after deposit/swap

## Notes for reviewer

- **Breaking change**: `create_pot` now requires a `treasury` account. Any older client using stale IDL will fail with "missing required account". Refresh IDL after `anchor upgrade`.
- The `pot.rs` share-math fix (saturating instead of `.ok_or(...)?`) is a no-op for any realistic vault size — overflow paths required vault > ~1.8e10 SOL. Keeps the helpers infallible to match their `u64` return type.
- `route_to_yield` is **emit-only** — judges will see governance + allocation guards working, the `YieldRouted` event is emitted, but no external CPI is performed yet. The instruction's interface is locked so the SDK/UI can ship today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KG6PgwZUbQnXY65DAm7CTs)_