### PR TITLE
feat(sns): sell <name>.potbot.sol subdomains

### DIFF
--- a/apps/web/.env.sns.example
+++ b/apps/web/.env.sns.example
@@ -1,0 +1,7 @@
+# .potbot.sol subdomain sales (server-side env). Copy needed vars into .env.local / Vercel.
+POTBOT_SNS_OWNER_SECRET=        # potbot.sol owner key (base58 OR JSON array). Dedicated, ~0 SOL.
+POTBOT_SNS_TREASURY=            # address that receives payments (separate cold address)
+POTBOT_SNS_RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
+POTBOT_SNS_PRICE_SOL=0.05       # standard 5+ tier only
+POTBOT_SNS_PRICE_USDC=5
+POTBOT_SNS_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.13.0",
     "@solana/kit": "^6.9.0",
+    "@solana/spl-token": "^0.4.14",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-react": "^0.15.35",
     "@solana/wallet-adapter-react-ui": "^0.9.35",
@@ -38,6 +39,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
+    "server-only": "^0.0.1",
     "tailwindcss": "^3.4.4",
     "zustand": "^4.5.4"
   },

--- a/apps/web/src/app/api/sns/bind/route.ts
+++ b/apps/web/src/app/api/sns/bind/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST() {
+  if (process.env.POTBOT_SNS_BIND_ENABLED !== '1') {
+    return NextResponse.json({
+      error: 'not_enabled', phase: 2,
+      message: 'SNS→pot binding ships once pots are live on mainnet. Names currently resolve to the owner wallet.',
+    }, { status: 501 })
+  }
+  return NextResponse.json({ error: 'not_implemented' }, { status: 501 })
+}

--- a/apps/web/src/app/api/sns/check/route.ts
+++ b/apps/web/src/app/api/sns/check/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { normalizeLabel } from '@/lib/sns'
+import { checkAvailability } from '@/lib/sns-server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const raw = req.nextUrl.searchParams.get('name') ?? ''
+  const label = normalizeLabel(raw)
+  try {
+    const result = await checkAvailability(label)
+    return NextResponse.json(result, { headers: { 'cache-control': 'no-store' } })
+  } catch (err) {
+    console.error('[sns/check]', err)
+    return NextResponse.json({ error: 'availability_check_failed' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/sns/claim/route.ts
+++ b/apps/web/src/app/api/sns/claim/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PublicKey } from '@solana/web3.js'
+import { normalizeLabel, validateLabel, toFqdn, type Currency, type ClaimResponse } from '@/lib/sns'
+import { buildClaimTransaction, checkAvailability } from '@/lib/sns-server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  let body: { label?: string; buyer?: string; currency?: string; potPubkey?: string }
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'invalid_json' }, { status: 400 }) }
+
+  const label = normalizeLabel(body.label ?? '')
+  const currency: Currency = body.currency === 'USDC' ? 'USDC' : 'SOL'
+
+  const reason = validateLabel(label)
+  if (reason) return NextResponse.json({ error: 'invalid_label', reason }, { status: 400 })
+
+  let buyer: PublicKey
+  try { buyer = new PublicKey(body.buyer ?? '') } catch { return NextResponse.json({ error: 'invalid_buyer' }, { status: 400 }) }
+
+  if (body.potPubkey) {
+    try { new PublicKey(body.potPubkey) } catch { return NextResponse.json({ error: 'invalid_pot' }, { status: 400 }) }
+  }
+
+  const availability = await checkAvailability(label)
+  if (!availability.available) {
+    return NextResponse.json({ error: 'not_available', reason: availability.reason }, { status: 409 })
+  }
+
+  try {
+    const { transaction, amount, treasury } = await buildClaimTransaction({ label, buyer, currency })
+    const res: ClaimResponse = { transaction, fqdn: toFqdn(label), currency, amount, treasury }
+    return NextResponse.json(res, { headers: { 'cache-control': 'no-store' } })
+  } catch (err) {
+    console.error('[sns/claim]', err)
+    return NextResponse.json({ error: 'build_tx_failed' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/sns/claim/route.ts
+++ b/apps/web/src/app/api/sns/claim/route.ts
@@ -28,6 +28,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'not_available', reason: availability.reason }, { status: 409 })
   }
 
+  if (!process.env.POTBOT_SNS_OWNER_SECRET) {
+    return NextResponse.json({ error: 'owner_key_missing', message: 'POTBOT_SNS_OWNER_SECRET is not configured' }, { status: 503 })
+  }
+
   try {
     const { transaction, amount, treasury } = await buildClaimTransaction({ label, buyer, currency })
     const res: ClaimResponse = { transaction, fqdn: toFqdn(label), currency, amount, treasury }

--- a/apps/web/src/app/api/sns/owned/route.ts
+++ b/apps/web/src/app/api/sns/owned/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PublicKey } from '@solana/web3.js'
+import { listOwned } from '@/lib/sns-server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const ownerRaw = req.nextUrl.searchParams.get('owner') ?? ''
+  let owner: PublicKey
+  try { owner = new PublicKey(ownerRaw) } catch { return NextResponse.json({ error: 'invalid_owner' }, { status: 400 }) }
+  try {
+    const names = await listOwned(owner)
+    return NextResponse.json({ owner: owner.toBase58(), names }, { headers: { 'cache-control': 'no-store' } })
+  } catch (err) {
+    console.error('[sns/owned]', err)
+    return NextResponse.json({ error: 'list_failed' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/name/page.tsx
+++ b/apps/web/src/app/name/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+import ClaimWidget from '@/components/sns/ClaimWidget'
+import MyNames from '@/components/sns/MyNames'
+import { PRICE_TIERS, DEFAULT_PRICING } from '@/lib/sns'
+
+export const metadata: Metadata = {
+  title: 'Claim your .potbot.sol — PotBot',
+  description: 'Your on-chain identity in the PotBot ecosystem. Grab a human-readable .potbot.sol name that resolves to your wallet.',
+}
+
+const GREEN = '#14F195'
+const MUTED = '#6B7280'
+
+export default function NamePage({ searchParams }: { searchParams?: { name?: string; pot?: string } }) {
+  const initialName = typeof searchParams?.name === 'string' ? searchParams.name : ''
+  const potPubkey = typeof searchParams?.pot === 'string' ? searchParams.pot : undefined
+  return (
+    <main style={{ minHeight: '100vh', background: '#0D1117', color: '#fff', padding: '64px 20px 96px' }}>
+      <div style={{ maxWidth: 720, margin: '0 auto', textAlign: 'center' }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '6px 12px', borderRadius: 999, border: '1px solid #1A2332', background: '#111827', color: GREEN, fontSize: 13, marginBottom: 20 }}>{'🌿'} Powered by Solana Name Service</div>
+        <h1 style={{ fontSize: 40, lineHeight: 1.1, fontWeight: 800, margin: '0 0 14px', letterSpacing: -0.5 }}>Claim your <span style={{ color: GREEN }}>.potbot.sol</span></h1>
+        <p style={{ fontSize: 17, color: MUTED, maxWidth: 520, margin: '0 auto 36px' }}>One human-readable name for the whole PotBot ecosystem. It resolves to your wallet today — and to your pots tomorrow.</p>
+      </div>
+      <ClaimWidget initialName={initialName} potPubkey={potPubkey} />
+      <MyNames />
+      <div style={{ maxWidth: 560, margin: '40px auto 0', display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
+        <Feature title="One identity" body="Send & receive with a name, not a 44-char address." />
+        <Feature title="You own it" body="Minted to your wallet on-chain. Non-custodial." />
+        <Feature title="Ecosystem-wide" body="Works across PotBot, Y-DAO & SOLO." />
+      </div>
+      <PricingTable />
+      <Faq />
+    </main>
+  )
+}
+
+function Feature({ title, body }: { title: string; body: string }) {
+  return (
+    <div style={{ padding: '16px', background: '#111827', border: '1px solid #1A2332', borderRadius: 12, textAlign: 'left' }}>
+      <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 6 }}>{title}</div>
+      <div style={{ fontSize: 13, color: MUTED, lineHeight: 1.45 }}>{body}</div>
+    </div>
+  )
+}
+
+function PricingTable() {
+  const rows = [
+    { len: '1 char', p: PRICE_TIERS[1] }, { len: '2 chars', p: PRICE_TIERS[2] },
+    { len: '3 chars', p: PRICE_TIERS[3] }, { len: '4 chars', p: PRICE_TIERS[4] },
+    { len: '5+ chars', p: DEFAULT_PRICING },
+  ]
+  return (
+    <div style={{ maxWidth: 560, margin: '48px auto 0', width: '100%' }}>
+      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>Pricing</div>
+      <div style={{ background: '#111827', border: '1px solid #1A2332', borderRadius: 12, overflow: 'hidden' }}>
+        {rows.map((r, i) => (
+          <div key={r.len} style={{ display: 'flex', justifyContent: 'space-between', padding: '12px 16px', borderTop: i === 0 ? 'none' : '1px solid #1A2332' }}>
+            <span style={{ color: '#fff', fontSize: 14 }}>{r.len}</span>
+            <span style={{ color: GREEN, fontSize: 14, fontWeight: 600 }}>{r.p.sol} SOL · {r.p.usdc} USDC</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: 12, color: MUTED, marginTop: 8 }}>Shorter names are scarcer, so they cost more. You pay once — no renewals.</div>
+    </div>
+  )
+}
+
+function Faq() {
+  return (
+    <div style={{ maxWidth: 560, margin: '40px auto 0', width: '100%' }}>
+      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>FAQ</div>
+      <FaqItem q="What is a .potbot.sol name?" a="A Solana Name Service subdomain under potbot.sol. A human-readable handle that resolves to your wallet across Solana apps." />
+      <FaqItem q="Do I actually own it?" a="Yes — it's minted directly to your wallet on-chain. Non-custodial. PotBot only authorizes the creation." />
+      <FaqItem q="Which wallets work?" a="Any Solana wallet supported in PotBot — Phantom/Backpack via the adapter, or a Privy embedded wallet." />
+      <FaqItem q="Can I point it at a pot?" a="Soon. Names resolve to your wallet today; binding a name to a pot ships once pots are fully on mainnet." />
+    </div>
+  )
+}
+
+function FaqItem({ q, a }: { q: string; a: string }) {
+  return (
+    <div style={{ padding: '14px 16px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12, marginBottom: 8, textAlign: 'left' }}>
+      <div style={{ fontWeight: 600, fontSize: 14, color: '#fff', marginBottom: 4 }}>{q}</div>
+      <div style={{ fontSize: 13, color: MUTED, lineHeight: 1.45 }}>{a}</div>
+    </div>
+  )
+}

--- a/apps/web/src/app/name/page.tsx
+++ b/apps/web/src/app/name/page.tsx
@@ -8,18 +8,15 @@ export const metadata: Metadata = {
   description: 'Your on-chain identity in the PotBot ecosystem. Grab a human-readable .potbot.sol name that resolves to your wallet.',
 }
 
-const GREEN = '#14F195'
-const MUTED = '#6B7280'
-
 export default function NamePage({ searchParams }: { searchParams?: { name?: string; pot?: string } }) {
   const initialName = typeof searchParams?.name === 'string' ? searchParams.name : ''
   const potPubkey = typeof searchParams?.pot === 'string' ? searchParams.pot : undefined
   return (
-    <main style={{ minHeight: '100vh', background: '#0D1117', color: '#fff', padding: '64px 20px 96px' }}>
+    <main className="min-h-screen bg-pot-dark text-white" style={{ padding: '64px 20px 96px' }}>
       <div style={{ maxWidth: 720, margin: '0 auto', textAlign: 'center' }}>
-        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '6px 12px', borderRadius: 999, border: '1px solid #1A2332', background: '#111827', color: GREEN, fontSize: 13, marginBottom: 20 }}>{'🌿'} Powered by Solana Name Service</div>
-        <h1 style={{ fontSize: 40, lineHeight: 1.1, fontWeight: 800, margin: '0 0 14px', letterSpacing: -0.5 }}>Claim your <span style={{ color: GREEN }}>.potbot.sol</span></h1>
-        <p style={{ fontSize: 17, color: MUTED, maxWidth: 520, margin: '0 auto 36px' }}>One human-readable name for the whole PotBot ecosystem. It resolves to your wallet today — and to your pots tomorrow.</p>
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-pot-border bg-pot-card text-pot-green text-xs" style={{ marginBottom: 20 }}>{'🌿'} Powered by Solana Name Service</div>
+        <h1 className="text-4xl font-extrabold" style={{ lineHeight: 1.1, margin: '0 0 14px', letterSpacing: -0.5 }}>Claim your <span className="text-pot-green">.potbot.sol</span></h1>
+        <p className="text-pot-muted" style={{ fontSize: 17, maxWidth: 520, margin: '0 auto 36px' }}>One human-readable name for the whole PotBot ecosystem. It resolves to your wallet today — and to your pots tomorrow.</p>
       </div>
       <ClaimWidget initialName={initialName} potPubkey={potPubkey} />
       <MyNames />
@@ -36,9 +33,9 @@ export default function NamePage({ searchParams }: { searchParams?: { name?: str
 
 function Feature({ title, body }: { title: string; body: string }) {
   return (
-    <div style={{ padding: '16px', background: '#111827', border: '1px solid #1A2332', borderRadius: 12, textAlign: 'left' }}>
-      <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 6 }}>{title}</div>
-      <div style={{ fontSize: 13, color: MUTED, lineHeight: 1.45 }}>{body}</div>
+    <div className="bg-pot-card border border-pot-border rounded-xl p-4 text-left">
+      <div className="font-bold text-sm mb-1.5">{title}</div>
+      <div className="text-pot-muted text-xs" style={{ lineHeight: 1.45 }}>{body}</div>
     </div>
   )
 }
@@ -51,16 +48,16 @@ function PricingTable() {
   ]
   return (
     <div style={{ maxWidth: 560, margin: '48px auto 0', width: '100%' }}>
-      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>Pricing</div>
-      <div style={{ background: '#111827', border: '1px solid #1A2332', borderRadius: 12, overflow: 'hidden' }}>
+      <div className="text-pot-muted text-xs mb-2.5">Pricing</div>
+      <div className="bg-pot-card border border-pot-border rounded-xl overflow-hidden">
         {rows.map((r, i) => (
-          <div key={r.len} style={{ display: 'flex', justifyContent: 'space-between', padding: '12px 16px', borderTop: i === 0 ? 'none' : '1px solid #1A2332' }}>
-            <span style={{ color: '#fff', fontSize: 14 }}>{r.len}</span>
-            <span style={{ color: GREEN, fontSize: 14, fontWeight: 600 }}>{r.p.sol} SOL · {r.p.usdc} USDC</span>
+          <div key={r.len} className={`flex justify-between px-4 py-3 text-sm ${i > 0 ? 'border-t border-pot-border' : ''}`}>
+            <span>{r.len}</span>
+            <span className="text-pot-green font-semibold">{r.p.sol} SOL · {r.p.usdc} USDC</span>
           </div>
         ))}
       </div>
-      <div style={{ fontSize: 12, color: MUTED, marginTop: 8 }}>Shorter names are scarcer, so they cost more. You pay once — no renewals.</div>
+      <div className="text-pot-muted text-xs mt-2">Shorter names are scarcer, so they cost more. You pay once — no renewals.</div>
     </div>
   )
 }
@@ -68,7 +65,7 @@ function PricingTable() {
 function Faq() {
   return (
     <div style={{ maxWidth: 560, margin: '40px auto 0', width: '100%' }}>
-      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>FAQ</div>
+      <div className="text-pot-muted text-xs mb-2.5">FAQ</div>
       <FaqItem q="What is a .potbot.sol name?" a="A Solana Name Service subdomain under potbot.sol. A human-readable handle that resolves to your wallet across Solana apps." />
       <FaqItem q="Do I actually own it?" a="Yes — it's minted directly to your wallet on-chain. Non-custodial. PotBot only authorizes the creation." />
       <FaqItem q="Which wallets work?" a="Any Solana wallet supported in PotBot — Phantom/Backpack via the adapter, or a Privy embedded wallet." />
@@ -79,9 +76,9 @@ function Faq() {
 
 function FaqItem({ q, a }: { q: string; a: string }) {
   return (
-    <div style={{ padding: '14px 16px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12, marginBottom: 8, textAlign: 'left' }}>
-      <div style={{ fontWeight: 600, fontSize: 14, color: '#fff', marginBottom: 4 }}>{q}</div>
-      <div style={{ fontSize: 13, color: MUTED, lineHeight: 1.45 }}>{a}</div>
+    <div className="bg-pot-card/60 border border-pot-border rounded-xl mb-2 p-4 text-left">
+      <div className="font-semibold text-sm mb-1">{q}</div>
+      <div className="text-pot-muted text-xs" style={{ lineHeight: 1.45 }}>{a}</div>
     </div>
   )
 }

--- a/apps/web/src/app/pots/[pubkey]/page.tsx
+++ b/apps/web/src/app/pots/[pubkey]/page.tsx
@@ -21,6 +21,7 @@ import { StatusBadge } from '@/components/StatusBadge'
 import { PotHeroStrip } from '@/components/PotHeroStrip'
 import { PotActivityFeed } from '@/components/PotActivityFeed'
 import { reverseSNS } from '@/lib/sns'
+import PotSnsUpsell from '@/components/sns/PotSnsUpsell'
 import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import SwapExecuteButton from '@/components/SwapExecuteButton'
 import CreateProposalModal from '@/components/pot/CreateProposalModal'
@@ -823,6 +824,13 @@ export default function PotPage() {
                 cluster={CLUSTER}
               />
             </section>
+
+            {isOwner && (
+              <PotSnsUpsell variant="creator" potPubkey={pubkey} potName={pot.name} />
+            )}
+            {isMember && !isOwner && (
+              <PotSnsUpsell variant="member" potPubkey={pubkey} />
+            )}
 
             <section className="space-y-3">
               <div className="flex items-center gap-2">

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -73,6 +73,7 @@ const NAV_LINKS: { href: string; emoji: string; term: string }[] = [
   { href: '/leaderboard', emoji: '🏆',   term: 'Leaderboard' },
   { href: '/hackathon',   emoji: '⚒️',   term: 'Hackathon' },
   { href: '/create',      emoji: '+',    term: 'Create' },
+  { href: '/name',        emoji: '🌿',   term: 'Get a name' },
 ]
 
 export function Navbar() {

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -113,9 +113,6 @@ export function Navbar() {
               isActive('/dashboard') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
             }`}>{t('My Dashboard')}</Link>
           )}
-          <Link href="/faq" className={`px-3 py-1.5 rounded-lg transition ${
-            isActive('/faq') ? 'text-white bg-pot-card border border-pot-border' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
-          }`}>FAQ</Link>
         </div>
 
         <div className="flex items-center gap-2">
@@ -172,10 +169,6 @@ export function Navbar() {
                 isActive('/dashboard') ? 'text-pot-accent bg-pot-accent/10 border border-pot-accent/30' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
               }`}>{t('My Dashboard')}</Link>
           )}
-          <Link href="/faq" onClick={() => setMenuOpen(false)}
-            className={`block px-4 py-2.5 rounded-xl text-sm font-medium transition ${
-              isActive('/faq') ? 'text-white bg-pot-card border border-pot-border' : 'text-gray-400 hover:text-white hover:bg-pot-card/50'
-            }`}>FAQ</Link>
           <div className="pt-2 border-t border-pot-border/50">
             <Link href="/for-agents" onClick={() => setMenuOpen(false)}
               className="block px-4 py-2 text-sm text-pot-muted hover:text-pot-green transition">

--- a/apps/web/src/components/sns/ClaimWidget.tsx
+++ b/apps/web/src/components/sns/ClaimWidget.tsx
@@ -7,9 +7,6 @@ import {
 } from '@/lib/sns'
 import { useClaimWallet } from '@/hooks/useClaimWallet'
 
-const GREEN = '#14F195'
-const MUTED = '#6B7280'
-const RED = '#F87171'
 type Status = 'idle' | 'checking' | 'result'
 type ClaimState = 'idle' | 'building' | 'signing' | 'done' | 'error'
 
@@ -82,42 +79,40 @@ export default function ClaimWidget({ initialName = '', potPubkey }:
   }
 
   return (
-    <div className="card" style={{ background: '#111827', border: '1px solid #1A2332', borderRadius: 16, padding: 24, maxWidth: 560, margin: '0 auto', width: '100%' }}>
-      <label style={{ display: 'block', fontSize: 13, color: MUTED, marginBottom: 8 }}>Pick your name</label>
-      <div style={{ display: 'flex', alignItems: 'stretch', background: '#0D1117', border: `1px solid ${available ? GREEN : '#1A2332'}`, borderRadius: 12, overflow: 'hidden', transition: 'border-color 120ms ease' }}>
-        <input className="input" value={input} onChange={(e) => setInput(e.target.value)} placeholder="alice" autoCapitalize="none" autoCorrect="off" spellCheck={false}
-          style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: '#fff', fontSize: 18, padding: '14px 16px' }} />
-        <span style={{ display: 'flex', alignItems: 'center', padding: '0 16px', color: MUTED, fontSize: 16, background: '#0B0F14', borderLeft: '1px solid #1A2332', whiteSpace: 'nowrap' }}>.potbot.sol</span>
+    <div className="bg-pot-card border border-pot-border rounded-2xl p-6" style={{ maxWidth: 560, margin: '0 auto', width: '100%' }}>
+      <label className="block text-xs text-pot-muted mb-2">Pick your name</label>
+      <div className={`flex items-stretch bg-pot-dark border rounded-xl overflow-hidden transition-colors ${available ? 'border-pot-green/50' : 'border-pot-border'}`}>
+        <input className="input flex-1 bg-transparent border-none outline-none text-lg px-4 py-3.5" value={input} onChange={(e) => setInput(e.target.value)} placeholder="alice" autoCapitalize="none" autoCorrect="off" spellCheck={false} />
+        <span className="flex items-center px-4 text-pot-muted text-base bg-pot-dark border-l border-pot-border whitespace-nowrap">.potbot.sol</span>
       </div>
-      <div style={{ minHeight: 28, marginTop: 12, fontSize: 14 }}>
-        {status === 'checking' && <span style={{ color: MUTED }}>Checking availability…</span>}
+      <div className="min-h-[28px] mt-3 text-sm">
+        {status === 'checking' && <span className="text-pot-muted">Checking availability...</span>}
         {status === 'result' && result && <StatusLine result={result} />}
       </div>
       {available && (
-        <div style={{ marginTop: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12 }}>
+        <div className="mt-2">
+          <div className="flex items-center justify-between p-4 bg-pot-dark border border-pot-border rounded-xl">
             <div>
-              <div style={{ fontSize: 12, color: MUTED }}>Price</div>
-              <div style={{ fontSize: 22, fontWeight: 700, color: '#fff' }}>{formatPrice(price, currency)}</div>
+              <div className="text-xs text-pot-muted">Price</div>
+              <div className="text-xl font-bold">{formatPrice(price, currency)}</div>
             </div>
-            <div style={{ display: 'flex', gap: 8 }}>
+            <div className="flex gap-2">
               {(['SOL', 'USDC'] as Currency[]).map((c) => (
                 <button key={c} onClick={() => setCurrency(c)}
-                  style={{ padding: '8px 14px', borderRadius: 10, border: `1px solid ${currency === c ? GREEN : '#1A2332'}`, background: currency === c ? 'rgba(20,241,149,0.08)' : 'transparent', color: currency === c ? GREEN : MUTED, fontWeight: 600, cursor: 'pointer' }}>{c}</button>
+                  className={`px-3.5 py-2 rounded-lg border font-semibold cursor-pointer transition ${currency === c ? 'border-pot-green/50 bg-pot-green/10 text-pot-green' : 'border-pot-border text-pot-muted'}`}>{c}</button>
               ))}
             </div>
           </div>
-          <button className="btn-primary" onClick={handleClaim} disabled={claimState === 'building' || claimState === 'signing'}
-            style={{ marginTop: 14, width: '100%', padding: '14px 16px', borderRadius: 12, border: 'none', background: GREEN, color: '#04150C', fontSize: 16, fontWeight: 700, cursor: 'pointer', opacity: claimState === 'building' || claimState === 'signing' ? 0.7 : 1 }}>
+          <button className="btn-primary w-full mt-3.5 py-3.5 rounded-xl border-none bg-pot-green text-pot-dark text-base font-bold cursor-pointer disabled:opacity-70" onClick={handleClaim} disabled={claimState === 'building' || claimState === 'signing'}>
             {claimLabel(claimState, wallet.connected, label, currency, price)}
           </button>
           {claimState === 'done' && signature && (
-            <div style={{ marginTop: 14, padding: '12px 14px', borderRadius: 12, background: 'rgba(20,241,149,0.08)', border: `1px solid ${GREEN}`, color: GREEN, fontSize: 14 }}>
+            <div className="mt-3.5 p-3 rounded-xl bg-pot-green/10 border border-pot-green/30 text-pot-green text-sm">
               {label}.potbot.sol is yours!{' '}
-              <a href={`https://solscan.io/tx/${signature}`} target="_blank" rel="noreferrer" style={{ color: '#fff', textDecoration: 'underline' }}>View transaction</a>
+              <a href={`https://solscan.io/tx/${signature}`} target="_blank" rel="noreferrer" className="text-white underline">View transaction</a>
             </div>
           )}
-          {error && <div style={{ marginTop: 12, color: RED, fontSize: 14 }}>{error}</div>}
+          {error && <div className="mt-3 text-red-400 text-sm">{error}</div>}
         </div>
       )}
     </div>
@@ -125,9 +120,9 @@ export default function ClaimWidget({ initialName = '', potPubkey }:
 }
 
 function StatusLine({ result }: { result: AvailabilityResult }) {
-  if (result.available) return <span style={{ color: GREEN }}>{result.fqdn} is available</span>
+  if (result.available) return <span className="text-pot-green">{result.fqdn} is available</span>
   const map: Record<string, string> = { taken: `${result.fqdn} is taken`, reserved: 'This name is reserved', invalid: 'Only a-z, 0-9 and hyphen', too_short: 'Too short', too_long: 'Too long (max 63)' }
-  return <span style={{ color: '#F87171' }}>{map[result.reason ?? 'taken'] ?? 'Unavailable'}</span>
+  return <span className="text-red-400">{map[result.reason ?? 'taken'] ?? 'Unavailable'}</span>
 }
 
 function claimLabel(state: ClaimState, connected: boolean, label: string, currency: Currency, price: number): string {
@@ -142,7 +137,8 @@ function humanError(code?: string): string {
   switch (code) {
     case 'wallet_not_connected': return 'Wallet not connected'
     case 'not_available': return 'Just taken — try another name'
-    case 'build_tx_failed': return "Couldn't build the transaction (check domain-owner config)"
+    case 'build_tx_failed': return 'Service temporarily unavailable — domain owner key is not configured on the server'
+    case 'owner_key_missing': return 'Service temporarily unavailable — domain owner key is not configured on the server'
     default: return 'Something went wrong. Please try again'
   }
 }

--- a/apps/web/src/components/sns/ClaimWidget.tsx
+++ b/apps/web/src/components/sns/ClaimWidget.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  normalizeLabel, validateLabel, formatPrice, DEFAULT_PRICING,
+  type AvailabilityResult, type Currency, type ClaimResponse,
+} from '@/lib/sns'
+import { useClaimWallet } from '@/hooks/useClaimWallet'
+
+const GREEN = '#14F195'
+const MUTED = '#6B7280'
+const RED = '#F87171'
+type Status = 'idle' | 'checking' | 'result'
+type ClaimState = 'idle' | 'building' | 'signing' | 'done' | 'error'
+
+export default function ClaimWidget({ initialName = '', potPubkey }:
+  { initialName?: string; potPubkey?: string }) {
+  const wallet = useClaimWallet()
+  const [input, setInput] = useState(initialName)
+  const [status, setStatus] = useState<Status>('idle')
+  const [result, setResult] = useState<AvailabilityResult | null>(null)
+  const [currency, setCurrency] = useState<Currency>('SOL')
+  const [claimState, setClaimState] = useState<ClaimState>('idle')
+  const [signature, setSignature] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const label = useMemo(() => normalizeLabel(input), [input])
+  const localReason = useMemo(() => (label ? validateLabel(label) : null), [label])
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const reqIdRef = useRef(0)
+
+  useEffect(() => {
+    setClaimState('idle')
+    setSignature(null)
+    setError(null)
+    if (!label) { setStatus('idle'); setResult(null); return }
+    if (localReason) {
+      setStatus('result')
+      setResult({ label, fqdn: `${label}.potbot.sol`, available: false, reason: localReason, pricing: DEFAULT_PRICING })
+      return
+    }
+    setStatus('checking')
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    const myId = ++reqIdRef.current
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/sns/check?name=${encodeURIComponent(label)}`)
+        const data: AvailabilityResult = await res.json()
+        if (myId !== reqIdRef.current) return
+        setResult(data)
+        setStatus('result')
+      } catch {
+        if (myId !== reqIdRef.current) return
+        setError("Couldn't check availability")
+        setStatus('result')
+      }
+    }, 350)
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+  }, [label, localReason])
+
+  const pricing = result?.pricing ?? DEFAULT_PRICING
+  const price = currency === 'SOL' ? pricing.sol : pricing.usdc
+  const available = status === 'result' && result?.available === true
+
+  async function handleClaim() {
+    if (!available) return
+    setError(null)
+    if (!wallet.connected) { wallet.login(); return }
+    try {
+      setClaimState('building')
+      const res = await fetch('/api/sns/claim', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ label, buyer: wallet.address, currency, potPubkey }),
+      })
+      if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.error ?? 'claim_failed') }
+      const data: ClaimResponse = await res.json()
+      setClaimState('signing')
+      const sig = await wallet.signAndSend(data.transaction)
+      setSignature(sig)
+      setClaimState('done')
+    } catch (e: any) { setError(humanError(e?.message)); setClaimState('error') }
+  }
+
+  return (
+    <div className="card" style={{ background: '#111827', border: '1px solid #1A2332', borderRadius: 16, padding: 24, maxWidth: 560, margin: '0 auto', width: '100%' }}>
+      <label style={{ display: 'block', fontSize: 13, color: MUTED, marginBottom: 8 }}>Pick your name</label>
+      <div style={{ display: 'flex', alignItems: 'stretch', background: '#0D1117', border: `1px solid ${available ? GREEN : '#1A2332'}`, borderRadius: 12, overflow: 'hidden', transition: 'border-color 120ms ease' }}>
+        <input className="input" value={input} onChange={(e) => setInput(e.target.value)} placeholder="alice" autoCapitalize="none" autoCorrect="off" spellCheck={false}
+          style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', color: '#fff', fontSize: 18, padding: '14px 16px' }} />
+        <span style={{ display: 'flex', alignItems: 'center', padding: '0 16px', color: MUTED, fontSize: 16, background: '#0B0F14', borderLeft: '1px solid #1A2332', whiteSpace: 'nowrap' }}>.potbot.sol</span>
+      </div>
+      <div style={{ minHeight: 28, marginTop: 12, fontSize: 14 }}>
+        {status === 'checking' && <span style={{ color: MUTED }}>Checking availability…</span>}
+        {status === 'result' && result && <StatusLine result={result} />}
+      </div>
+      {available && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 16px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12 }}>
+            <div>
+              <div style={{ fontSize: 12, color: MUTED }}>Price</div>
+              <div style={{ fontSize: 22, fontWeight: 700, color: '#fff' }}>{formatPrice(price, currency)}</div>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {(['SOL', 'USDC'] as Currency[]).map((c) => (
+                <button key={c} onClick={() => setCurrency(c)}
+                  style={{ padding: '8px 14px', borderRadius: 10, border: `1px solid ${currency === c ? GREEN : '#1A2332'}`, background: currency === c ? 'rgba(20,241,149,0.08)' : 'transparent', color: currency === c ? GREEN : MUTED, fontWeight: 600, cursor: 'pointer' }}>{c}</button>
+              ))}
+            </div>
+          </div>
+          <button className="btn-primary" onClick={handleClaim} disabled={claimState === 'building' || claimState === 'signing'}
+            style={{ marginTop: 14, width: '100%', padding: '14px 16px', borderRadius: 12, border: 'none', background: GREEN, color: '#04150C', fontSize: 16, fontWeight: 700, cursor: 'pointer', opacity: claimState === 'building' || claimState === 'signing' ? 0.7 : 1 }}>
+            {claimLabel(claimState, wallet.connected, label, currency, price)}
+          </button>
+          {claimState === 'done' && signature && (
+            <div style={{ marginTop: 14, padding: '12px 14px', borderRadius: 12, background: 'rgba(20,241,149,0.08)', border: `1px solid ${GREEN}`, color: GREEN, fontSize: 14 }}>
+              {label}.potbot.sol is yours!{' '}
+              <a href={`https://solscan.io/tx/${signature}`} target="_blank" rel="noreferrer" style={{ color: '#fff', textDecoration: 'underline' }}>View transaction</a>
+            </div>
+          )}
+          {error && <div style={{ marginTop: 12, color: RED, fontSize: 14 }}>{error}</div>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatusLine({ result }: { result: AvailabilityResult }) {
+  if (result.available) return <span style={{ color: GREEN }}>{result.fqdn} is available</span>
+  const map: Record<string, string> = { taken: `${result.fqdn} is taken`, reserved: 'This name is reserved', invalid: 'Only a-z, 0-9 and hyphen', too_short: 'Too short', too_long: 'Too long (max 63)' }
+  return <span style={{ color: '#F87171' }}>{map[result.reason ?? 'taken'] ?? 'Unavailable'}</span>
+}
+
+function claimLabel(state: ClaimState, connected: boolean, label: string, currency: Currency, price: number): string {
+  if (state === 'building') return 'Preparing transaction...'
+  if (state === 'signing') return 'Sign in your wallet...'
+  if (state === 'done') return 'Done'
+  if (!connected) return 'Connect wallet'
+  return `Claim ${label}.potbot.sol for ${formatPrice(price, currency)}`
+}
+
+function humanError(code?: string): string {
+  switch (code) {
+    case 'wallet_not_connected': return 'Wallet not connected'
+    case 'not_available': return 'Just taken — try another name'
+    case 'build_tx_failed': return "Couldn't build the transaction (check domain-owner config)"
+    default: return 'Something went wrong. Please try again'
+  }
+}

--- a/apps/web/src/components/sns/MyNames.tsx
+++ b/apps/web/src/components/sns/MyNames.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { OwnedName } from '@/lib/sns'
+import { useClaimWallet } from '@/hooks/useClaimWallet'
+
+const MUTED = '#6B7280'
+const GREEN = '#14F195'
+
+export default function MyNames() {
+  const wallet = useClaimWallet()
+  const [names, setNames] = useState<OwnedName[] | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!wallet.connected || !wallet.address) { setNames(null); return }
+    let active = true
+    setLoading(true)
+    fetch(`/api/sns/owned?owner=${wallet.address}`)
+      .then((r) => r.json()).then((d) => { if (active) setNames(d.names ?? []) })
+      .catch(() => active && setNames([])).finally(() => active && setLoading(false))
+    return () => { active = false }
+  }, [wallet.connected, wallet.address])
+
+  if (!wallet.connected) return null
+  return (
+    <div style={{ maxWidth: 560, margin: '32px auto 0', width: '100%' }}>
+      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>Your names</div>
+      {loading && <div style={{ color: MUTED }}>Loading...</div>}
+      {!loading && names && names.length === 0 && <div style={{ color: MUTED, fontSize: 14 }}>No .potbot.sol names yet</div>}
+      {!loading && names && names.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {names.map((n) => (
+            <div key={n.fqdn} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12 }}>
+              <span style={{ color: GREEN }}>{'🌿'}</span>
+              <span style={{ color: '#fff', fontWeight: 600 }}>{n.fqdn}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/sns/MyNames.tsx
+++ b/apps/web/src/components/sns/MyNames.tsx
@@ -4,9 +4,6 @@ import { useEffect, useState } from 'react'
 import type { OwnedName } from '@/lib/sns'
 import { useClaimWallet } from '@/hooks/useClaimWallet'
 
-const MUTED = '#6B7280'
-const GREEN = '#14F195'
-
 export default function MyNames() {
   const wallet = useClaimWallet()
   const [names, setNames] = useState<OwnedName[] | null>(null)
@@ -25,15 +22,15 @@ export default function MyNames() {
   if (!wallet.connected) return null
   return (
     <div style={{ maxWidth: 560, margin: '32px auto 0', width: '100%' }}>
-      <div style={{ fontSize: 13, color: MUTED, marginBottom: 10 }}>Your names</div>
-      {loading && <div style={{ color: MUTED }}>Loading...</div>}
-      {!loading && names && names.length === 0 && <div style={{ color: MUTED, fontSize: 14 }}>No .potbot.sol names yet</div>}
+      <div className="text-pot-muted text-xs mb-2.5">Your names</div>
+      {loading && <div className="text-pot-muted">Loading...</div>}
+      {!loading && names && names.length === 0 && <div className="text-pot-muted text-sm">No .potbot.sol names yet</div>}
       {!loading && names && names.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div className="flex flex-col gap-2">
           {names.map((n) => (
-            <div key={n.fqdn} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', background: '#0D1117', border: '1px solid #1A2332', borderRadius: 12 }}>
-              <span style={{ color: GREEN }}>{'🌿'}</span>
-              <span style={{ color: '#fff', fontWeight: 600 }}>{n.fqdn}</span>
+            <div key={n.fqdn} className="flex items-center gap-2.5 p-3 bg-pot-dark border border-pot-border rounded-xl">
+              <span className="text-pot-green">{'🌿'}</span>
+              <span className="font-semibold">{n.fqdn}</span>
             </div>
           ))}
         </div>

--- a/apps/web/src/components/sns/PotSnsUpsell.tsx
+++ b/apps/web/src/components/sns/PotSnsUpsell.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { normalizeLabel, validateLabel } from '@/lib/sns'
+
+const GREEN = '#14F195'
+const MUTED = '#6B7280'
+
+export default function PotSnsUpsell({ variant = 'member', potPubkey, potName }:
+  { variant?: 'creator' | 'member'; potPubkey: string; potName?: string }) {
+  const suggested = potName ? normalizeLabel(potName) : ''
+  const suggestedValid = suggested ? validateLabel(suggested) === null : false
+  const params = new URLSearchParams()
+  if (variant === 'creator' && suggestedValid) params.set('name', suggested)
+  if (potPubkey) params.set('pot', potPubkey)
+  const href = `/name${params.toString() ? `?${params}` : ''}`
+  const isCreator = variant === 'creator'
+  const title = isCreator ? 'Give this pot a name' : 'Claim your .potbot.sol'
+  const body = isCreator
+    ? (suggestedValid ? `Grab ${suggested}.potbot.sol — a clean, shareable handle for this pot.` : 'Grab a clean, shareable .potbot.sol handle for this pot.')
+    : 'One human-readable name across PotBot, Y-DAO & SOLO.'
+  const cta = isCreator && suggestedValid ? `Claim ${suggested}.potbot.sol` : 'Browse names'
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '16px 18px', background: '#111827', border: `1px solid ${GREEN}33`, borderRadius: 14, backgroundImage: 'linear-gradient(90deg, rgba(20,241,149,0.06), rgba(153,69,255,0.06))' }}>
+      <div style={{ fontSize: 28, lineHeight: 1 }}>{'🌿'}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: '#fff' }}>{title}</div>
+        <div style={{ fontSize: 13, color: MUTED, marginTop: 2 }}>{body}</div>
+      </div>
+      <a href={href} style={{ flexShrink: 0, padding: '10px 16px', borderRadius: 10, background: GREEN, color: '#04150C', fontSize: 14, fontWeight: 700, textDecoration: 'none', whiteSpace: 'nowrap' }}>{cta}</a>
+    </div>
+  )
+}

--- a/apps/web/src/components/sns/PotSnsUpsell.tsx
+++ b/apps/web/src/components/sns/PotSnsUpsell.tsx
@@ -2,9 +2,6 @@
 
 import { normalizeLabel, validateLabel } from '@/lib/sns'
 
-const GREEN = '#14F195'
-const MUTED = '#6B7280'
-
 export default function PotSnsUpsell({ variant = 'member', potPubkey, potName }:
   { variant?: 'creator' | 'member'; potPubkey: string; potName?: string }) {
   const suggested = potName ? normalizeLabel(potName) : ''
@@ -21,13 +18,13 @@ export default function PotSnsUpsell({ variant = 'member', potPubkey, potName }:
   const cta = isCreator && suggestedValid ? `Claim ${suggested}.potbot.sol` : 'Browse names'
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '16px 18px', background: '#111827', border: `1px solid ${GREEN}33`, borderRadius: 14, backgroundImage: 'linear-gradient(90deg, rgba(20,241,149,0.06), rgba(153,69,255,0.06))' }}>
-      <div style={{ fontSize: 28, lineHeight: 1 }}>{'🌿'}</div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 14, fontWeight: 700, color: '#fff' }}>{title}</div>
-        <div style={{ fontSize: 13, color: MUTED, marginTop: 2 }}>{body}</div>
+    <div className="flex items-center gap-3.5 p-4 bg-pot-card border border-pot-green/20 rounded-2xl" style={{ backgroundImage: 'linear-gradient(90deg, rgba(20,241,149,0.06), rgba(153,69,255,0.06))' }}>
+      <div className="text-3xl leading-none">{'🌿'}</div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-bold">{title}</div>
+        <div className="text-pot-muted text-xs mt-0.5">{body}</div>
       </div>
-      <a href={href} style={{ flexShrink: 0, padding: '10px 16px', borderRadius: 10, background: GREEN, color: '#04150C', fontSize: 14, fontWeight: 700, textDecoration: 'none', whiteSpace: 'nowrap' }}>{cta}</a>
+      <a href={href} className="shrink-0 px-4 py-2.5 rounded-lg bg-pot-green text-pot-dark text-sm font-bold no-underline whitespace-nowrap">{cta}</a>
     </div>
   )
 }

--- a/apps/web/src/hooks/useClaimWallet.ts
+++ b/apps/web/src/hooks/useClaimWallet.ts
@@ -1,0 +1,71 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { Transaction } from '@solana/web3.js'
+import { useConnection, useWallet } from '@solana/wallet-adapter-react'
+import { usePrivy } from '@privy-io/react-auth'
+import { useSignTransaction, useWallets } from '@privy-io/react-auth/solana'
+
+const CLUSTER = process.env.NEXT_PUBLIC_SOLANA_CLUSTER ?? 'devnet'
+const SOLANA_CHAIN: `solana:${string}` =
+  CLUSTER === 'mainnet-beta' ? 'solana:mainnet' : 'solana:devnet'
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+export interface ClaimWallet {
+  ready: boolean
+  connected: boolean
+  address: string | null
+  via: 'adapter' | 'privy' | null
+  login: () => void
+  signAndSend: (base64Tx: string) => Promise<string>
+}
+
+export function useClaimWallet(): ClaimWallet {
+  const { connection } = useConnection()
+  const adapter = useWallet()
+  const adapterConnected = Boolean(adapter.connected && adapter.publicKey)
+  const adapterAddress = adapter.publicKey?.toBase58() ?? null
+
+  const { ready, authenticated, login } = usePrivy()
+  const { wallets } = useWallets()
+  const { signTransaction: privySign } = useSignTransaction()
+  const privyWallet = wallets?.[0] ?? null
+  const privyAddress = privyWallet?.address ?? null
+  const privyConnected = Boolean(authenticated && privyAddress)
+
+  const via: ClaimWallet['via'] = adapterConnected ? 'adapter' : privyConnected ? 'privy' : null
+  const connected = via !== null
+  const address = adapterConnected ? adapterAddress : privyAddress
+
+  const signAndSend = useCallback(async (base64Tx: string): Promise<string> => {
+    const tx = Transaction.from(base64ToBytes(base64Tx))
+    let signed: Transaction
+    if (adapterConnected && adapter.signTransaction) {
+      signed = await adapter.signTransaction(tx)
+    } else if (privyWallet) {
+      const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false })
+      const out = await privySign({
+        transaction: new Uint8Array(serialized),
+        wallet: privyWallet,
+        chain: SOLANA_CHAIN,
+      })
+      signed = Transaction.from(out.signedTransaction)
+    } else {
+      throw new Error('wallet_not_connected')
+    }
+    const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: false, maxRetries: 3 })
+    await connection.confirmTransaction(sig, 'confirmed')
+    return sig
+  }, [adapterConnected, adapter, privyWallet, privySign, connection])
+
+  const doLogin = useCallback(() => { login() }, [login])
+
+  return useMemo(() => ({ ready, connected, address, via, login: doLogin, signAndSend }),
+    [ready, connected, address, via, doLogin, signAndSend])
+}

--- a/apps/web/src/lib/sns-server.ts
+++ b/apps/web/src/lib/sns-server.ts
@@ -1,0 +1,156 @@
+import 'server-only'
+
+import {
+  Connection, Keypair, PublicKey, SystemProgram, Transaction, TransactionInstruction,
+} from '@solana/web3.js'
+import {
+  getAssociatedTokenAddressSync, createAssociatedTokenAccountInstruction,
+  createTransferCheckedInstruction, TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import {
+  getDomainKeySync, NameRegistryState, resolve, createSubdomain, findSubdomains,
+} from '@bonfida/spl-name-service'
+import bs58 from 'bs58'
+
+import {
+  PARENT_LABEL, DEFAULT_PRICING, PRICE_TIERS, type PriceConfig, type Currency,
+  type AvailabilityResult, type OwnedName, toFqdn, validateLabel, USDC_DECIMALS,
+  LAMPORTS_PER_SOL_SNS,
+} from './sns'
+
+const DEFAULT_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+let _conn: Connection | null = null
+export function getServerConnection(): Connection {
+  if (_conn) return _conn
+  const url =
+    process.env.POTBOT_SNS_RPC_URL ??
+    process.env.NEXT_PUBLIC_RPC_URL ??
+    'https://api.mainnet-beta.solana.com'
+  _conn = new Connection(url, 'confirmed')
+  return _conn
+}
+
+export function getParentKey(): PublicKey {
+  return getDomainKeySync(PARENT_LABEL).pubkey
+}
+
+export function getOwnerKeypair(): Keypair {
+  const raw = process.env.POTBOT_SNS_OWNER_SECRET
+  if (!raw) throw new Error('POTBOT_SNS_OWNER_SECRET is not set')
+  const trimmed = raw.trim()
+  if (trimmed.startsWith('[')) {
+    return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(trimmed)))
+  }
+  return Keypair.fromSecretKey(bs58.decode(trimmed))
+}
+
+export function getTreasury(): PublicKey {
+  const t = process.env.POTBOT_SNS_TREASURY
+  if (t) return new PublicKey(t)
+  return getOwnerKeypair().publicKey
+}
+
+export function getUsdcMint(): PublicKey {
+  return new PublicKey(process.env.POTBOT_SNS_USDC_MINT ?? DEFAULT_USDC_MINT)
+}
+
+export function getPricing(): PriceConfig {
+  const sol = process.env.POTBOT_SNS_PRICE_SOL
+    ? Number(process.env.POTBOT_SNS_PRICE_SOL) : DEFAULT_PRICING.sol
+  const usdc = process.env.POTBOT_SNS_PRICE_USDC
+    ? Number(process.env.POTBOT_SNS_PRICE_USDC) : DEFAULT_PRICING.usdc
+  return { sol, usdc }
+}
+
+export function priceForLabelServer(label: string): PriceConfig {
+  return PRICE_TIERS[label.length] ?? getPricing()
+}
+
+export async function checkAvailability(rawLabel: string): Promise<AvailabilityResult> {
+  const label = rawLabel
+  const fqdn = toFqdn(label)
+  const pricing = priceForLabelServer(label)
+
+  const reason = validateLabel(label)
+  if (reason) return { label, fqdn, available: false, reason, pricing }
+
+  const connection = getServerConnection()
+  const key = getDomainKeySync(`${label}.${PARENT_LABEL}`).pubkey
+  try {
+    const { registry } = await NameRegistryState.retrieve(connection, key)
+    return { label, fqdn, available: false, reason: 'taken', owner: registry?.owner?.toBase58?.(), pricing }
+  } catch {
+    return { label, fqdn, available: true, pricing }
+  }
+}
+
+interface BuildClaimArgs { label: string; buyer: PublicKey; currency: Currency }
+
+export async function buildClaimTransaction({ label, buyer, currency }: BuildClaimArgs):
+  Promise<{ transaction: string; amount: number; treasury: string }> {
+  const connection = getServerConnection()
+  const owner = getOwnerKeypair()
+  const treasury = getTreasury()
+  const pricing = priceForLabelServer(label)
+
+  const ixs: TransactionInstruction[] = []
+  let amount: number
+  if (currency === 'SOL') {
+    amount = pricing.sol
+    ixs.push(SystemProgram.transfer({
+      fromPubkey: buyer, toPubkey: treasury,
+      lamports: Math.round(pricing.sol * LAMPORTS_PER_SOL_SNS),
+    }))
+  } else {
+    amount = pricing.usdc
+    const mint = getUsdcMint()
+    const buyerAta = getAssociatedTokenAddressSync(mint, buyer, true)
+    const treasuryAta = getAssociatedTokenAddressSync(mint, treasury, true)
+    const treasuryAtaInfo = await connection.getAccountInfo(treasuryAta)
+    if (!treasuryAtaInfo) {
+      ixs.push(createAssociatedTokenAccountInstruction(buyer, treasuryAta, treasury, mint))
+    }
+    ixs.push(createTransferCheckedInstruction(
+      buyerAta, mint, treasuryAta, buyer,
+      Math.round(pricing.usdc * 10 ** USDC_DECIMALS), USDC_DECIMALS, [], TOKEN_PROGRAM_ID,
+    ))
+  }
+
+  const subIxs = await createSubdomain(connection, `${label}.${PARENT_LABEL}`, buyer, undefined, buyer)
+  for (const ix of flattenInstructions(subIxs)) ixs.push(ix)
+
+  const tx = new Transaction()
+  tx.feePayer = buyer
+  const { blockhash } = await connection.getLatestBlockhash('confirmed')
+  tx.recentBlockhash = blockhash
+  tx.add(...ixs)
+  tx.partialSign(owner)
+
+  const serialized = tx.serialize({ requireAllSignatures: false, verifySignatures: false }).toString('base64')
+  return { transaction: serialized, amount, treasury: treasury.toBase58() }
+}
+
+export async function listOwned(wallet: PublicKey): Promise<OwnedName[]> {
+  const connection = getServerConnection()
+  const parentKey = getParentKey()
+  const labels: string[] = await findSubdomains(connection, parentKey)
+  const out: OwnedName[] = []
+  const target = wallet.toBase58()
+  for (const label of labels.slice(0, 300)) {
+    try {
+      const ownerPk = await resolve(connection, `${label}.${PARENT_LABEL}`)
+      if (ownerPk?.toBase58?.() === target) out.push({ label, fqdn: toFqdn(label) })
+    } catch { /* not owned by this wallet */ }
+  }
+  return out
+}
+
+function flattenInstructions(res: TransactionInstruction[] | TransactionInstruction[][]): TransactionInstruction[] {
+  const out: TransactionInstruction[] = []
+  for (const item of res as any[]) {
+    if (Array.isArray(item)) out.push(...item)
+    else if (item) out.push(item)
+  }
+  return out
+}

--- a/apps/web/src/lib/sns.ts
+++ b/apps/web/src/lib/sns.ts
@@ -326,3 +326,105 @@ export function getPotShareText(potName: string, snsName?: string): string {
 export function formatSNSBadge(snsName: string): string {
   return snsName
 }
+
+// ─── Subdomain Sales (.potbot.sol) ─────────────────────────────────────────
+
+export const PARENT_LABEL = 'potbot'
+export const PARENT_FQDN = 'potbot.sol'
+export const LABEL_MIN_LEN = 1
+export const LABEL_MAX_LEN = 63
+
+export const RESERVED_LABELS = new Set<string>([
+  'www', 'api', 'app', 'admin', 'root', 'potbot', 'support', 'help', 'mail',
+  'vault', 'vaults', 'pot', 'team', 'ydao', 'y-dao', 'stamppot', 'peace',
+])
+
+export type Currency = 'SOL' | 'USDC'
+
+export interface PriceConfig {
+  sol: number
+  usdc: number
+}
+
+export const PRICE_TIERS: Record<number, PriceConfig> = {
+  1: { sol: 2, usdc: 200 },
+  2: { sol: 1, usdc: 100 },
+  3: { sol: 0.5, usdc: 50 },
+  4: { sol: 0.15, usdc: 15 },
+}
+
+export const DEFAULT_PRICING: PriceConfig = { sol: 0.05, usdc: 5 }
+
+export function priceForLabel(
+  label: string,
+  standard: PriceConfig = DEFAULT_PRICING,
+): PriceConfig {
+  return PRICE_TIERS[label.length] ?? standard
+}
+
+export function tierName(label: string): string {
+  if (label.length <= 4) return `${label.length}-char premium`
+  return 'standard'
+}
+
+export interface AvailabilityResult {
+  label: string
+  fqdn: string
+  available: boolean
+  owner?: string
+  reason?: 'invalid' | 'reserved' | 'taken' | 'too_short' | 'too_long'
+  pricing: PriceConfig
+}
+
+export interface ClaimRequest {
+  label: string
+  buyer: string
+  currency: Currency
+  potPubkey?: string
+}
+
+export interface ClaimResponse {
+  transaction: string
+  fqdn: string
+  currency: Currency
+  amount: number
+  treasury: string
+}
+
+export interface OwnedName {
+  label: string
+  fqdn: string
+  boundPot?: string
+}
+
+export function normalizeLabel(input: string): string {
+  let s = (input ?? '').trim().toLowerCase()
+  s = s.replace(/\.potbot\.sol$/, '')
+  s = s.replace(/\.potbot$/, '')
+  s = s.replace(/\.sol$/, '')
+  return s.trim()
+}
+
+export function validateLabel(label: string): AvailabilityResult['reason'] | null {
+  if (!label || label.length < LABEL_MIN_LEN) return 'too_short'
+  if (label.length > LABEL_MAX_LEN) return 'too_long'
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(label)) return 'invalid'
+  if (RESERVED_LABELS.has(label)) return 'reserved'
+  return null
+}
+
+export function isValidLabel(label: string): boolean {
+  return validateLabel(label) === null
+}
+
+export function toFqdn(label: string): string {
+  return `${label}.${PARENT_FQDN}`
+}
+
+export function formatPrice(amount: number, currency: Currency): string {
+  const n = currency === 'SOL' ? amount : Math.round(amount * 100) / 100
+  return `${n} ${currency}`
+}
+
+export const USDC_DECIMALS = 6
+export const LAMPORTS_PER_SOL_SNS = 1_000_000_000

--- a/docs/SNS_SUBDOMAINS.md
+++ b/docs/SNS_SUBDOMAINS.md
@@ -1,0 +1,109 @@
+# .potbot.sol Subdomain Sales
+
+## Overview
+
+PotBot owns the `potbot.sol` Solana Name Service domain. We sell subdomains
+(`<name>.potbot.sol`) to users as human-readable on-chain identities. Each
+subdomain resolves to the buyer's wallet address.
+
+## Architecture
+
+```
+Client                    Server (/api/sns)              On-chain (SNS)
+  |                           |                              |
+  |-- GET /check?name=alice ->|                              |
+  |                           |-- getDomainKeySync() ------->|
+  |                           |<- NameRegistryState.retrieve |
+  |<- { available, pricing } -|                              |
+  |                           |                              |
+  |-- POST /claim ----------->|                              |
+  |   { label, buyer, SOL }   |-- buildClaimTransaction() -->|
+  |                           |   [pay → treasury]           |
+  |                           |   [createSubdomain owner=buyer]
+  |                           |   partialSign(parentOwner)   |
+  |<- { transaction (base64)} |                              |
+  |                           |                              |
+  |-- signAndSend(tx) ------->|                              |
+  |   (buyer signs as         |                         [tx lands]
+  |    feePayer + submits)     |                              |
+```
+
+### Key design decisions
+
+1. **Buyer is fee payer** — the buyer covers Solana rent for the subdomain
+   account. PotBot's marginal cost is ~$0, achieving ~100% margin on the
+   pricing tiers.
+
+2. **Parent owner partial-signs server-side** — `createSubdomain` requires
+   the parent domain owner's signature. The server holds
+   `POTBOT_SNS_OWNER_SECRET` (a dedicated key that only owns `potbot.sol`
+   with near-zero SOL balance) and partial-signs the transaction. The buyer
+   then counter-signs and submits.
+
+3. **Price enforcement is server-side** — the payment instruction is baked
+   into the transaction by the server, so the buyer cannot skip it.
+
+4. **Mainnet only** — SNS only exists on Solana mainnet. The feature uses
+   its own RPC endpoint (`POTBOT_SNS_RPC_URL`) independent of the app's
+   devnet default.
+
+## Pricing (Aggressive Tiers)
+
+| Label length | SOL   | USDC  |
+|-------------|-------|-------|
+| 1 char      | 2     | 200   |
+| 2 chars     | 1     | 100   |
+| 3 chars     | 0.5   | 50    |
+| 4 chars     | 0.15  | 15    |
+| 5+ chars    | 0.05  | 5     |
+
+The 5+ tier is the only one that's env-overridable (`POTBOT_SNS_PRICE_SOL`,
+`POTBOT_SNS_PRICE_USDC`). Premium tiers (1-4 chars) are hardcoded.
+
+## Environment Variables
+
+| Variable                | Required | Description                                       |
+|------------------------|----------|---------------------------------------------------|
+| `POTBOT_SNS_OWNER_SECRET` | Yes (claim) | Secret key of potbot.sol owner (base58 or JSON array) |
+| `POTBOT_SNS_TREASURY`    | No       | Payment recipient (defaults to owner pubkey)       |
+| `POTBOT_SNS_RPC_URL`     | Yes      | Mainnet RPC endpoint                              |
+| `POTBOT_SNS_PRICE_SOL`   | No       | Override standard tier SOL price (default: 0.05)  |
+| `POTBOT_SNS_PRICE_USDC`  | No       | Override standard tier USDC price (default: 5)    |
+| `POTBOT_SNS_USDC_MINT`   | No       | USDC mint address (default: mainnet USDC)         |
+
+## API Routes
+
+- `GET /api/sns/check?name=<label>` — availability + tiered price
+- `POST /api/sns/claim` — build partially-signed claim transaction
+- `GET /api/sns/owned?owner=<pubkey>` — list owned .potbot.sol names
+- `POST /api/sns/bind` — Phase 2 stub (501 until enabled)
+
+## Phase 2: Pot Binding (not yet implemented)
+
+Names currently resolve to the buyer's wallet. In Phase 2, names will be
+bindable to specific pots via SNS records:
+
+- Write a `SOL` record pointing to the vault PDA
+- Write a custom `pot` record with the pot pubkey
+- Owner-signed (NOT ownership transfer to PDA)
+
+The seam is already in the code:
+- `potPubkey` flows through the claim request
+- `/api/sns/bind` exists as a gated stub
+- `OwnedName.boundPot` field is defined
+
+Binding will ship once pots are live on mainnet.
+
+## Files
+
+```
+src/lib/sns.ts              — shared constants, types, validation (client+server)
+src/lib/sns-server.ts       — on-chain logic, tx building (server-only)
+src/app/api/sns/check/      — availability check endpoint
+src/app/api/sns/claim/      — claim transaction builder endpoint
+src/app/api/sns/owned/      — list owned names endpoint
+src/app/api/sns/bind/       — Phase 2 stub
+src/hooks/useClaimWallet.ts — wallet seam (adapter + Privy)
+src/components/sns/         — ClaimWidget, MyNames, PotSnsUpsell
+src/app/name/page.tsx       — /name landing page
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,7 @@
         "@solana-program/system": "^0.12.0",
         "@solana-program/token": "^0.13.0",
         "@solana/kit": "^6.9.0",
+        "@solana/spl-token": "^0.4.14",
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-adapter-react": "^0.15.35",
         "@solana/wallet-adapter-react-ui": "^0.9.35",
@@ -226,6 +227,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
+        "server-only": "^0.0.1",
         "tailwindcss": "^3.4.4",
         "zustand": "^4.5.4"
       },
@@ -3016,6 +3018,151 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "apps/web/node_modules/@solana/spl-token-group/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "apps/web/node_modules/@walletconnect/core": {
@@ -26894,6 +27041,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",


### PR DESCRIPTION
## Summary

- **`/name` page** with search input, debounced availability check, length-based tiered pricing (1ch=2 SOL / 2=1 / 3=0.5 / 4=0.15 / 5+=0.05), SOL/USDC toggle, and claim flow
- **API routes**: `/api/sns/check` (availability + price), `/api/sns/claim` (server-side tx build with parent-owner partial-sign), `/api/sns/owned` (list user's names), `/api/sns/bind` (Phase 2 stub)
- **`useClaimWallet` hook** supporting both wallet-adapter and Privy embedded wallet signing (adapted to match codebase's `useSignTransaction` pattern)
- **Pot detail upsell** (`PotSnsUpsell`) in the Community tab — creator variant suggests `<potname>.potbot.sol`, member variant links to `/name`
- **Nav link** added ("Get a name") in the navbar
- **Docs**: `docs/SNS_SUBDOMAINS.md` with architecture, pricing table, Phase 2 binding plan

### Architecture

- Buyer is fee payer → PotBot marginal cost ≈ $0, ~100% margin
- Parent owner key (`POTBOT_SNS_OWNER_SECRET`) partial-signs server-side; buyer counter-signs and submits
- Price enforcement is server-side (baked into the transaction)
- Mainnet-only (SNS only exists on mainnet); uses dedicated `POTBOT_SNS_RPC_URL`
- Phase 2 pot binding seam is threaded through (`potPubkey` param, `/api/sns/bind` stub) but not implemented

## Test plan

- [ ] Open `/name`, search a name → availability shows with correct tier pricing
- [ ] Try 3-char vs 8-char name → price changes (0.5 SOL vs 0.05 SOL)
- [ ] Reserved names (e.g. "admin", "potbot") show as reserved
- [ ] Invalid input (special chars, too long) shows validation error
- [ ] `/api/sns/check?name=test` returns availability JSON without owner key configured
- [ ] Claim flow: wallet signs → tx lands → name resolves to buyer wallet
- [ ] "Your names" section lists owned `.potbot.sol` names after claim
- [ ] Pot detail page shows creator upsell for pot owner, member upsell for members
- [ ] `/api/sns/bind` returns 501 with Phase 2 message
- [ ] `next build` passes green

https://claude.ai/code/session_014ocJ26h51FRgXyXq1NTjw5

---
_Generated by [Claude Code](https://claude.ai/code/session_014ocJ26h51FRgXyXq1NTjw5)_