### PR TITLE
feat(program): Phase A security hardening — sentinel, timelocks, caps + critical payout fixes

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "next/core-web-vitals",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "react/no-unescaped-entities": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": "off"
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,10 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.10",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^14.2.5",
     "typescript": "^5.5.3"
   }
 }

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -690,6 +690,11 @@
           "signer": true
         },
         {
+          "name": "recipient",
+          "writable": true,
+          "optional": true
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -717,7 +722,7 @@
           "name": "pot",
           "docs": [
             "Parent pot. Authority / agent_authority are validated dynamically",
-            "inside `authorize_mode` — we can't bind via `has_one` here because",
+            "inside `authorize_mode` \u2014 we can't bind via `has_one` here because",
             "the required signer varies by mode."
           ],
           "writable": true,
@@ -840,9 +845,9 @@
           "name": "authority",
           "docs": [
             "Signer interpretation:",
-            "AdminDirect      → must equal pot.authority",
-            "Proposal         → must equal pot.authority (Phase 2: or Member NFT)",
-            "StrategyTrigger  → must equal pot.agent_authority"
+            "AdminDirect      \u2192 must equal pot.authority",
+            "Proposal         \u2192 must equal pot.authority (Phase 2: or Member NFT)",
+            "StrategyTrigger  \u2192 must equal pot.agent_authority"
           ],
           "writable": true,
           "signer": true
@@ -1596,7 +1601,7 @@
     {
       "name": "pause_pot",
       "docs": [
-        "Emergency pause — blocks all execute_swap calls on this pot."
+        "Emergency pause \u2014 blocks all execute_swap calls on this pot."
       ],
       "discriminator": [
         240,
@@ -1625,7 +1630,7 @@
       "docs": [
         "Register (or re-register) a delegate wallet that may sign votes for this",
         "member. `rules_uri` is an off-chain URI describing the delegate's",
-        "voting policy — purely for transparency, not enforced on-chain."
+        "voting policy \u2014 purely for transparency, not enforced on-chain."
       ],
       "discriminator": [
         218,
@@ -2234,7 +2239,7 @@
         {
           "name": "voter_record",
           "docs": [
-            "VoterRecord PDA — `init` (NOT init_if_needed) means tx fails if already exists.",
+            "VoterRecord PDA \u2014 `init` (NOT init_if_needed) means tx fails if already exists.",
             "This is the on-chain double-vote prevention mechanism."
           ],
           "writable": true,
@@ -2369,8 +2374,8 @@
         {
           "name": "voter_record",
           "docs": [
-            "VoterRecord PDA — keyed by member.wallet (NOT delegate_signer.key).",
-            "`init` (not `init_if_needed`) → fails if the member or any prior",
+            "VoterRecord PDA \u2014 keyed by member.wallet (NOT delegate_signer.key).",
+            "`init` (not `init_if_needed`) \u2192 fails if the member or any prior",
             "delegate already voted on this proposal. Same double-vote prevention",
             "as the original `vote` instruction."
           ],
@@ -2497,6 +2502,358 @@
           "name": "shares",
           "type": "u64"
         }
+      ]
+    },
+    {
+      "name": "set_sentinel",
+      "discriminator": [
+        94,
+        200,
+        82,
+        129,
+        53,
+        149,
+        232,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_sentinel",
+          "type": {
+            "option": "pubkey"
+          }
+        }
+      ],
+      "docs": [
+        "Assign or clear the sentinel/guardian wallet. The sentinel can freeze the pot and cancel proposals but can NEVER move funds."
+      ]
+    },
+    {
+      "name": "freeze_pot",
+      "discriminator": [
+        214,
+        106,
+        66,
+        139,
+        63,
+        30,
+        222,
+        108
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Freeze the pot (sentinel or authority). Blocks deposits, proposal execution, swaps and strategy creation. Member withdrawals stay open."
+      ]
+    },
+    {
+      "name": "unfreeze_pot",
+      "discriminator": [
+        56,
+        13,
+        215,
+        37,
+        23,
+        228,
+        254,
+        118
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Unfreeze the pot \u2014 authority only."
+      ]
+    },
+    {
+      "name": "cancel_proposal",
+      "discriminator": [
+        106,
+        74,
+        128,
+        146,
+        19,
+        65,
+        39,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Cancel an Active or Passed proposal (sentinel, authority or proposer)."
+      ]
+    },
+    {
+      "name": "set_allowed_programs",
+      "discriminator": [
+        242,
+        240,
+        178,
+        3,
+        188,
+        33,
+        161,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetAllowedProgramsArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Set the program-id allowlist for external CPI targets."
+      ]
+    },
+    {
+      "name": "set_risk_timelock",
+      "discriminator": [
+        57,
+        91,
+        75,
+        195,
+        185,
+        80,
+        142,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetRiskTimelockArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Configure the risk-param timelock and per-asset exposure cap."
+      ]
+    },
+    {
+      "name": "apply_pending_params",
+      "discriminator": [
+        11,
+        15,
+        47,
+        58,
+        28,
+        220,
+        231,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "cranker",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Permissionless crank: apply a staged risky-param change once its timelock has elapsed."
+      ]
+    },
+    {
+      "name": "fund_fee_reserve",
+      "discriminator": [
+        218,
+        216,
+        202,
+        40,
+        206,
+        195,
+        149,
+        71
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "FundFeeReserveArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Fund the pot's keeper-gas reserve."
+      ]
+    },
+    {
+      "name": "redeem_tokens",
+      "discriminator": [
+        246,
+        98,
+        134,
+        41,
+        152,
+        33,
+        120,
+        69
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Burn SPL share-tokens and receive SOL from the vault at NAV."
+      ]
+    },
+    {
+      "name": "route_to_yield",
+      "discriminator": [
+        82,
+        31,
+        61,
+        118,
+        105,
+        209,
+        221,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RouteToYieldArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
     }
   ],
@@ -2762,6 +3119,84 @@
         85,
         49
       ]
+    },
+    {
+      "name": "SentinelUpdated",
+      "discriminator": [
+        47,
+        118,
+        194,
+        209,
+        176,
+        50,
+        176,
+        137
+      ]
+    },
+    {
+      "name": "PotFrozenEvent",
+      "discriminator": [
+        228,
+        183,
+        174,
+        100,
+        119,
+        9,
+        61,
+        57
+      ]
+    },
+    {
+      "name": "ProposalCancelled",
+      "discriminator": [
+        253,
+        59,
+        104,
+        46,
+        129,
+        78,
+        9,
+        14
+      ]
+    },
+    {
+      "name": "AllowedProgramsUpdated",
+      "discriminator": [
+        114,
+        253,
+        112,
+        200,
+        132,
+        74,
+        185,
+        113
+      ]
+    },
+    {
+      "name": "PendingParamsApplied",
+      "discriminator": [
+        197,
+        32,
+        230,
+        125,
+        18,
+        42,
+        85,
+        234
+      ]
+    },
+    {
+      "name": "YieldRouted",
+      "discriminator": [
+        10,
+        238,
+        211,
+        233,
+        196,
+        63,
+        203,
+        70
+      ]
     }
   ],
   "errors": [
@@ -2883,7 +3318,7 @@
     {
       "code": 6023,
       "name": "TimelockNotExpired",
-      "msg": "Timelock period has not elapsed — wait before executing this proposal"
+      "msg": "Timelock period has not elapsed \u2014 wait before executing this proposal"
     },
     {
       "code": 6024,
@@ -2963,7 +3398,7 @@
     {
       "code": 6039,
       "name": "ProposalMismatch",
-      "msg": "Proposal mismatch — proposal_id or pot does not match attached spec"
+      "msg": "Proposal mismatch \u2014 proposal_id or pot does not match attached spec"
     },
     {
       "code": 6040,
@@ -3079,6 +3514,96 @@
       "code": 6062,
       "name": "MathOverflow",
       "msg": "Arithmetic overflow during fixed-point math"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidBurnAmount",
+      "msg": "Burn amount must be > 0"
+    },
+    {
+      "code": 6064,
+      "name": "InsufficientReserve",
+      "msg": "Redemption would violate 20% reserve guard"
+    },
+    {
+      "code": 6065,
+      "name": "RedemptionPausedWhilePotPaused",
+      "msg": "Cannot redeem while pot is paused"
+    },
+    {
+      "code": 6066,
+      "name": "RedemptionInsufficientVault",
+      "msg": "Insufficient vault balance for redemption"
+    },
+    {
+      "code": 6067,
+      "name": "YieldTargetNoneNotRoutable",
+      "msg": "YieldTarget None is not routable"
+    },
+    {
+      "code": 6068,
+      "name": "WithdrawalReserveBreached",
+      "msg": "Redemption exceeds 80% vault liquidity reserve"
+    },
+    {
+      "code": 6069,
+      "name": "PotPaused",
+      "msg": "Pot is paused -- redemptions blocked"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidAmount",
+      "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 6071,
+      "name": "NotSentinelOrAuthority",
+      "msg": "Signer is neither the pot authority nor the sentinel"
+    },
+    {
+      "code": 6072,
+      "name": "PotFrozen",
+      "msg": "Pot is frozen \u2014 this action is blocked until unfreeze"
+    },
+    {
+      "code": 6073,
+      "name": "SentinelCannotUnfreeze",
+      "msg": "Only the pot authority can unfreeze the pot"
+    },
+    {
+      "code": 6074,
+      "name": "ProposalNotCancellable",
+      "msg": "Proposal is not in a cancellable state"
+    },
+    {
+      "code": 6075,
+      "name": "RecipientMismatch",
+      "msg": "Recipient account does not match the proposal beneficiary"
+    },
+    {
+      "code": 6076,
+      "name": "RecipientMissing",
+      "msg": "Recipient account is required for this proposal type"
+    },
+    {
+      "code": 6077,
+      "name": "PendingChangeNotReady",
+      "msg": "Pending parameter change has not reached effective_at yet"
+    },
+    {
+      "code": 6078,
+      "name": "NoPendingChange",
+      "msg": "No pending parameter change staged for this pot"
+    },
+    {
+      "code": 6079,
+      "name": "ProgramNotAllowed",
+      "msg": "Program is not in the pot's protocol allowlist"
+    },
+    {
+      "code": 6080,
+      "name": "AssetExposureExceeded",
+      "msg": "Daily exposure cap for this asset exceeded"
     }
   ],
   "types": [
@@ -3289,7 +3814,7 @@
           {
             "name": "min_out",
             "docs": [
-              "Minimum acceptable output — hard floor enforced on-chain."
+              "Minimum acceptable output \u2014 hard floor enforced on-chain."
             ],
             "type": "u64"
           },
@@ -3303,7 +3828,7 @@
           {
             "name": "is_entry",
             "docs": [
-              "Entry (Pending→Active) or exit (Active/Parked→Closed)."
+              "Entry (Pending\u2192Active) or exit (Active/Parked\u2192Closed)."
             ],
             "type": "bool"
           },
@@ -3479,7 +4004,7 @@
             "name": "rules_uri",
             "docs": [
               "IPFS / Arweave / https URI describing the agent's voting policy.",
-              "On-chain program does NOT enforce this — it's a transparency artefact",
+              "On-chain program does NOT enforce this \u2014 it's a transparency artefact",
               "that lets other members audit the AI's behaviour and revoke if needed."
             ],
             "type": "string"
@@ -3696,7 +4221,7 @@
             "name": "agent_authority",
             "docs": [
               "Keeper agent authority for StrategyTrigger mode.",
-              "This is the keeper's hot wallet pubkey — separate from agent_pubkey.",
+              "This is the keeper's hot wallet pubkey \u2014 separate from agent_pubkey.",
               "Set via set_allowed_mints."
             ],
             "type": "pubkey"
@@ -3764,6 +4289,68 @@
               "Keeper gas reserve (lamports). Keeper draws from this for trigger gas."
             ],
             "type": "u64"
+          },
+          {
+            "name": "sentinel",
+            "docs": [
+              "Optional sentinel/guardian wallet. Can freeze the pot and cancel proposals; has NO instruction that can move funds."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "risk_param_timelock_secs",
+            "docs": [
+              "Timelock (seconds) applied when a risky governance parameter is LOOSENED. 0 = disabled."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "pending_params",
+            "docs": [
+              "Staged loosening change awaiting its timelock."
+            ],
+            "type": {
+              "defined": {
+                "name": "PendingRiskParams"
+              }
+            }
+          },
+          {
+            "name": "allowed_programs",
+            "docs": [
+              "Program-id allowlist for external CPI targets. count == 0 = open mode."
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                8
+              ]
+            }
+          },
+          {
+            "name": "allowed_programs_count",
+            "type": "u8"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "docs": [
+              "Max cumulative daily spend toward one output mint, bps of vault. 0 = unlimited."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "per_mint_daily_spent",
+            "docs": [
+              "Daily spend per allowed_mints slot."
+            ],
+            "type": {
+              "array": [
+                "u64",
+                16
+              ]
+            }
           }
         ]
       }
@@ -3868,7 +4455,7 @@
           {
             "name": "passed_at",
             "docs": [
-              "Timestamp when proposal transitioned to Passed — used for timelock enforcement.",
+              "Timestamp when proposal transitioned to Passed \u2014 used for timelock enforcement.",
               "0 if not yet passed."
             ],
             "type": "i64"
@@ -3927,6 +4514,9 @@
           },
           {
             "name": "Expired"
+          },
+          {
+            "name": "Cancelled"
           }
         ]
       }
@@ -3959,14 +4549,14 @@
           {
             "name": "max_in",
             "docs": [
-              "Maximum input the executor may spend. Enforced on-chain: spent ≤ max_in."
+              "Maximum input the executor may spend. Enforced on-chain: spent \u2264 max_in."
             ],
             "type": "u64"
           },
           {
             "name": "min_out",
             "docs": [
-              "Minimum output the executor must receive. Enforced: received ≥ min_out."
+              "Minimum output the executor must receive. Enforced: received \u2265 min_out."
             ],
             "type": "u64"
           },
@@ -3980,7 +4570,7 @@
           {
             "name": "price_feed_id",
             "docs": [
-              "Optional Pyth feed id — if set, execute_swap verifies execution price",
+              "Optional Pyth feed id \u2014 if set, execute_swap verifies execution price",
               "is within oracle_deviation_bps of the oracle mid at execution time."
             ],
             "type": {
@@ -4996,7 +5586,7 @@
       "docs": [
         "Tracks that a specific wallet has already voted on a specific proposal.",
         "PDA: [b\"voter\", proposal_pubkey, voter_pubkey]",
-        "Using `init` (not `init_if_needed`) means the tx fails if this already exists —",
+        "Using `init` (not `init_if_needed`) means the tx fails if this already exists \u2014",
         "which is exactly the double-vote prevention mechanism."
       ],
       "type": {
@@ -5173,6 +5763,251 @@
                 "type": "pubkey"
               }
             ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingRiskParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_pending",
+            "type": "bool"
+          },
+          {
+            "name": "effective_at",
+            "type": "i64"
+          },
+          {
+            "name": "trade_level",
+            "type": "u8"
+          },
+          {
+            "name": "withdraw_level",
+            "type": "u8"
+          },
+          {
+            "name": "max_trade_size_bps",
+            "type": "u16"
+          },
+          {
+            "name": "single_swap_cap_bps",
+            "type": "u16"
+          },
+          {
+            "name": "daily_budget_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "risk_param_timelock_secs",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetAllowedProgramsArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "programs",
+            "type": {
+              "vec": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetRiskTimelockArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "risk_param_timelock_secs",
+            "type": "i64"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FundFeeReserveArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SentinelUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "sentinel",
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PotFrozenEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "by",
+            "type": "pubkey"
+          },
+          {
+            "name": "frozen",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCancelled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal_id",
+            "type": "u64"
+          },
+          {
+            "name": "by",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllowedProgramsUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "count",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingParamsApplied",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "applied_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RouteToYieldArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "yield_target",
+            "type": {
+              "defined": {
+                "name": "YieldRouteTarget"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldRouteTarget",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Kamino"
+          },
+          {
+            "name": "MeteoraStable"
+          },
+          {
+            "name": "MeteoraDynamic"
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldRouted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "target",
+            "type": {
+              "defined": {
+                "name": "YieldRouteTarget"
+              }
+            }
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "executed",
+            "type": "bool"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,10 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.57.1",
+        "eslint-config-next": "^14.2.5",
         "typescript": "^5.5.3"
       }
     },
@@ -3166,6 +3170,114 @@
         "node": ">=18"
       }
     },
+    "apps/web/node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "apps/web/node_modules/@vercel/analytics": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
@@ -3391,6 +3503,16 @@
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
+    "apps/web/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "apps/web/node_modules/es-toolkit": {
       "version": "1.39.3",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
@@ -3408,6 +3530,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "apps/web/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "apps/web/node_modules/on-exit-leak-free": {
@@ -5367,6 +5505,40 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
@@ -5836,6 +6008,123 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@ethereumjs/common": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-10.1.1.tgz",
@@ -6092,6 +6381,44 @@
         "hono": "^4"
       }
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
@@ -6117,6 +6444,109 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -7496,11 +7926,90 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.5",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
       "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==",
       "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.5.tgz",
+      "integrity": "sha512-LY3btOpPh+OTIpviNojDpUdIbHW9j0JBYBjsIp8IxtDFfYFyORvw3yNq6N231FVqQA7n7lwaf7xHbVJlA1ED7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "14.2.5",
@@ -7735,6 +8244,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
     "node_modules/@particle-network/analytics": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@particle-network/analytics/-/analytics-1.0.2.tgz",
@@ -7791,6 +8310,17 @@
       "license": "MIT",
       "dependencies": {
         "lit": "^3"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@potbot/api": {
@@ -10163,6 +10693,20 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@safe-global/safe-apps-provider": {
       "version": "0.18.6",
@@ -15074,6 +15618,17 @@
         "win32"
       ]
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -15202,8 +15757,7 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
@@ -15327,6 +15881,787 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
+      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -18747,6 +20082,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -18908,6 +20253,186 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -18963,6 +20488,23 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/async-mutex": {
@@ -19040,6 +20582,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
@@ -19073,6 +20625,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -19464,7 +21026,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -19828,6 +21389,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -20210,8 +21781,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -20599,6 +22169,67 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -20677,6 +22308,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -20859,11 +22497,37 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -20936,6 +22600,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -21091,6 +22762,75 @@
         "stackframe": "^1.3.4"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -21109,10 +22849,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -21134,6 +22902,37 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-toolkit": {
@@ -21230,6 +23029,606 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.5.tgz",
+      "integrity": "sha512-zogs9zlOiZ7ka+wgUnmcM0KBEDjo4Jis7kxN1jvC0N4wynQ2MIx/KBkg4mVF63J5EK4W0QMCn7xO3vNisjaAoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "14.2.5",
+        "@rushstack/eslint-patch": "^1.3.3",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.0.0-canary-7118f5dd7-20230705",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
+      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -21244,6 +23643,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -21252,6 +23687,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -21723,6 +24168,13 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-password-entropy": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fast-password-entropy/-/fast-password-entropy-1.1.1.tgz",
@@ -21820,6 +24272,19 @@
       "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -21891,6 +24356,28 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/flow-enums-runtime": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
@@ -21931,6 +24418,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -22025,6 +24542,37 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -22134,6 +24682,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -22153,7 +24719,6 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -22179,6 +24744,73 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/goober": {
@@ -22208,6 +24840,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/graphemesplit": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.6.0.tgz",
@@ -22235,6 +24874,19 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -22251,6 +24903,22 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -22482,6 +25150,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/image-size": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
@@ -22498,12 +25176,38 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -22530,6 +25234,21 @@
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
       "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
       "license": "MIT"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -22583,11 +25302,65 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -22601,11 +25374,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -22620,12 +25420,47 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -22657,6 +25492,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -22699,6 +25550,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -22715,6 +25579,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -22722,6 +25599,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -22770,6 +25674,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-standalone-pwa": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
@@ -22803,6 +25736,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -22829,6 +25797,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -22915,6 +25929,43 @@
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jayson": {
@@ -23330,6 +26381,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-rpc-engine": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
@@ -23386,6 +26444,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -23419,6 +26484,22 @@
       "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
       "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -23485,11 +26566,41 @@
         "node": ">= 6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/keyvaluestorage-interface": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
       "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
       "license": "MIT"
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -23499,6 +26610,20 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/libphonenumber-js": {
@@ -24441,7 +27566,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -24456,6 +27580,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mipd": {
@@ -24805,6 +27939,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -24919,6 +28076,35 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/node-fetch": {
@@ -25166,6 +28352,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/oblivious-set": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.4.0.tgz",
@@ -25260,6 +28515,42 @@
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
       "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ox": {
       "version": "0.14.17",
@@ -25380,6 +28671,19 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-asn1": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
@@ -25419,7 +28723,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25439,6 +28742,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -25447,6 +28774,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -26014,6 +29351,16 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -26533,12 +29880,56 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -26621,7 +30012,6 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -26916,6 +30306,26 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -26935,6 +30345,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -27120,6 +30547,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -27280,7 +30738,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -27439,6 +30896,13 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -27504,6 +30968,20 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -27590,10 +31068,154 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -27608,7 +31230,6 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -27847,6 +31468,13 @@
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -28045,6 +31673,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -28131,7 +31772,6 @@
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -28145,7 +31785,6 @@
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -28197,6 +31836,19 @@
         "@turbo/windows-arm64": "2.9.6"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -28242,6 +31894,69 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typeforce": {
@@ -28338,6 +32053,25 @@
         "multiformats": "^9.4.2"
       }
     },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/uncrypto": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
@@ -28391,6 +32125,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/unstorage": {
@@ -28545,6 +32317,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urijs": {
@@ -29489,6 +33271,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -29567,6 +33416,16 @@
         "bs58": "^6.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -29586,6 +33445,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/packages/program/Anchor.toml
+++ b/packages/program/Anchor.toml
@@ -26,7 +26,7 @@ cluster = "Devnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 
 [workspace]
 members = [

--- a/packages/program/Cargo.lock
+++ b/packages/program/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
 ]
 
@@ -471,17 +471,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -501,15 +500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -540,12 +530,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
- "borsh-derive 1.6.1",
- "bytes",
+ "borsh-derive 1.5.7",
  "cfg_aliases",
 ]
 
@@ -577,12 +566,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -690,12 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cargo_toml"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,12 +731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,24 +752,15 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -839,15 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,15 +823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -957,19 +907,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
- "ctutils",
 ]
 
 [[package]]
@@ -1118,18 +1057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,12 +1084,6 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1219,15 +1140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,12 +1163,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1276,11 +1188,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "getrandom 0.3.4",
  "libc",
 ]
 
@@ -1302,7 +1213,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1507,7 +1418,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1591,7 +1502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1626,18 +1537,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1670,12 +1581,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1940,7 +1845,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -1952,7 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2082,7 +1987,7 @@ dependencies = [
  "blake3",
  "borsh 0.10.4",
  "borsh 0.9.3",
- "borsh 1.6.1",
+ "borsh 1.5.7",
  "bs58 0.4.0",
  "bv",
  "bytemuck",
@@ -2131,7 +2036,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "bitflags",
- "borsh 1.6.1",
+ "borsh 1.5.7",
  "bs58 0.4.0",
  "bytemuck",
  "byteorder",
@@ -2234,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143109d789171379e6143ef23191786dfaac54289ad6e7917cfb26b36c432b10"
 dependencies = [
  "assert_matches",
- "borsh 1.6.1",
+ "borsh 1.5.7",
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
@@ -2293,7 +2198,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c52d84c55efeef8edcc226743dc089d7e3888b8e3474569aa3eff152b37b9996"
 dependencies = [
- "borsh 1.6.1",
+ "borsh 1.5.7",
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
@@ -2397,7 +2302,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3da00495b602ebcf5d8ba8b3ecff1ee454ce4c125c9077747be49c2d62335ba"
 dependencies = [
- "borsh 1.6.1",
+ "borsh 1.5.7",
  "solana-program",
  "spl-discriminator",
  "spl-pod",
@@ -2548,7 +2453,7 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "toml_edit 0.22.27",
 ]
 
@@ -2562,12 +2467,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+name = "toml_edit"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "serde_core",
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2579,30 +2486,9 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "toml_write",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2634,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "universal-hash"
@@ -2675,15 +2561,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2788,27 +2665,21 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -163,6 +163,28 @@ pub enum ErrorCode {
     PotPaused,
     #[msg("Amount must be greater than zero")]
     InvalidAmount,
+
+    // ─── Security hardening (Phase A) ─────────────────────────────────────
+    #[msg("Signer is neither the pot authority nor the sentinel")]
+    NotSentinelOrAuthority,
+    #[msg("Pot is frozen — this action is blocked until unfreeze")]
+    PotFrozen,
+    #[msg("Only the pot authority can unfreeze the pot")]
+    SentinelCannotUnfreeze,
+    #[msg("Proposal is not in a cancellable state")]
+    ProposalNotCancellable,
+    #[msg("Recipient account does not match the proposal beneficiary")]
+    RecipientMismatch,
+    #[msg("Recipient account is required for this proposal type")]
+    RecipientMissing,
+    #[msg("Pending parameter change has not reached effective_at yet")]
+    PendingChangeNotReady,
+    #[msg("No pending parameter change staged for this pot")]
+    NoPendingChange,
+    #[msg("Program is not in the pot's protocol allowlist")]
+    ProgramNotAllowed,
+    #[msg("Daily exposure cap for this asset exceeded")]
+    AssetExposureExceeded,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/instructions/close_strategy.rs
+++ b/packages/program/programs/pot_vault/src/instructions/close_strategy.rs
@@ -18,7 +18,7 @@ pub struct CloseStrategy<'info> {
         mut,
         constraint = pot.key() == strategy.pot @ PotError::StrategyPotMismatch,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -104,6 +104,15 @@ pub fn handler(ctx: Context<CreatePot>, params: CreatePotParams) -> Result<()> {
     pot.token_mint = Pubkey::default();
     pot.shares_per_sol = 100;
 
+    // Security hardening (Phase A) — safe defaults, all opt-in.
+    pot.sentinel                 = None;
+    pot.risk_param_timelock_secs = 0;
+    pot.pending_params           = PendingRiskParams::default();
+    pot.allowed_programs         = [Pubkey::default(); 8];
+    pot.allowed_programs_count   = 0;
+    pot.max_asset_exposure_bps   = 0;
+    pot.per_mint_daily_spent     = [0u64; 16];
+
     pot.config = PotConfig {
         is_public: params.is_public,
         min_deposit: params.min_deposit,

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -39,7 +39,7 @@ pub struct CreatePot<'info> {
         seeds = [b"pot", authority.key().as_ref(), params.name.as_bytes()],
         bump
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// CHECK: PDA vault that holds SOL
     #[account(

--- a/packages/program/programs/pot_vault/src/instructions/create_private_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_private_pot.rs
@@ -22,7 +22,7 @@ pub struct CreatePrivatePot<'info> {
         seeds = [b"pot", name.as_bytes(), authority.key().as_ref()],
         bump
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,

--- a/packages/program/programs/pot_vault/src/instructions/create_proposal.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_proposal.rs
@@ -12,7 +12,7 @@ pub struct CreateProposalParams {
 #[instruction(params: CreateProposalParams)]
 pub struct CreateProposal<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,

--- a/packages/program/programs/pot_vault/src/instructions/create_sns_domain.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_sns_domain.rs
@@ -8,7 +8,7 @@ use crate::errors::ErrorCode;
 #[instruction(domain_name: String)]
 pub struct CreateSnsDomain<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,

--- a/packages/program/programs/pot_vault/src/instructions/create_strategy.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_strategy.rs
@@ -68,6 +68,10 @@ pub struct CreateStrategy<'info> {
 }
 
 pub fn handler(ctx: Context<CreateStrategy>, args: CreateStrategyArgs) -> Result<()> {
+    require!(
+        !ctx.accounts.pot.paused,
+        crate::errors::PotError::PotFrozen
+    );
     validate_bps(&args)?;
     validate_triggers_need_feed(&args)?;
 

--- a/packages/program/programs/pot_vault/src/instructions/create_strategy.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_strategy.rs
@@ -44,7 +44,7 @@ pub struct CreateStrategyArgs {
 pub struct CreateStrategy<'info> {
     /// Parent pot. Must match `args.source` (e.g. pot.authority for AdminDirect).
     #[account(mut)]
-    pub pot: Account<'info, crate::state::pot::PotAccount>,
+    pub pot: Box<Account<'info, crate::state::pot::PotAccount>>,
 
     #[account(
         init,

--- a/packages/program/programs/pot_vault/src/instructions/delegate.rs
+++ b/packages/program/programs/pot_vault/src/instructions/delegate.rs
@@ -11,7 +11,7 @@ use crate::errors::PotError;
 
 #[derive(Accounts)]
 pub struct RegisterDelegate<'info> {
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// The caller must be a member of this pot with non-zero shares.
     #[account(
@@ -72,7 +72,7 @@ pub fn register_handler(
 
 #[derive(Accounts)]
 pub struct RevokeDelegate<'info> {
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/deposit.rs
+++ b/packages/program/programs/pot_vault/src/instructions/deposit.rs
@@ -34,6 +34,9 @@ pub struct Deposit<'info> {
 pub fn handler(ctx: Context<Deposit>, lamports: u64) -> Result<()> {
     let pot = &ctx.accounts.pot;
 
+    // Frozen pot accepts no new capital (members can still withdraw).
+    require!(!pot.paused, PotError::PotFrozen);
+
     // Validate minimum deposit
     require!(lamports >= pot.config.min_deposit, PotError::DepositTooSmall);
 

--- a/packages/program/programs/pot_vault/src/instructions/deposit.rs
+++ b/packages/program/programs/pot_vault/src/instructions/deposit.rs
@@ -6,7 +6,7 @@ use crate::errors::PotError;
 #[derive(Accounts)]
 pub struct Deposit<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// CHECK: PDA vault that holds SOL
     #[account(

--- a/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
@@ -4,7 +4,10 @@ use crate::errors::PotError;
 
 #[derive(Accounts)]
 pub struct ExecuteProposal<'info> {
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = !pot.paused @ PotError::PotFrozen,
+    )]
     pub pot: Account<'info, PotAccount>,
 
     /// CHECK: PDA vault
@@ -23,6 +26,13 @@ pub struct ExecuteProposal<'info> {
 
     #[account(mut)]
     pub executor: Signer<'info>,
+
+    /// Destination for fund-moving proposals (Withdraw / TransferFunds).
+    /// MUST equal the beneficiary recorded in the proposal — the executor
+    /// only cranks the instruction, funds never flow to the executor.
+    /// CHECK: validated in the handler against the proposal payload.
+    #[account(mut)]
+    pub recipient: Option<UncheckedAccount<'info>>,
 
     pub system_program: Program<'info, System>,
 }
@@ -73,6 +83,12 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
         }
 
         ProposalType::Withdraw { beneficiary, amount } => {
+            let recipient = ctx
+                .accounts
+                .recipient
+                .as_ref()
+                .ok_or(PotError::RecipientMissing)?;
+            require_keys_eq!(recipient.key(), *beneficiary, PotError::RecipientMismatch);
             let vault_lamports = ctx.accounts.vault.lamports();
             let rent = Rent::get()?;
             let min_balance = rent.minimum_balance(0);
@@ -81,11 +97,17 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 PotError::InsufficientVaultBalance
             );
             **ctx.accounts.vault.to_account_info().try_borrow_mut_lamports()? -= amount;
-            **ctx.accounts.executor.to_account_info().try_borrow_mut_lamports()? += amount;
+            **recipient.to_account_info().try_borrow_mut_lamports()? += amount;
             msg!("Governance withdrawal: {} lamports to {}", amount, beneficiary);
         }
 
         ProposalType::TransferFunds { to, amount, purpose } => {
+            let recipient = ctx
+                .accounts
+                .recipient
+                .as_ref()
+                .ok_or(PotError::RecipientMissing)?;
+            require_keys_eq!(recipient.key(), *to, PotError::RecipientMismatch);
             let vault_lamports = ctx.accounts.vault.lamports();
             let rent = Rent::get()?;
             let min_balance = rent.minimum_balance(0);
@@ -94,14 +116,29 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 PotError::InsufficientVaultBalance
             );
             **ctx.accounts.vault.to_account_info().try_borrow_mut_lamports()? -= amount;
-            **ctx.accounts.executor.to_account_info().try_borrow_mut_lamports()? += amount;
+            **recipient.to_account_info().try_borrow_mut_lamports()? += amount;
             msg!("Transfer {} lamports to {} - purpose: {}", amount, to, purpose);
         }
 
         ProposalType::ChangeSettings { new_trade_level, new_withdraw_level } => {
-            pot.governance.trade_level    = *new_trade_level;
-            pot.governance.withdraw_level = *new_withdraw_level;
-            msg!("Governance updated: trade={}, withdraw={}", new_trade_level, new_withdraw_level);
+            // Risky-param change: tightening applies now, loosening waits
+            // out risk_param_timelock_secs via pending_params.
+            let target = PendingRiskParams {
+                is_pending: false,
+                effective_at: 0,
+                trade_level: *new_trade_level,
+                withdraw_level: *new_withdraw_level,
+                max_trade_size_bps: pot.config.max_trade_size_bps,
+                single_swap_cap_bps: pot.single_swap_cap_bps,
+                daily_budget_lamports: pot.daily_budget_lamports,
+                risk_param_timelock_secs: pot.risk_param_timelock_secs,
+            };
+            let staged = pot.stage_or_apply_risk_params(target, clock.unix_timestamp)?;
+            msg!(
+                "Governance change trade={}, withdraw={} — {}",
+                new_trade_level, new_withdraw_level,
+                if staged { "staged (risk-param timelock)" } else { "applied" }
+            );
         }
 
         ProposalType::ChangeYield { new_strategy } => {
@@ -116,9 +153,24 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
         }
 
         ProposalType::UpdateRiskConfig { max_trade_size_bps, max_members } => {
-            pot.config.max_trade_size_bps = *max_trade_size_bps;
-            pot.config.max_members        = *max_members;
-            msg!("Risk config updated: max_trade_bps={}, max_members={}", max_trade_size_bps, max_members);
+            // max_members is not a fund-risk parameter — applies immediately.
+            pot.config.max_members = *max_members;
+            let target = PendingRiskParams {
+                is_pending: false,
+                effective_at: 0,
+                trade_level: pot.governance.trade_level,
+                withdraw_level: pot.governance.withdraw_level,
+                max_trade_size_bps: *max_trade_size_bps,
+                single_swap_cap_bps: pot.single_swap_cap_bps,
+                daily_budget_lamports: pot.daily_budget_lamports,
+                risk_param_timelock_secs: pot.risk_param_timelock_secs,
+            };
+            let staged = pot.stage_or_apply_risk_params(target, clock.unix_timestamp)?;
+            msg!(
+                "Risk config max_trade_bps={}, max_members={} — {}",
+                max_trade_size_bps, max_members,
+                if staged { "staged (risk-param timelock)" } else { "applied" }
+            );
         }
 
         ProposalType::AddMember { wallet }   => { msg!("Member invited: {}", wallet); }

--- a/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
@@ -1,6 +1,33 @@
 use anchor_lang::prelude::*;
+use anchor_lang::system_program;
 use crate::state::*;
 use crate::errors::PotError;
+
+/// Move `amount` lamports out of the vault PDA via a seeds-signed system
+/// transfer. Direct lamport debits are rejected by the runtime because the
+/// vault is owned by the System program, not by this program.
+fn vault_transfer<'info>(
+    vault: &SystemAccount<'info>,
+    recipient: &UncheckedAccount<'info>,
+    system_program: &Program<'info, System>,
+    pot_key: &Pubkey,
+    vault_bump: u8,
+    amount: u64,
+) -> Result<()> {
+    let bump = [vault_bump];
+    let signer_seeds: &[&[u8]] = &[b"vault", pot_key.as_ref(), &bump];
+    system_program::transfer(
+        CpiContext::new_with_signer(
+            system_program.to_account_info(),
+            system_program::Transfer {
+                from: vault.to_account_info(),
+                to: recipient.to_account_info(),
+            },
+            &[signer_seeds],
+        ),
+        amount,
+    )
+}
 
 #[derive(Accounts)]
 pub struct ExecuteProposal<'info> {
@@ -8,7 +35,7 @@ pub struct ExecuteProposal<'info> {
         mut,
         constraint = !pot.paused @ PotError::PotFrozen,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// CHECK: PDA vault
     #[account(
@@ -96,8 +123,14 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 vault_lamports.saturating_sub(*amount) >= min_balance,
                 PotError::InsufficientVaultBalance
             );
-            **ctx.accounts.vault.to_account_info().try_borrow_mut_lamports()? -= amount;
-            **recipient.to_account_info().try_borrow_mut_lamports()? += amount;
+            vault_transfer(
+                &ctx.accounts.vault,
+                recipient,
+                &ctx.accounts.system_program,
+                &pot.key(),
+                pot.vault_bump,
+                *amount,
+            )?;
             msg!("Governance withdrawal: {} lamports to {}", amount, beneficiary);
         }
 
@@ -115,8 +148,14 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 vault_lamports.saturating_sub(*amount) >= min_balance,
                 PotError::InsufficientVaultBalance
             );
-            **ctx.accounts.vault.to_account_info().try_borrow_mut_lamports()? -= amount;
-            **recipient.to_account_info().try_borrow_mut_lamports()? += amount;
+            vault_transfer(
+                &ctx.accounts.vault,
+                recipient,
+                &ctx.accounts.system_program,
+                &pot.key(),
+                pot.vault_bump,
+                *amount,
+            )?;
             msg!("Transfer {} lamports to {} - purpose: {}", amount, to, purpose);
         }
 

--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -338,6 +338,7 @@ pub fn handler<'info>(
     // --- 8. update strategy state machine ---------------------------------
     let now = Clock::get()?.unix_timestamp;
     let strategy = &mut ctx.accounts.strategy;
+    let strategy_output_mint = strategy.output_mint;
     let trigger_reason = match &args.mode {
         SwapMode::StrategyTrigger { reason } => *reason,
         _ => TriggerReason::Manual,
@@ -374,6 +375,9 @@ pub fn handler<'info>(
 
     // --- 9. register spend against the pot daily budget -------------------
     ctx.accounts.pot.register_spend(spent, now)?;
+    if args.is_entry {
+        ctx.accounts.pot.register_asset_spend(&strategy_output_mint, spent)?;
+    }
 
     emit!(SwapExecuted {
         pot: pot_key,
@@ -504,6 +508,12 @@ fn enforce_spending_policy<'info>(
     let pot = &ctx.accounts.pot;
     let strategy = &ctx.accounts.strategy;
 
+    // Per-protocol allowlist: the CPI target must be sanctioned by the pot.
+    require!(
+        pot.is_program_allowed(&ctx.accounts.jupiter_program.key()),
+        crate::errors::PotError::ProgramNotAllowed
+    );
+
     require!(
         pot.is_mint_allowed(&strategy.input_mint),
         crate::errors::PotError::MintNotAllowlisted
@@ -516,8 +526,15 @@ fn enforce_spending_policy<'info>(
     // Use real vault SOL balance for the per-swap size cap. This replaces the
     // legacy fee_reserve proxy and gives a faithful "% of vault" semantics.
     let vault_lamports = ctx.accounts.vault.lamports();
+    let now = Clock::get()?.unix_timestamp;
     pot.check_single_swap_cap_against_vault(args.max_in, vault_lamports)?;
-    pot.check_daily_budget(args.max_in, Clock::get()?.unix_timestamp)?;
+    pot.check_daily_budget(args.max_in, now)?;
+
+    // Per-asset daily exposure cap — entries only (buying builds exposure;
+    // exits reduce it and are never blocked by this cap).
+    if args.is_entry {
+        pot.check_asset_exposure(&strategy.output_mint, args.max_in, vault_lamports, now)?;
+    }
 
     Ok(())
 }

--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -88,7 +88,7 @@ pub struct ExecuteSwap<'info> {
         mut,
         constraint = !pot.paused @ crate::errors::PotError::StrategyInactive,
     )]
-    pub pot: Account<'info, crate::state::pot::PotAccount>,
+    pub pot: Box<Account<'info, crate::state::pot::PotAccount>>,
 
     #[account(
         mut,
@@ -96,7 +96,7 @@ pub struct ExecuteSwap<'info> {
         bump = strategy.bump,
         has_one = pot,
     )]
-    pub strategy: Account<'info, StrategyAccount>,
+    pub strategy: Box<Account<'info, StrategyAccount>>,
 
     /// CHECK: vault PDA. Signs Jupiter CPI via invoke_signed with canonical bump.
     /// Asset ownership is validated via source_ata / destination_ata.owner below.
@@ -113,7 +113,7 @@ pub struct ExecuteSwap<'info> {
         constraint = (args.is_entry && source_ata.mint == strategy.input_mint) || (!args.is_entry && source_ata.mint == strategy.output_mint)
             @ crate::errors::PotError::MintNotAllowlisted,
     )]
-    pub source_ata: Account<'info, TokenAccount>,
+    pub source_ata: Box<Account<'info, TokenAccount>>,
 
     #[account(
         mut,
@@ -122,7 +122,7 @@ pub struct ExecuteSwap<'info> {
         constraint = (args.is_entry && destination_ata.mint == strategy.output_mint) || (!args.is_entry && destination_ata.mint == strategy.input_mint)
             @ crate::errors::PotError::MintNotAllowlisted,
     )]
-    pub destination_ata: Account<'info, TokenAccount>,
+    pub destination_ata: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: Jupiter v6. Pinned by pubkey.
     #[account(
@@ -146,7 +146,7 @@ pub struct ExecuteSwap<'info> {
         bump = proposal_swap_spec.bump,
         has_one = pot @ crate::errors::PotError::ProposalMismatch,
     )]
-    pub proposal_swap_spec: Option<Account<'info, ProposalSwapSpec>>,
+    pub proposal_swap_spec: Option<Box<Account<'info, ProposalSwapSpec>>>,
 
     /// Signer interpretation:
     ///   AdminDirect      → must equal pot.authority

--- a/packages/program/programs/pot_vault/src/instructions/init_token_mint.rs
+++ b/packages/program/programs/pot_vault/src/instructions/init_token_mint.rs
@@ -13,7 +13,7 @@ pub struct InitTokenMint<'info> {
         bump = pot.pot_bump,
         has_one = authority,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,

--- a/packages/program/programs/pot_vault/src/instructions/join_private_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/join_private_pot.rs
@@ -12,7 +12,7 @@ pub struct JoinPrivatePot<'info> {
         mut,
         constraint = !pot.config.is_public @ ErrorCode::NotPrivatePot
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/mark_proposal_passed.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mark_proposal_passed.rs
@@ -22,7 +22,7 @@ pub struct MarkProposalPassed<'info> {
         mut,
         constraint = pot.key() == strategy.pot @ PotError::StrategyPotMismatch,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/mint_tamagotchi_nft.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mint_tamagotchi_nft.rs
@@ -14,7 +14,7 @@ use crate::errors::ErrorCode;
 #[derive(Accounts)]
 pub struct MintTamagotchiNft<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,
@@ -23,7 +23,7 @@ pub struct MintTamagotchiNft<'info> {
         seeds = [b"tamagotchi_nft", pot.key().as_ref()],
         bump
     )]
-    pub tamagotchi_nft_account: Account<'info, TamagotchiNftAccount>,
+    pub tamagotchi_nft_account: Box<Account<'info, TamagotchiNftAccount>>,
 
     #[account(
         init,
@@ -34,7 +34,7 @@ pub struct MintTamagotchiNft<'info> {
         seeds = [b"tamagotchi_mint", pot.key().as_ref()],
         bump
     )]
-    pub tamagotchi_mint: Account<'info, Mint>,
+    pub tamagotchi_mint: Box<Account<'info, Mint>>,
 
     #[account(
         init,
@@ -42,7 +42,7 @@ pub struct MintTamagotchiNft<'info> {
         associated_token::mint = tamagotchi_mint,
         associated_token::authority = authority
     )]
-    pub tamagotchi_token_account: Account<'info, TokenAccount>,
+    pub tamagotchi_token_account: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: Metadata account, checked by Metaplex
     #[account(

--- a/packages/program/programs/pot_vault/src/instructions/mod.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mod.rs
@@ -30,6 +30,9 @@ pub mod close_strategy;
 pub mod mark_proposal_passed;
 pub mod pot_admin;
 
+// Security hardening (Phase A)
+pub mod sentinel;
+
 pub use create_pot::{CreatePot, CreatePotParams};
 pub(crate) use create_pot::__client_accounts_create_pot;
 pub use deposit::Deposit;
@@ -82,11 +85,24 @@ pub(crate) use close_strategy::__client_accounts_close_strategy;
 pub use mark_proposal_passed::{MarkProposalPassed, ProposalMarkedPassed};
 pub(crate) use mark_proposal_passed::__client_accounts_mark_proposal_passed;
 pub use pot_admin::{
-    fund_fee_reserve, pause_pot, set_allowed_mints, set_spending_policy, unpause_pot,
-    AllowedMintsUpdated, FeeReserveFunded, FundFeeReserve, FundFeeReserveArgs, PausePot,
-    SetAllowedMints, SetAllowedMintsArgs, SetSpendingPolicy, SetSpendingPolicyArgs,
+    apply_pending_params, fund_fee_reserve, pause_pot, set_allowed_mints,
+    set_allowed_programs, set_risk_timelock, set_spending_policy, unpause_pot,
+    AllowedMintsUpdated, AllowedProgramsUpdated, ApplyPendingParams, FeeReserveFunded,
+    FundFeeReserve, FundFeeReserveArgs, PausePot, PendingParamsApplied, SetAllowedMints,
+    SetAllowedMintsArgs, SetAllowedPrograms, SetAllowedProgramsArgs, SetRiskTimelock,
+    SetRiskTimelockArgs, SetSpendingPolicy, SetSpendingPolicyArgs,
 };
 pub(crate) use pot_admin::{
-    __client_accounts_fund_fee_reserve, __client_accounts_pause_pot,
-    __client_accounts_set_allowed_mints, __client_accounts_set_spending_policy,
+    __client_accounts_apply_pending_params, __client_accounts_fund_fee_reserve,
+    __client_accounts_pause_pot, __client_accounts_set_allowed_mints,
+    __client_accounts_set_allowed_programs, __client_accounts_set_risk_timelock,
+    __client_accounts_set_spending_policy,
+};
+pub use sentinel::{
+    cancel_proposal, freeze_pot, set_sentinel, unfreeze_pot, CancelProposal, FreezePot,
+    PotFrozenEvent, ProposalCancelled, SentinelUpdated, SetSentinel, UnfreezePot,
+};
+pub(crate) use sentinel::{
+    __client_accounts_cancel_proposal, __client_accounts_freeze_pot,
+    __client_accounts_set_sentinel, __client_accounts_unfreeze_pot,
 };

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -6,7 +6,7 @@
 // fund_fee_reserve           — deposit SOL into pot.fee_reserve for keeper gas
 
 use anchor_lang::prelude::*;
-use crate::state::pot::PotAccount;
+use crate::state::pot::{PendingRiskParams, PotAccount};
 use crate::errors::PotError;
 
 // ─── Pause / Unpause ────────────────────────────────────────────────────────
@@ -98,8 +98,144 @@ pub fn set_spending_policy(
         args: SetSpendingPolicyArgs,
     ) -> Result<()> {
         let pot = &mut ctx.accounts.pot;
-        pot.single_swap_cap_bps = args.single_swap_cap_bps;
-        pot.daily_budget_lamports = args.daily_budget_lamports;
+        let now = Clock::get()?.unix_timestamp;
+        // Risky-param change: tightening applies now, loosening waits out
+        // risk_param_timelock_secs via pending_params.
+        let target = PendingRiskParams {
+                is_pending: false,
+                effective_at: 0,
+                trade_level: pot.governance.trade_level,
+                withdraw_level: pot.governance.withdraw_level,
+                max_trade_size_bps: pot.config.max_trade_size_bps,
+                single_swap_cap_bps: args.single_swap_cap_bps,
+                daily_budget_lamports: args.daily_budget_lamports,
+                risk_param_timelock_secs: pot.risk_param_timelock_secs,
+        };
+        let staged = pot.stage_or_apply_risk_params(target, now)?;
+        msg!(
+                "spending policy cap={}bps daily={} — {}",
+                args.single_swap_cap_bps,
+                args.daily_budget_lamports,
+                if staged { "staged (risk-param timelock)" } else { "applied" }
+        );
+        Ok(())
+}
+
+// ─── Set allowed programs (protocol allowlist) ──────────────────────────────
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct SetAllowedProgramsArgs {
+        /// Up to 8 program ids. Pass empty slice to clear (open mode).
+    pub programs: Vec<Pubkey>,
+}
+
+#[derive(Accounts)]
+pub struct SetAllowedPrograms<'info> {
+        #[account(
+                    mut,
+                    constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
+                )]
+        pub pot: Account<'info, PotAccount>,
+        pub authority: Signer<'info>,
+}
+
+pub fn set_allowed_programs(
+        ctx: Context<SetAllowedPrograms>,
+        args: SetAllowedProgramsArgs,
+    ) -> Result<()> {
+        require!(args.programs.len() <= 8, PotError::InvalidStrategyConfig);
+        let pot = &mut ctx.accounts.pot;
+        pot.allowed_programs = [Pubkey::default(); 8];
+        for (i, program) in args.programs.iter().enumerate() {
+                    pot.allowed_programs[i] = *program;
+        }
+        pot.allowed_programs_count = args.programs.len() as u8;
+        emit!(AllowedProgramsUpdated {
+                    pot: pot.key(),
+                    count: pot.allowed_programs_count,
+        });
+        Ok(())
+}
+
+// ─── Risk-param timelock config + asset exposure cap ────────────────────────
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct SetRiskTimelockArgs {
+        /// Seconds a loosening param change must wait. 0 = disabled.
+        /// Raising the timelock applies instantly; lowering it is itself a
+        /// loosening change and waits out the CURRENT timelock.
+    pub risk_param_timelock_secs: i64,
+        /// Max daily spend toward one asset, bps of vault. 0 = unlimited.
+        /// Tightening (lower, or from 0 to bounded) applies instantly;
+        /// loosening waits out the timelock together with the rest.
+        pub max_asset_exposure_bps: u16,
+}
+
+#[derive(Accounts)]
+pub struct SetRiskTimelock<'info> {
+        #[account(
+                    mut,
+                    constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
+                )]
+        pub pot: Account<'info, PotAccount>,
+        pub authority: Signer<'info>,
+}
+
+pub fn set_risk_timelock(
+        ctx: Context<SetRiskTimelock>,
+        args: SetRiskTimelockArgs,
+    ) -> Result<()> {
+        let pot = &mut ctx.accounts.pot;
+        let now = Clock::get()?.unix_timestamp;
+
+        // Exposure cap: apply tightening instantly; loosening only when no
+        // timelock is configured (otherwise keep the tighter current value —
+        // loosening exposure caps goes through governance, not admin).
+        let old_exposure = pot.max_asset_exposure_bps;
+        let tightening = args.max_asset_exposure_bps != 0
+                && (old_exposure == 0 || args.max_asset_exposure_bps < old_exposure);
+        if tightening || pot.risk_param_timelock_secs <= 0 {
+                    pot.max_asset_exposure_bps = args.max_asset_exposure_bps;
+        }
+
+        let target = PendingRiskParams {
+                is_pending: false,
+                effective_at: 0,
+                trade_level: pot.governance.trade_level,
+                withdraw_level: pot.governance.withdraw_level,
+                max_trade_size_bps: pot.config.max_trade_size_bps,
+                single_swap_cap_bps: pot.single_swap_cap_bps,
+                daily_budget_lamports: pot.daily_budget_lamports,
+                risk_param_timelock_secs: args.risk_param_timelock_secs,
+        };
+        let staged = pot.stage_or_apply_risk_params(target, now)?;
+        msg!(
+                "risk timelock={}s exposure_cap={}bps — {}",
+                args.risk_param_timelock_secs,
+                args.max_asset_exposure_bps,
+                if staged { "staged (risk-param timelock)" } else { "applied" }
+        );
+        Ok(())
+}
+
+// ─── Apply pending params (permissionless crank) ────────────────────────────
+
+#[derive(Accounts)]
+pub struct ApplyPendingParams<'info> {
+        #[account(mut)]
+        pub pot: Account<'info, PotAccount>,
+        pub cranker: Signer<'info>,
+}
+
+pub fn apply_pending_params(ctx: Context<ApplyPendingParams>) -> Result<()> {
+        let pot = &mut ctx.accounts.pot;
+        let now = Clock::get()?.unix_timestamp;
+        pot.apply_pending(now)?;
+        emit!(PendingParamsApplied {
+                    pot: pot.key(),
+                    applied_at: now,
+        });
+        msg!("pending risk params applied for pot {}", pot.key());
         Ok(())
 }
 
@@ -176,4 +312,16 @@ pub struct FeeReserveFunded {
         pub pot: Pubkey,
         pub amount: u64,
         pub total: u64,
+}
+
+#[event]
+pub struct AllowedProgramsUpdated {
+        pub pot: Pubkey,
+        pub count: u8,
+}
+
+#[event]
+pub struct PendingParamsApplied {
+        pub pot: Pubkey,
+        pub applied_at: i64,
 }

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -17,7 +17,7 @@ pub struct PausePot<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub authority: Signer<'info>,
 }
 
@@ -49,7 +49,7 @@ pub struct SetAllowedMints<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub authority: Signer<'info>,
 }
 
@@ -89,7 +89,7 @@ pub struct SetSpendingPolicy<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub authority: Signer<'info>,
 }
 
@@ -135,7 +135,7 @@ pub struct SetAllowedPrograms<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub authority: Signer<'info>,
 }
 
@@ -177,7 +177,7 @@ pub struct SetRiskTimelock<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub authority: Signer<'info>,
 }
 
@@ -223,7 +223,7 @@ pub fn set_risk_timelock(
 #[derive(Accounts)]
 pub struct ApplyPendingParams<'info> {
         #[account(mut)]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         pub cranker: Signer<'info>,
 }
 
@@ -258,7 +258,7 @@ pub struct FundFeeReserve<'info> {
                     mut,
                     constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
                 )]
-        pub pot: Account<'info, PotAccount>,
+        pub pot: Box<Account<'info, PotAccount>>,
         #[account(mut)]
         pub authority: Signer<'info>,
         pub system_program: Program<'info, System>,

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -64,6 +64,10 @@ pub fn set_allowed_mints(
                     pot.allowed_mints[i] = *mint;
         }
         pot.allowed_mints_count = args.mints.len() as u8;
+        // Exposure counters are slot-aligned with allowed_mints — reordering
+        // or replacing the list would re-attach accumulated spend to a
+        // different mint (cap bypass / false block). Reset on every change.
+        pot.per_mint_daily_spent = [0u64; 16];
         pot.agent_authority = args.agent_authority;
         emit!(AllowedMintsUpdated {
                     pot: pot.key(),
@@ -126,6 +130,9 @@ pub fn set_spending_policy(
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct SetAllowedProgramsArgs {
         /// Up to 8 program ids. Pass empty slice to clear (open mode).
+        /// FOOTGUN: once non-empty, EVERY CPI target must be listed —
+        /// including Jupiter v6, or every swap reverts with
+        /// ProgramNotAllowed. Clients should auto-include Jupiter.
     pub programs: Vec<Pubkey>,
 }
 

--- a/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
@@ -21,7 +21,7 @@ const MAX_EXIT_BPS: u128 = 8_000;
 #[derive(Accounts)]
 pub struct RedeemTokens<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// Vault PDA holding the pot's SOL.
     #[account(

--- a/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
@@ -55,7 +55,11 @@ pub struct RedeemTokens<'info> {
 
 pub fn handler(ctx: Context<RedeemTokens>, token_amount: u64) -> Result<()> {
     require!(token_amount > 0, PotError::InvalidAmount);
-    require!(!ctx.accounts.pot.paused, PotError::PotPaused);
+    // NOTE: deliberately NOT gated on pot.paused. Redemption is the
+    // canonical member exit for tokenized pots — non-custodial exit must
+    // never be blockable by the authority or the sentinel (the same reason
+    // withdraw.rs has no pause check). Freeze stops capital coming IN and
+    // funds moving OUT to third parties, never a member's pro-rata exit.
 
     // Convert SPL token units → internal share units. The mint side
     // (`mint_tokens_to_member`) emits `internal_shares * shares_per_sol`

--- a/packages/program/programs/pot_vault/src/instructions/route_to_yield.rs
+++ b/packages/program/programs/pot_vault/src/instructions/route_to_yield.rs
@@ -49,7 +49,7 @@ pub struct RouteToYield<'info> {
         constraint = !pot.paused @ PotError::StrategyInactive,
         has_one = authority @ PotError::StrategyNotAdmin,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// CHECK: vault PDA. Read-only here — the stub doesn't move SOL yet.
     #[account(

--- a/packages/program/programs/pot_vault/src/instructions/sentinel.rs
+++ b/packages/program/programs/pot_vault/src/instructions/sentinel.rs
@@ -1,0 +1,152 @@
+// PotBot v2 — sentinel / guardian role (Phase A security hardening)
+//
+// set_sentinel       — authority assigns or clears the sentinel wallet
+// freeze_pot         — sentinel OR authority halts the pot (paused = true)
+// unfreeze_pot       — authority ONLY resumes the pot
+// cancel_proposal    — sentinel, authority, or proposer kills a proposal
+//
+// Invariant: the sentinel has NO instruction that can move funds. It can
+// only stop things (freeze, cancel). Withdrawals by members stay open even
+// while frozen — non-custodial exit is never blocked.
+
+use anchor_lang::prelude::*;
+use crate::state::pot::PotAccount;
+use crate::state::proposal::{ProposalAccount, ProposalStatus};
+use crate::errors::PotError;
+
+// ─── Set sentinel ───────────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct SetSentinel<'info> {
+    #[account(
+        mut,
+        constraint = authority.key() == pot.authority @ PotError::UnauthorizedAccess,
+    )]
+    pub pot: Account<'info, PotAccount>,
+    pub authority: Signer<'info>,
+}
+
+pub fn set_sentinel(ctx: Context<SetSentinel>, new_sentinel: Option<Pubkey>) -> Result<()> {
+    let pot = &mut ctx.accounts.pot;
+    pot.sentinel = new_sentinel;
+    emit!(SentinelUpdated {
+        pot: pot.key(),
+        sentinel: new_sentinel,
+    });
+    msg!("sentinel for pot {} set to {:?}", pot.key(), new_sentinel);
+    Ok(())
+}
+
+// ─── Freeze / unfreeze ──────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct FreezePot<'info> {
+    #[account(
+        mut,
+        constraint = pot.is_sentinel_or_authority(&signer.key())
+            @ PotError::NotSentinelOrAuthority,
+    )]
+    pub pot: Account<'info, PotAccount>,
+    pub signer: Signer<'info>,
+}
+
+pub fn freeze_pot(ctx: Context<FreezePot>) -> Result<()> {
+    let pot = &mut ctx.accounts.pot;
+    pot.paused = true;
+    emit!(PotFrozenEvent {
+        pot: pot.key(),
+        by: ctx.accounts.signer.key(),
+        frozen: true,
+    });
+    msg!("pot {} FROZEN by {}", pot.key(), ctx.accounts.signer.key());
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct UnfreezePot<'info> {
+    #[account(
+        mut,
+        constraint = signer.key() == pot.authority @ PotError::SentinelCannotUnfreeze,
+    )]
+    pub pot: Account<'info, PotAccount>,
+    pub signer: Signer<'info>,
+}
+
+pub fn unfreeze_pot(ctx: Context<UnfreezePot>) -> Result<()> {
+    let pot = &mut ctx.accounts.pot;
+    pot.paused = false;
+    emit!(PotFrozenEvent {
+        pot: pot.key(),
+        by: ctx.accounts.signer.key(),
+        frozen: false,
+    });
+    msg!("pot {} unfrozen by authority", pot.key());
+    Ok(())
+}
+
+// ─── Cancel proposal ────────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct CancelProposal<'info> {
+    #[account(mut)]
+    pub pot: Account<'info, PotAccount>,
+
+    #[account(
+        mut,
+        has_one = pot @ PotError::UnauthorizedAccess,
+        constraint = pot.is_sentinel_or_authority(&signer.key())
+            || signer.key() == proposal.proposer
+            @ PotError::NotSentinelOrAuthority,
+    )]
+    pub proposal: Account<'info, ProposalAccount>,
+
+    pub signer: Signer<'info>,
+}
+
+pub fn cancel_proposal(ctx: Context<CancelProposal>) -> Result<()> {
+    let proposal = &mut ctx.accounts.proposal;
+    require!(
+        matches!(
+            proposal.status,
+            ProposalStatus::Active | ProposalStatus::Passed
+        ),
+        PotError::ProposalNotCancellable
+    );
+    proposal.status = ProposalStatus::Cancelled;
+    proposal.resolved_at = Clock::get()?.unix_timestamp;
+    emit!(ProposalCancelled {
+        pot: ctx.accounts.pot.key(),
+        proposal: proposal.key(),
+        proposal_id: proposal.proposal_id,
+        by: ctx.accounts.signer.key(),
+    });
+    msg!(
+        "proposal #{} cancelled by {}",
+        proposal.proposal_id,
+        ctx.accounts.signer.key()
+    );
+    Ok(())
+}
+
+// ─── Events ─────────────────────────────────────────────────────────────────
+
+#[event]
+pub struct SentinelUpdated {
+    pub pot: Pubkey,
+    pub sentinel: Option<Pubkey>,
+}
+
+#[event]
+pub struct PotFrozenEvent {
+    pub pot: Pubkey,
+    pub by: Pubkey,
+    pub frozen: bool,
+}
+
+#[event]
+pub struct ProposalCancelled {
+    pub pot: Pubkey,
+    pub proposal: Pubkey,
+    pub proposal_id: u64,
+    pub by: Pubkey,
+}

--- a/packages/program/programs/pot_vault/src/instructions/sentinel.rs
+++ b/packages/program/programs/pot_vault/src/instructions/sentinel.rs
@@ -22,7 +22,7 @@ pub struct SetSentinel<'info> {
         mut,
         constraint = authority.key() == pot.authority @ PotError::UnauthorizedAccess,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
     pub authority: Signer<'info>,
 }
 
@@ -46,7 +46,7 @@ pub struct FreezePot<'info> {
         constraint = pot.is_sentinel_or_authority(&signer.key())
             @ PotError::NotSentinelOrAuthority,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
     pub signer: Signer<'info>,
 }
 
@@ -68,7 +68,7 @@ pub struct UnfreezePot<'info> {
         mut,
         constraint = signer.key() == pot.authority @ PotError::SentinelCannotUnfreeze,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
     pub signer: Signer<'info>,
 }
 
@@ -89,7 +89,7 @@ pub fn unfreeze_pot(ctx: Context<UnfreezePot>) -> Result<()> {
 #[derive(Accounts)]
 pub struct CancelProposal<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/strategy_vault.rs
+++ b/packages/program/programs/pot_vault/src/instructions/strategy_vault.rs
@@ -15,7 +15,7 @@ pub struct CreateStrategyVault<'info> {
         seeds = [b"pot", creator.key().as_ref(), pot_name.as_bytes()],
         bump = pot.pot_bump,
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         init,
@@ -223,7 +223,7 @@ pub struct EvolveTamagotchi<'info> {
     #[account(mut)]
     pub strategy_vault: Account<'info, StrategyVaultAccount>,
 
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 }
 
 pub fn evolve_tamagotchi(ctx: Context<EvolveTamagotchi>) -> Result<()> {

--- a/packages/program/programs/pot_vault/src/instructions/tokenize_shares.rs
+++ b/packages/program/programs/pot_vault/src/instructions/tokenize_shares.rs
@@ -8,7 +8,7 @@ use crate::errors::ErrorCode;
 #[derive(Accounts)]
 pub struct TokenizeShares<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
     
     #[account(
         mut,
@@ -81,7 +81,7 @@ pub struct MintTokensToMember<'info> {
     #[account(
         constraint = pot.token_mint != Pubkey::default() @ ErrorCode::NotTokenized
     )]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
     
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/tokenize_shares.rs
+++ b/packages/program/programs/pot_vault/src/instructions/tokenize_shares.rs
@@ -48,19 +48,31 @@ pub struct TokenizeShares<'info> {
 }
 
 pub fn handler(ctx: Context<TokenizeShares>) -> Result<()> {
-    let pot = &mut ctx.accounts.pot;
-    
     // Check if already tokenized
-    require!(pot.token_mint == Pubkey::default(), ErrorCode::AlreadyTokenized);
-    
+    require!(
+        ctx.accounts.pot.token_mint == Pubkey::default(),
+        ErrorCode::AlreadyTokenized
+    );
+
     // Tokenization fee: 0.1 SOL
     let tokenization_fee = 100_000_000; // 0.1 SOL in lamports
-    
-    // Transfer fee to YD's treasury
-    **ctx.accounts.authority.lamports.borrow_mut() -= tokenization_fee;
-    **ctx.accounts.treasury.lamports.borrow_mut() += tokenization_fee;
-    
+
+    // Transfer fee to the treasury. authority is System-owned, so the fee
+    // must move via a system-program CPI — direct lamport debits of
+    // accounts this program does not own are rejected by the runtime.
+    anchor_lang::system_program::transfer(
+        CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            anchor_lang::system_program::Transfer {
+                from: ctx.accounts.authority.to_account_info(),
+                to: ctx.accounts.treasury.to_account_info(),
+            },
+        ),
+        tokenization_fee,
+    )?;
+
     // Set the token mint in pot account
+    let pot = &mut ctx.accounts.pot;
     pot.token_mint = ctx.accounts.token_mint.key();
     pot.shares_per_sol = 1000; // 1000 tokens per 1 SOL for better UX
     

--- a/packages/program/programs/pot_vault/src/instructions/update_tamagotchi.rs
+++ b/packages/program/programs/pot_vault/src/instructions/update_tamagotchi.rs
@@ -4,7 +4,7 @@ use crate::state::*;
 #[derive(Accounts)]
 pub struct UpdateTamagotchi<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 }
 
 pub fn handler(ctx: Context<UpdateTamagotchi>) -> Result<()> {

--- a/packages/program/programs/pot_vault/src/instructions/update_tamagotchi_metadata.rs
+++ b/packages/program/programs/pot_vault/src/instructions/update_tamagotchi_metadata.rs
@@ -12,7 +12,7 @@ use crate::state::tamagotchi_nft::TamagotchiNftAccount;
 #[derive(Accounts)]
 pub struct UpdateTamagotchiMetadata<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/vote.rs
+++ b/packages/program/programs/pot_vault/src/instructions/vote.rs
@@ -4,7 +4,7 @@ use crate::errors::PotError;
 
 #[derive(Accounts)]
 pub struct Vote<'info> {
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/vote_as_delegate.rs
+++ b/packages/program/programs/pot_vault/src/instructions/vote_as_delegate.rs
@@ -9,7 +9,7 @@ use crate::errors::PotError;
 /// same proposal.
 #[derive(Accounts)]
 pub struct VoteAsDelegate<'info> {
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     #[account(
         mut,

--- a/packages/program/programs/pot_vault/src/instructions/withdraw.rs
+++ b/packages/program/programs/pot_vault/src/instructions/withdraw.rs
@@ -1,11 +1,12 @@
 use anchor_lang::prelude::*;
+use anchor_lang::system_program;
 use crate::state::*;
 use crate::errors::PotError;
 
 #[derive(Accounts)]
 pub struct Withdraw<'info> {
     #[account(mut)]
-    pub pot: Account<'info, PotAccount>,
+    pub pot: Box<Account<'info, PotAccount>>,
 
     /// CHECK: PDA vault that holds SOL
     #[account(
@@ -54,8 +55,23 @@ pub fn handler(ctx: Context<Withdraw>, shares: u64) -> Result<()> {
         PotError::InsufficientVaultBalance
     );
 
-    **ctx.accounts.vault.to_account_info().try_borrow_mut_lamports()? -= lamports_out;
-    **ctx.accounts.withdrawer.to_account_info().try_borrow_mut_lamports()? += lamports_out;
+    // Vault is a System-owned PDA: lamports must leave via a system-program
+    // transfer signed with the vault seeds (direct lamport debits are
+    // rejected by the runtime for accounts this program does not own).
+    let pot_key = ctx.accounts.pot.key();
+    let vault_bump = ctx.accounts.pot.vault_bump;
+    let signer_seeds: &[&[u8]] = &[b"vault", pot_key.as_ref(), core::slice::from_ref(&vault_bump)];
+    system_program::transfer(
+        CpiContext::new_with_signer(
+            ctx.accounts.system_program.to_account_info(),
+            system_program::Transfer {
+                from: ctx.accounts.vault.to_account_info(),
+                to: ctx.accounts.withdrawer.to_account_info(),
+            },
+            &[signer_seeds],
+        ),
+        lamports_out,
+    )?;
 
     let member = &mut ctx.accounts.member;
     member.shares = member.shares.checked_sub(shares).ok_or(PotError::ArithmeticOverflow)?;

--- a/packages/program/programs/pot_vault/src/lib.rs
+++ b/packages/program/programs/pot_vault/src/lib.rs
@@ -207,12 +207,71 @@ pub mod pot_vault {
         instructions::pot_admin::set_allowed_mints(ctx, args)
     }
 
-    /// Configure per-swap size cap and daily budget.
+    /// Configure per-swap size cap and daily budget. When a risk-param
+    /// timelock is configured, loosening changes are staged and only take
+    /// effect after the delay (see apply_pending_params).
     pub fn set_spending_policy(
         ctx: Context<SetSpendingPolicy>,
         args: SetSpendingPolicyArgs,
     ) -> Result<()> {
         instructions::pot_admin::set_spending_policy(ctx, args)
+    }
+
+    /// Fund the pot's keeper-gas reserve.
+    pub fn fund_fee_reserve(
+        ctx: Context<FundFeeReserve>,
+        args: FundFeeReserveArgs,
+    ) -> Result<()> {
+        instructions::pot_admin::fund_fee_reserve(ctx, args)
+    }
+
+    // ─── Security hardening (Phase A) ─────────────────────────────────────
+
+    /// Assign or clear the sentinel/guardian wallet. The sentinel can
+    /// freeze the pot and cancel proposals but can NEVER move funds.
+    pub fn set_sentinel(
+        ctx: Context<SetSentinel>,
+        new_sentinel: Option<Pubkey>,
+    ) -> Result<()> {
+        instructions::sentinel::set_sentinel(ctx, new_sentinel)
+    }
+
+    /// Freeze the pot (sentinel or authority). Blocks deposits, proposal
+    /// execution, swaps and strategy creation. Member withdrawals stay open.
+    pub fn freeze_pot(ctx: Context<FreezePot>) -> Result<()> {
+        instructions::sentinel::freeze_pot(ctx)
+    }
+
+    /// Unfreeze the pot — authority only.
+    pub fn unfreeze_pot(ctx: Context<UnfreezePot>) -> Result<()> {
+        instructions::sentinel::unfreeze_pot(ctx)
+    }
+
+    /// Cancel an Active or Passed proposal (sentinel, authority or proposer).
+    pub fn cancel_proposal(ctx: Context<CancelProposal>) -> Result<()> {
+        instructions::sentinel::cancel_proposal(ctx)
+    }
+
+    /// Set the program-id allowlist for external CPI targets.
+    pub fn set_allowed_programs(
+        ctx: Context<SetAllowedPrograms>,
+        args: SetAllowedProgramsArgs,
+    ) -> Result<()> {
+        instructions::pot_admin::set_allowed_programs(ctx, args)
+    }
+
+    /// Configure the risk-param timelock and per-asset exposure cap.
+    pub fn set_risk_timelock(
+        ctx: Context<SetRiskTimelock>,
+        args: SetRiskTimelockArgs,
+    ) -> Result<()> {
+        instructions::pot_admin::set_risk_timelock(ctx, args)
+    }
+
+    /// Permissionless crank: apply a staged risky-param change once its
+    /// timelock has elapsed.
+    pub fn apply_pending_params(ctx: Context<ApplyPendingParams>) -> Result<()> {
+        instructions::pot_admin::apply_pending_params(ctx)
     }
 
     // ─── Yield routing (Phase 4 stub — emit-only) ─────────────────────────

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -87,6 +87,36 @@ pub struct PotAccount {
 
     /// Keeper gas reserve (lamports). Keeper draws from this for trigger gas.
     pub fee_reserve: u64,
+
+    // ─── Security hardening (Phase A) ─────────────────────────────────────
+
+    /// Optional sentinel/guardian wallet. Can freeze the pot and cancel
+    /// proposals; has NO instruction that can move funds. None = unset.
+    pub sentinel: Option<Pubkey>,
+
+    /// Timelock (seconds) applied when a risky governance parameter is
+    /// LOOSENED (caps raised, approval levels lowered). Tightening changes
+    /// apply immediately. 0 = disabled — all changes apply immediately.
+    pub risk_param_timelock_secs: i64,
+
+    /// Staged loosening change awaiting its timelock. Applied via the
+    /// permissionless `apply_pending_params` instruction once
+    /// `effective_at` has passed. A new staged change replaces this one.
+    pub pending_params: PendingRiskParams,
+
+    /// Program-id allowlist for external CPI targets (Jupiter, yield
+    /// protocols). Zeroed entries = unused slots. count == 0 = open mode.
+    pub allowed_programs: [Pubkey; 8],
+    pub allowed_programs_count: u8,
+
+    /// Max cumulative daily spend toward any single output mint, as bps of
+    /// vault balance. Tracked per allowed_mints slot. 0 = unlimited.
+    /// Only enforceable when the mint allowlist is configured.
+    pub max_asset_exposure_bps: u16,
+
+    /// Daily spend (input lamport-equivalents) per allowed_mints slot.
+    /// Resets together with daily_spend_day.
+    pub per_mint_daily_spent: [u64; 16],
 }
 
 // ─── Config structs ───────────────────────────────────────────────────────
@@ -112,6 +142,23 @@ pub struct GovSettings {
     pub vote_timeout_seconds: i64,
     pub quorum_bps: u16,
     pub timelock_seconds: i64,
+}
+
+/// A staged change to risky governance parameters, waiting out the
+/// risk-param timelock. Stores the FULL target value set: fields that were
+/// tightened are applied immediately at staging time, so re-applying them
+/// here is a no-op; loosened fields take effect only at `effective_at`.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Default)]
+pub struct PendingRiskParams {
+    pub is_pending: bool,
+    /// Unix timestamp after which apply_pending_params may apply this change.
+    pub effective_at: i64,
+    pub trade_level: u8,
+    pub withdraw_level: u8,
+    pub max_trade_size_bps: u16,
+    pub single_swap_cap_bps: u16,
+    pub daily_budget_lamports: u64,
+    pub risk_param_timelock_secs: i64,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, PartialEq)]
@@ -311,6 +358,8 @@ impl PotAccount {
         if current_day > self.daily_spend_day {
             self.daily_spent_lamports = 0;
             self.daily_spend_day = current_day;
+            // Per-mint exposure counters share the same UTC-day window.
+            self.per_mint_daily_spent = [0u64; 16];
         }
         self.daily_spent_lamports = self
             .daily_spent_lamports
@@ -318,4 +367,195 @@ impl PotAccount {
             .ok_or(error!(PotError::MathOverflow))?;
         Ok(())
     }
+
+    // ─── Security hardening (Phase A) methods ────────────────────────────
+
+    /// True if `signer` is the pot authority or the configured sentinel.
+    pub fn is_sentinel_or_authority(&self, signer: &Pubkey) -> bool {
+        *signer == self.authority || self.sentinel.as_ref() == Some(signer)
+    }
+
+    /// Returns true if `program_id` may be CPI'd into from execute paths.
+    /// count == 0 = open mode (any program) for backward compatibility.
+    pub fn is_program_allowed(&self, program_id: &Pubkey) -> bool {
+        if self.allowed_programs_count == 0 {
+            return true;
+        }
+        self.allowed_programs[..self.allowed_programs_count as usize]
+            .iter()
+            .any(|p| p == program_id)
+    }
+
+    /// Slot index of `mint` in allowed_mints, if listed.
+    fn mint_slot(&self, mint: &Pubkey) -> Option<usize> {
+        self.allowed_mints[..self.allowed_mints_count as usize]
+            .iter()
+            .position(|m| m == mint)
+    }
+
+    /// Check that spending `amount` more input lamports toward `mint` today
+    /// stays within max_asset_exposure_bps of the vault balance.
+    /// No-op when the cap is 0 or the mint allowlist is open (no slots to
+    /// track against). Does NOT mutate — call register_asset_spend after.
+    pub fn check_asset_exposure(
+        &self,
+        mint: &Pubkey,
+        amount: u64,
+        vault_lamports: u64,
+        now: i64,
+    ) -> Result<()> {
+        if self.max_asset_exposure_bps == 0 {
+            return Ok(());
+        }
+        let Some(slot) = self.mint_slot(mint) else {
+            return Ok(()); // open mode / unlisted mint — allowlist guard handles it
+        };
+        let spent_today = if now / 86400 > self.daily_spend_day {
+            0u64
+        } else {
+            self.per_mint_daily_spent[slot]
+        };
+        let cap = (vault_lamports as u128)
+            .checked_mul(self.max_asset_exposure_bps as u128)
+            .ok_or(error!(PotError::MathOverflow))?
+            / 10_000u128;
+        let new_total = (spent_today as u128)
+            .checked_add(amount as u128)
+            .ok_or(error!(PotError::MathOverflow))?;
+        require!(new_total <= cap, PotError::AssetExposureExceeded);
+        Ok(())
+    }
+
+    /// Record spend toward `mint` for the per-asset daily exposure cap.
+    /// Call AFTER register_spend (which handles the day rollover).
+    pub fn register_asset_spend(&mut self, mint: &Pubkey, amount: u64) -> Result<()> {
+        if let Some(slot) = self.mint_slot(mint) {
+            self.per_mint_daily_spent[slot] = self.per_mint_daily_spent[slot]
+                .checked_add(amount)
+                .ok_or(error!(PotError::MathOverflow))?;
+        }
+        Ok(())
+    }
+
+    /// Stage-or-apply a risky-parameter change.
+    ///
+    /// `target` carries the FULL desired value set. Per field: if the new
+    /// value is tighter-or-equal it is applied immediately; if ANY field is
+    /// looser and a risk-param timelock is configured, the full target set
+    /// is staged into pending_params (replacing any prior staged change)
+    /// and takes effect via apply_pending_params after the delay.
+    /// Returns true if a change was staged (caller may emit/log).
+    pub fn stage_or_apply_risk_params(
+        &mut self,
+        mut target: PendingRiskParams,
+        now: i64,
+    ) -> Result<bool> {
+        let mut any_loosening = false;
+
+        // Approval levels: HIGHER = tighter. Apply raises now; delay lowers.
+        if target.trade_level >= self.governance.trade_level {
+            self.governance.trade_level = target.trade_level;
+        } else {
+            any_loosening = true;
+        }
+        if target.withdraw_level >= self.governance.withdraw_level {
+            self.governance.withdraw_level = target.withdraw_level;
+        } else {
+            any_loosening = true;
+        }
+
+        // Caps: 0 = unlimited (loosest); otherwise lower = tighter.
+        if !cap_is_looser(self.config.max_trade_size_bps as u64, target.max_trade_size_bps as u64) {
+            self.config.max_trade_size_bps = target.max_trade_size_bps;
+        } else {
+            any_loosening = true;
+        }
+        if !cap_is_looser(self.single_swap_cap_bps as u64, target.single_swap_cap_bps as u64) {
+            self.single_swap_cap_bps = target.single_swap_cap_bps;
+        } else {
+            any_loosening = true;
+        }
+        if !cap_is_looser(self.daily_budget_lamports, target.daily_budget_lamports) {
+            self.daily_budget_lamports = target.daily_budget_lamports;
+        } else {
+            any_loosening = true;
+        }
+
+        // Timelock itself: HIGHER = tighter; 0 = disabled (loosest).
+        if !timelock_is_looser(self.risk_param_timelock_secs, target.risk_param_timelock_secs) {
+            self.risk_param_timelock_secs = target.risk_param_timelock_secs;
+        } else {
+            any_loosening = true;
+        }
+
+        if any_loosening {
+            if self.risk_param_timelock_secs <= 0 {
+                // No timelock configured — loosening applies immediately too.
+                self.apply_params(&target);
+                self.pending_params = PendingRiskParams::default();
+                return Ok(false);
+            }
+            target.is_pending = true;
+            target.effective_at = now
+                .checked_add(self.risk_param_timelock_secs)
+                .ok_or(error!(PotError::MathOverflow))?;
+            self.pending_params = target;
+            return Ok(true);
+        }
+
+        // Fully-tightening change: clear any stale staged loosening so it
+        // cannot later override the new, tighter values.
+        self.pending_params = PendingRiskParams::default();
+        Ok(false)
+    }
+
+    /// Apply the staged change (permissionless once effective_at passed).
+    pub fn apply_pending(&mut self, now: i64) -> Result<()> {
+        require!(self.pending_params.is_pending, PotError::NoPendingChange);
+        require!(
+            now >= self.pending_params.effective_at,
+            PotError::PendingChangeNotReady
+        );
+        let staged = self.pending_params.clone();
+        self.apply_params(&staged);
+        self.pending_params = PendingRiskParams::default();
+        Ok(())
+    }
+
+    fn apply_params(&mut self, p: &PendingRiskParams) {
+        self.governance.trade_level = p.trade_level;
+        self.governance.withdraw_level = p.withdraw_level;
+        self.config.max_trade_size_bps = p.max_trade_size_bps;
+        self.single_swap_cap_bps = p.single_swap_cap_bps;
+        self.daily_budget_lamports = p.daily_budget_lamports;
+        self.risk_param_timelock_secs = p.risk_param_timelock_secs;
+    }
+}
+
+/// 0 = unlimited (loosest). Otherwise a higher cap is looser.
+fn cap_is_looser(old: u64, new: u64) -> bool {
+    if old == new {
+        return false;
+    }
+    if new == 0 {
+        return true; // bounded → unlimited
+    }
+    if old == 0 {
+        return false; // unlimited → bounded = tightening
+    }
+    new > old
+}
+
+/// 0 = disabled (loosest). Otherwise a shorter timelock is looser.
+fn timelock_is_looser(old: i64, new: i64) -> bool {
+    if old == new {
+        return false;
+    }
+    if new <= 0 {
+        return true;
+    }
+    if old <= 0 {
+        return false;
+    }
+    new < old
 }

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -397,6 +397,11 @@ impl PotAccount {
     /// stays within max_asset_exposure_bps of the vault balance.
     /// No-op when the cap is 0 or the mint allowlist is open (no slots to
     /// track against). Does NOT mutate — call register_asset_spend after.
+    ///
+    /// LIMITATION: `amount` is in INPUT-mint base units, the cap in
+    /// lamports — the comparison is only meaningful for wSOL-denominated
+    /// entries (like the daily budget and single-swap caps). Token→token
+    /// strategies need oracle normalization (Phase 2) for a faithful cap.
     pub fn check_asset_exposure(
         &self,
         mint: &Pubkey,

--- a/packages/program/programs/pot_vault/src/state/proposal.rs
+++ b/packages/program/programs/pot_vault/src/state/proposal.rs
@@ -80,6 +80,9 @@ pub enum ProposalStatus {
     Rejected,
     Executed,
     Expired,
+    /// Cancelled by the sentinel, the pot authority, or the proposer
+    /// before execution. Terminal state.
+    Cancelled,
 }
 
 impl ProposalAccount {

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Patch the pot_vault IDL with Phase A security-hardening surface.
+
+Why this exists: anchor 0.30.1's IDL generation is broken on modern
+toolchains (anchor-syn needs proc_macro2::Span::source_file(), removed in
+rustc >= 1.85 / proc-macro2 >= 1.0.95, while the IDL temp-project resolves
+fresh dependencies that require newer rustc). `anchor build --no-idl`
+builds the program fine, so we patch the IDL deterministically instead.
+
+Self-check: recomputes discriminators of entries already present in the
+IDL and aborts on mismatch, proving the algorithm matches anchor's.
+"""
+import hashlib
+import json
+import sys
+
+SRC = sys.argv[1] if len(sys.argv) > 1 else "/Users/yegordo/potbot-v2/packages/sdk/src/idl/pot_vault.json"
+OUT = sys.argv[2] if len(sys.argv) > 2 else SRC
+
+idl = json.load(open(SRC))
+
+def disc(prefix: str, name: str) -> list[int]:
+    return list(hashlib.sha256(f"{prefix}:{name}".encode()).digest()[:8])
+
+# ── self-check ──────────────────────────────────────────────────────────────
+for ins in idl["instructions"]:
+    assert ins["discriminator"] == disc("global", ins["name"]), f"ix disc mismatch: {ins['name']}"
+for ev in idl["events"]:
+    assert ev["discriminator"] == disc("event", ev["name"]), f"event disc mismatch: {ev['name']}"
+for acc in idl["accounts"]:
+    assert acc["discriminator"] == disc("account", acc["name"]), f"acct disc mismatch: {acc['name']}"
+print(f"self-check OK: {len(idl['instructions'])} ix, {len(idl['events'])} events, {len(idl['accounts'])} accounts")
+
+names = {i["name"] for i in idl["instructions"]}
+
+def add_ix(name, accounts, args, docs=None):
+    if name in names:
+        return
+    entry = {"name": name, "discriminator": disc("global", name), "accounts": accounts, "args": args}
+    if docs:
+        entry["docs"] = docs
+    idl["instructions"].append(entry)
+
+POT_W = {"name": "pot", "writable": True}
+AUTH_S = {"name": "authority", "signer": True}
+SIGNER = {"name": "signer", "signer": True}
+
+# ── new instructions ────────────────────────────────────────────────────────
+add_ix("set_sentinel", [POT_W, AUTH_S],
+       [{"name": "new_sentinel", "type": {"option": "pubkey"}}],
+       ["Assign or clear the sentinel/guardian wallet. The sentinel can freeze the pot and cancel proposals but can NEVER move funds."])
+add_ix("freeze_pot", [POT_W, SIGNER], [],
+       ["Freeze the pot (sentinel or authority). Blocks deposits, proposal execution, swaps and strategy creation. Member withdrawals stay open."])
+add_ix("unfreeze_pot", [POT_W, SIGNER], [],
+       ["Unfreeze the pot — authority only."])
+add_ix("cancel_proposal",
+       [POT_W, {"name": "proposal", "writable": True}, SIGNER], [],
+       ["Cancel an Active or Passed proposal (sentinel, authority or proposer)."])
+add_ix("set_allowed_programs", [POT_W, AUTH_S],
+       [{"name": "args", "type": {"defined": {"name": "SetAllowedProgramsArgs"}}}],
+       ["Set the program-id allowlist for external CPI targets."])
+add_ix("set_risk_timelock", [POT_W, AUTH_S],
+       [{"name": "args", "type": {"defined": {"name": "SetRiskTimelockArgs"}}}],
+       ["Configure the risk-param timelock and per-asset exposure cap."])
+add_ix("apply_pending_params", [POT_W, {"name": "cranker", "signer": True}], [],
+       ["Permissionless crank: apply a staged risky-param change once its timelock has elapsed."])
+add_ix("fund_fee_reserve",
+       [POT_W, {"name": "authority", "writable": True, "signer": True},
+        {"name": "system_program", "address": "11111111111111111111111111111111"}],
+       [{"name": "args", "type": {"defined": {"name": "FundFeeReserveArgs"}}}],
+       ["Fund the pot's keeper-gas reserve."])
+
+# ── instructions missing from the stale May-2026 IDL ────────────────────────
+add_ix("redeem_tokens",
+       [POT_W,
+        {"name": "vault", "writable": True},
+        {"name": "member", "writable": True, "signer": True},
+        {"name": "token_mint", "writable": True},
+        {"name": "member_token_ata", "writable": True},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"}],
+       [{"name": "token_amount", "type": "u64"}],
+       ["Burn SPL share-tokens and receive SOL from the vault at NAV."])
+add_ix("route_to_yield",
+       [POT_W,
+        {"name": "vault"},
+        {"name": "authority", "writable": True, "signer": True}],
+       [{"name": "args", "type": {"defined": {"name": "RouteToYieldArgs"}}}],
+       ["Route idle vault SOL to a yield protocol (Phase 4 stub)."])
+
+# ── execute_proposal: optional recipient account ────────────────────────────
+for ins in idl["instructions"]:
+    if ins["name"] == "execute_proposal":
+        acc_names = [a["name"] for a in ins["accounts"]]
+        if "recipient" not in acc_names:
+            ins["accounts"].insert(acc_names.index("system_program"),
+                                   {"name": "recipient", "writable": True, "optional": True})
+
+# ── PotAccount: new fields ──────────────────────────────────────────────────
+NEW_POT_FIELDS = [
+    {"name": "sentinel", "docs": ["Optional sentinel/guardian wallet. Can freeze the pot and cancel proposals; has NO instruction that can move funds."], "type": {"option": "pubkey"}},
+    {"name": "risk_param_timelock_secs", "docs": ["Timelock (seconds) applied when a risky governance parameter is LOOSENED. 0 = disabled."], "type": "i64"},
+    {"name": "pending_params", "docs": ["Staged loosening change awaiting its timelock."], "type": {"defined": {"name": "PendingRiskParams"}}},
+    {"name": "allowed_programs", "docs": ["Program-id allowlist for external CPI targets. count == 0 = open mode."], "type": {"array": ["pubkey", 8]}},
+    {"name": "allowed_programs_count", "type": "u8"},
+    {"name": "max_asset_exposure_bps", "docs": ["Max cumulative daily spend toward one output mint, bps of vault. 0 = unlimited."], "type": "u16"},
+    {"name": "per_mint_daily_spent", "docs": ["Daily spend per allowed_mints slot."], "type": {"array": ["u64", 16]}},
+]
+for t in idl["types"]:
+    if t["name"] == "PotAccount":
+        existing = {f["name"] for f in t["type"]["fields"]}
+        for f in NEW_POT_FIELDS:
+            if f["name"] not in existing:
+                t["type"]["fields"].append(f)
+    if t["name"] == "ProposalStatus":
+        if not any(v["name"] == "Cancelled" for v in t["type"]["variants"]):
+            t["type"]["variants"].append({"name": "Cancelled"})
+
+# ── new types ───────────────────────────────────────────────────────────────
+type_names = {t["name"] for t in idl["types"]}
+
+def add_type(name, fields):
+    if name in type_names:
+        return
+    idl["types"].append({"name": name, "type": {"kind": "struct", "fields": fields}})
+
+add_type("PendingRiskParams", [
+    {"name": "is_pending", "type": "bool"},
+    {"name": "effective_at", "type": "i64"},
+    {"name": "trade_level", "type": "u8"},
+    {"name": "withdraw_level", "type": "u8"},
+    {"name": "max_trade_size_bps", "type": "u16"},
+    {"name": "single_swap_cap_bps", "type": "u16"},
+    {"name": "daily_budget_lamports", "type": "u64"},
+    {"name": "risk_param_timelock_secs", "type": "i64"},
+])
+add_type("SetAllowedProgramsArgs", [
+    {"name": "programs", "type": {"vec": "pubkey"}},
+])
+add_type("SetRiskTimelockArgs", [
+    {"name": "risk_param_timelock_secs", "type": "i64"},
+    {"name": "max_asset_exposure_bps", "type": "u16"},
+])
+add_type("FundFeeReserveArgs", [
+    {"name": "amount", "type": "u64"},
+])
+# event payload types
+add_type("SentinelUpdated", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "sentinel", "type": {"option": "pubkey"}},
+])
+add_type("PotFrozenEvent", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "by", "type": "pubkey"},
+    {"name": "frozen", "type": "bool"},
+])
+add_type("ProposalCancelled", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "proposal", "type": "pubkey"},
+    {"name": "proposal_id", "type": "u64"},
+    {"name": "by", "type": "pubkey"},
+])
+add_type("AllowedProgramsUpdated", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "count", "type": "u8"},
+])
+add_type("PendingParamsApplied", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "applied_at", "type": "i64"},
+])
+
+add_type("RouteToYieldArgs", [
+    {"name": "amount_lamports", "type": "u64"},
+    {"name": "yield_target", "type": {"defined": {"name": "YieldRouteTarget"}}},
+])
+if "YieldRouteTarget" not in type_names:
+    idl["types"].append({"name": "YieldRouteTarget", "type": {"kind": "enum", "variants": [
+        {"name": "Kamino"}, {"name": "MeteoraStable"}, {"name": "MeteoraDynamic"}]}})
+add_type("YieldRouted", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "target", "type": {"defined": {"name": "YieldRouteTarget"}}},
+    {"name": "amount", "type": "u64"},
+    {"name": "executed", "type": "bool"},
+    {"name": "timestamp", "type": "i64"},
+])
+
+# ── events ──────────────────────────────────────────────────────────────────
+event_names = {e["name"] for e in idl["events"]}
+for ev in ["SentinelUpdated", "PotFrozenEvent", "ProposalCancelled",
+           "AllowedProgramsUpdated", "PendingParamsApplied", "YieldRouted"]:
+    if ev not in event_names:
+        idl["events"].append({"name": ev, "discriminator": disc("event", ev)})
+
+# ── errors ──────────────────────────────────────────────────────────────────
+# The May-2026 IDL ends at 6062 MathOverflow; the program enum continues with
+# the redeem_tokens block, then the Phase A block. Codes are positional.
+TAIL_ERRORS = [
+    ("InvalidBurnAmount", "Burn amount must be > 0"),
+    ("InsufficientReserve", "Redemption would violate 20% reserve guard"),
+    ("RedemptionPausedWhilePotPaused", "Cannot redeem while pot is paused"),
+    ("RedemptionInsufficientVault", "Insufficient vault balance for redemption"),
+    ("YieldTargetNoneNotRoutable", "YieldTarget None is not routable"),
+    ("WithdrawalReserveBreached", "Redemption exceeds 80% vault liquidity reserve"),
+    ("PotPaused", "Pot is paused -- redemptions blocked"),
+    ("InvalidAmount", "Amount must be greater than zero"),
+    ("NotSentinelOrAuthority", "Signer is neither the pot authority nor the sentinel"),
+    ("PotFrozen", "Pot is frozen — this action is blocked until unfreeze"),
+    ("SentinelCannotUnfreeze", "Only the pot authority can unfreeze the pot"),
+    ("ProposalNotCancellable", "Proposal is not in a cancellable state"),
+    ("RecipientMismatch", "Recipient account does not match the proposal beneficiary"),
+    ("RecipientMissing", "Recipient account is required for this proposal type"),
+    ("PendingChangeNotReady", "Pending parameter change has not reached effective_at yet"),
+    ("NoPendingChange", "No pending parameter change staged for this pot"),
+    ("ProgramNotAllowed", "Program is not in the pot's protocol allowlist"),
+    ("AssetExposureExceeded", "Daily exposure cap for this asset exceeded"),
+]
+have = {e["name"] for e in idl["errors"]}
+next_code = max(e["code"] for e in idl["errors"]) + 1
+for name, msg in TAIL_ERRORS:
+    if name not in have:
+        idl["errors"].append({"code": next_code, "name": name, "msg": msg})
+        next_code += 1
+
+json.dump(idl, open(OUT, "w"), indent=2)
+print(f"patched → {OUT}: {len(idl['instructions'])} ix, {len(idl['events'])} events, "
+      f"{len(idl['types'])} types, {len(idl['errors'])} errors")

--- a/packages/program/tests/redeem_tokens.test.ts
+++ b/packages/program/tests/redeem_tokens.test.ts
@@ -208,12 +208,12 @@ describe('redeem_tokens', () => {
   })
 
   it('rejects redemption that exceeds 80% liquidity reserve', async () => {
-    // Mint enough tokens that one redemption would breach 80% of vault. We
-    // already burned 5000 above, so member has 5000 remaining; redeeming
-    // those would only be ~50% of the remaining ~0.5 SOL vault — within
-    // the cap. Mint another batch so the request crosses 80%.
+    // Mint enough tokens that one redemption would breach 80% of vault.
+    // deposit() granted ~1e9 internal shares (1 share : 1 lamport on first
+    // deposit), so to cross the 80% reserve the member must tokenize and
+    // redeem a true majority of total_shares — 0.9e9 internal ≈ 90% of vault.
     await (program.methods as any)
-      .mintTokensToMember(new BN(900)) // +90_000 SPL tokens = 900 internal
+      .mintTokensToMember(new BN(900_000_000)) // 0.9e9 internal ≈ 90% of shares
       .accounts({
         pot: potPda,
         tokenMint,

--- a/packages/program/tests/security.test.ts
+++ b/packages/program/tests/security.test.ts
@@ -1,0 +1,405 @@
+// tests/security.test.ts
+//
+// Phase A security hardening coverage:
+//   1. recipient fix      — governance withdrawal pays the proposal
+//                           beneficiary, never the executor
+//   2. sentinel           — can freeze + cancel, can NOT unfreeze, has no
+//                           fund-moving path
+//   3. freeze surface     — frozen pot blocks deposit + execute_proposal,
+//                           unfreeze restores them
+//   4. risk-param timelock — loosening staged, tightening instant,
+//                           apply_pending_params honours effective_at
+//   5. cap breach         — swap proposal above max_trade_size_bps rejected
+//   6. double execute     — second execute_proposal fails
+//   7. cancel_proposal    — proposer cancels, cancelled cannot execute
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { expect } from 'chai'
+
+const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+
+describe('security hardening (Phase A)', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+  const program = (anchor.workspace as any).PotVault as Program
+  const authority = provider.wallet.publicKey
+
+  const sentinel = Keypair.generate()
+  const stranger = Keypair.generate()
+  const beneficiary = Keypair.generate()
+
+  function pdas(name: string) {
+    const [pot] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), authority.toBuffer(), Buffer.from(name)],
+      program.programId,
+    )
+    const [vault] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), pot.toBuffer()],
+      program.programId,
+    )
+    return { pot, vault }
+  }
+
+  function memberPda(pot: PublicKey, wallet: PublicKey) {
+    return PublicKey.findProgramAddressSync(
+      [Buffer.from('member'), pot.toBuffer(), wallet.toBuffer()],
+      program.programId,
+    )[0]
+  }
+
+  function proposalPda(pot: PublicKey, id: number) {
+    return PublicKey.findProgramAddressSync(
+      [Buffer.from('proposal'), pot.toBuffer(), new BN(id).toArrayLike(Buffer, 'le', 8)],
+      program.programId,
+    )[0]
+  }
+
+  async function createPot(name: string, overrides: Record<string, any> = {}) {
+    const { pot, vault } = pdas(name)
+    await (program.methods as any)
+      .createPot({
+        name,
+        emoji: '🛡️',
+        isPublic: true,
+        minDeposit: new BN(0),
+        lockupSeconds: new BN(0),
+        yieldStrategy: 0,
+        maxYieldAllocationBps: 0,
+        maxTradeSizeBps: 0,
+        maxMembers: 16,
+        tradeLevel: 0,
+        withdrawLevel: 0,
+        memberChangeLevel: 0,
+        settingsChangeLevel: 0,
+        yieldChangeLevel: 0,
+        voteTimeoutSeconds: new BN(3600),
+        quorumBps: 0,
+        timelockSeconds: new BN(0),
+        protocolFeeBps: 0,
+        ...overrides,
+      })
+      .accounts({
+        pot, vault,
+        treasury: TREASURY,
+        authority,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+    return { pot, vault }
+  }
+
+  async function deposit(pot: PublicKey, vault: PublicKey, lamports: number) {
+    await (program.methods as any)
+      .deposit(new BN(lamports))
+      .accounts({
+        pot, vault,
+        member: memberPda(pot, authority),
+        depositor: authority,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+  }
+
+  /** Create a Withdraw proposal (auto-passes — withdrawLevel 0 autocracy). */
+  async function passedWithdrawProposal(
+    pot: PublicKey, vault: PublicKey, to: PublicKey, lamports: number,
+  ) {
+    const potState: any = await (program.account as any).potAccount.fetch(pot)
+    const id = potState.nextProposalId.toNumber()
+    const proposal = proposalPda(pot, id)
+    await (program.methods as any)
+      .createProposal({
+        proposalType: { withdraw: { beneficiary: to, amount: new BN(lamports) } },
+        description: 'test withdrawal',
+      })
+      .accounts({
+        pot, proposal, vault,
+        member: memberPda(pot, authority),
+        proposer: authority,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+    return proposal
+  }
+
+  async function expectError(p: Promise<any>, code: string) {
+    try {
+      await p
+      expect.fail(`expected ${code}, but the tx succeeded`)
+    } catch (e: any) {
+      expect(String(e.error?.errorCode?.code ?? e), `expected ${code}`).to.include(code)
+    }
+  }
+
+  before(async () => {
+    // Fund helper wallets for tx fees.
+    for (const kp of [sentinel, stranger]) {
+      const sig = await provider.connection.requestAirdrop(kp.publicKey, LAMPORTS_PER_SOL)
+      await provider.connection.confirmTransaction(sig)
+    }
+  })
+
+  // ── 1. recipient fix ─────────────────────────────────────────────────────
+
+  it('pays governance withdrawal to the beneficiary, never the executor', async () => {
+    const { pot, vault } = await createPot(`sec-recip-${Date.now() % 1e6}`)
+    await deposit(pot, vault, LAMPORTS_PER_SOL)
+    const amount = 0.1 * LAMPORTS_PER_SOL
+
+    // Wrong recipient (the executor itself) must be rejected.
+    const p1 = await passedWithdrawProposal(pot, vault, beneficiary.publicKey, amount)
+    await expectError(
+      (program.methods as any)
+        .executeProposal()
+        .accounts({
+          pot, vault, proposal: p1,
+          executor: authority,
+          recipient: authority, // ≠ beneficiary
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc(),
+      'RecipientMismatch',
+    )
+
+    // Correct recipient receives the funds.
+    const before = await provider.connection.getBalance(beneficiary.publicKey)
+    await (program.methods as any)
+      .executeProposal()
+      .accounts({
+        pot, vault, proposal: p1,
+        executor: authority,
+        recipient: beneficiary.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc()
+    const after = await provider.connection.getBalance(beneficiary.publicKey)
+    expect(after - before).to.equal(amount)
+  })
+
+  // ── 2 + 3. sentinel & freeze surface ─────────────────────────────────────
+
+  it('sentinel can freeze; only authority unfreezes; freeze blocks deposit + execute', async () => {
+    const { pot, vault } = await createPot(`sec-frz-${Date.now() % 1e6}`)
+    await deposit(pot, vault, LAMPORTS_PER_SOL)
+
+    // Strangers cannot freeze.
+    await expectError(
+      (program.methods as any)
+        .freezePot()
+        .accounts({ pot, signer: stranger.publicKey })
+        .signers([stranger])
+        .rpc(),
+      'NotSentinelOrAuthority',
+    )
+
+    // Authority assigns the sentinel; sentinel freezes.
+    await (program.methods as any)
+      .setSentinel(sentinel.publicKey)
+      .accounts({ pot, authority })
+      .rpc()
+    await (program.methods as any)
+      .freezePot()
+      .accounts({ pot, signer: sentinel.publicKey })
+      .signers([sentinel])
+      .rpc()
+    let potState: any = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.paused).to.equal(true)
+
+    // Frozen: deposits blocked.
+    await expectError(deposit(pot, vault, 0.1 * LAMPORTS_PER_SOL), 'PotFrozen')
+
+    // Frozen: execute_proposal blocked (proposal created before freeze
+    // would be needed; creating one now still works — only execution is
+    // gated — so create then try to execute).
+    // NOTE: createProposal is allowed while frozen by design (discussion
+    // can continue); execution cannot.
+    const p = await passedWithdrawProposal(pot, vault, beneficiary.publicKey, 1000)
+    await expectError(
+      (program.methods as any)
+        .executeProposal()
+        .accounts({
+          pot, vault, proposal: p,
+          executor: authority,
+          recipient: beneficiary.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc(),
+      'PotFrozen',
+    )
+
+    // Sentinel cannot unfreeze.
+    await expectError(
+      (program.methods as any)
+        .unfreezePot()
+        .accounts({ pot, signer: sentinel.publicKey })
+        .signers([sentinel])
+        .rpc(),
+      'SentinelCannotUnfreeze',
+    )
+
+    // Authority unfreezes; deposits work again.
+    await (program.methods as any)
+      .unfreezePot()
+      .accounts({ pot, signer: authority })
+      .rpc()
+    await deposit(pot, vault, 0.1 * LAMPORTS_PER_SOL)
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.paused).to.equal(false)
+  })
+
+  // ── 4. risk-param timelock ───────────────────────────────────────────────
+
+  it('stages loosening param changes and applies them only after the timelock', async () => {
+    const { pot } = await createPot(`sec-tl-${Date.now() % 1e6}`)
+
+    // Tighten first: cap 2000 bps, timelock 2s + exposure cap — instant.
+    await (program.methods as any)
+      .setSpendingPolicy({ singleSwapCapBps: 2000, dailyBudgetLamports: new BN(0) })
+      .accounts({ pot, authority })
+      .rpc()
+    await (program.methods as any)
+      .setRiskTimelock({ riskParamTimelockSecs: new BN(2), maxAssetExposureBps: 3000 })
+      .accounts({ pot, authority })
+      .rpc()
+    let potState: any = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.singleSwapCapBps).to.equal(2000)
+    expect(potState.riskParamTimelockSecs.toNumber()).to.equal(2)
+    expect(potState.maxAssetExposureBps).to.equal(3000)
+
+    // Loosening (2000 → 5000) must NOT apply immediately.
+    await (program.methods as any)
+      .setSpendingPolicy({ singleSwapCapBps: 5000, dailyBudgetLamports: new BN(0) })
+      .accounts({ pot, authority })
+      .rpc()
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.singleSwapCapBps).to.equal(2000) // unchanged
+    expect(potState.pendingParams.isPending).to.equal(true)
+
+    // Applying before effective_at fails.
+    await expectError(
+      (program.methods as any)
+        .applyPendingParams()
+        .accounts({ pot, cranker: authority })
+        .rpc(),
+      'PendingChangeNotReady',
+    )
+
+    // After the timelock the permissionless crank applies it.
+    await new Promise((r) => setTimeout(r, 3000))
+    await (program.methods as any)
+      .applyPendingParams()
+      .accounts({ pot, cranker: stranger.publicKey })
+      .signers([stranger])
+      .rpc()
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.singleSwapCapBps).to.equal(5000)
+    expect(potState.pendingParams.isPending).to.equal(false)
+
+    // Tightening (5000 → 1000) applies instantly even with timelock set.
+    await (program.methods as any)
+      .setSpendingPolicy({ singleSwapCapBps: 1000, dailyBudgetLamports: new BN(0) })
+      .accounts({ pot, authority })
+      .rpc()
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.singleSwapCapBps).to.equal(1000)
+    expect(potState.pendingParams.isPending).to.equal(false)
+  })
+
+  // ── 5. cap breach ────────────────────────────────────────────────────────
+
+  it('rejects a swap proposal above max_trade_size_bps', async () => {
+    const { pot, vault } = await createPot(`sec-cap-${Date.now() % 1e6}`, {
+      maxTradeSizeBps: 1000, // 10% of vault
+    })
+    await deposit(pot, vault, LAMPORTS_PER_SOL)
+
+    const potState: any = await (program.account as any).potAccount.fetch(pot)
+    const id = potState.nextProposalId.toNumber()
+    await expectError(
+      (program.methods as any)
+        .createProposal({
+          proposalType: {
+            swap: {
+              fromMint: PublicKey.default,
+              toMint: PublicKey.default,
+              amountIn: new BN(0.5 * LAMPORTS_PER_SOL), // 50% > 10% cap
+              minAmountOut: new BN(1),
+            },
+          },
+          description: 'oversized swap',
+        })
+        .accounts({
+          pot, proposal: proposalPda(pot, id), vault,
+          member: memberPda(pot, authority),
+          proposer: authority,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc(),
+      'TradeSizeExceeded',
+    )
+  })
+
+  // ── 6. double execute ────────────────────────────────────────────────────
+
+  it('prevents double execution of a passed proposal', async () => {
+    const { pot, vault } = await createPot(`sec-dbl-${Date.now() % 1e6}`)
+    await deposit(pot, vault, LAMPORTS_PER_SOL)
+    const p = await passedWithdrawProposal(pot, vault, beneficiary.publicKey, 1000)
+
+    const exec = () =>
+      (program.methods as any)
+        .executeProposal()
+        .accounts({
+          pot, vault, proposal: p,
+          executor: authority,
+          recipient: beneficiary.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc()
+
+    await exec()
+    await expectError(exec(), 'ProposalNotPassed')
+  })
+
+  // ── 7. cancel proposal ───────────────────────────────────────────────────
+
+  it('cancel_proposal kills a passed proposal; cancelled cannot execute', async () => {
+    const { pot, vault } = await createPot(`sec-cxl-${Date.now() % 1e6}`)
+    await deposit(pot, vault, LAMPORTS_PER_SOL)
+    const p = await passedWithdrawProposal(pot, vault, beneficiary.publicKey, 1000)
+
+    // Stranger cannot cancel.
+    await expectError(
+      (program.methods as any)
+        .cancelProposal()
+        .accounts({ pot, proposal: p, signer: stranger.publicKey })
+        .signers([stranger])
+        .rpc(),
+      'NotSentinelOrAuthority',
+    )
+
+    // Proposer (== authority here) cancels.
+    await (program.methods as any)
+      .cancelProposal()
+      .accounts({ pot, proposal: p, signer: authority })
+      .rpc()
+    const prop: any = await (program.account as any).proposalAccount.fetch(p)
+    expect(Object.keys(prop.status)[0]).to.equal('cancelled')
+
+    // Cancelled proposal cannot be executed.
+    await expectError(
+      (program.methods as any)
+        .executeProposal()
+        .accounts({
+          pot, vault, proposal: p,
+          executor: authority,
+          recipient: beneficiary.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc(),
+      'ProposalNotPassed',
+    )
+  })
+})

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -247,6 +247,106 @@ export async function fetchAllStrategyVaults(
   return accounts
 }
 
+// ── Security hardening (Phase A) helpers ─────────────────────────────────────
+//
+// Sentinel role, freeze/unfreeze, proposal cancellation, protocol allowlist
+// and the risk-param timelock. The sentinel can stop things but can never
+// move funds — there is no fund-moving instruction it is authorized for.
+
+/** Assign or clear the pot's sentinel/guardian wallet (authority only). */
+export async function buildSetSentinelTx(
+  program: Program<any>,
+  pot: PublicKey,
+  authority: PublicKey,
+  newSentinel: PublicKey | null,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .setSentinel(newSentinel)
+    .accounts({ pot, authority })
+    .transaction()
+}
+
+/** Freeze the pot — sentinel or authority. Blocks deposits, proposal
+ *  execution, swaps and new strategies. Member withdrawals stay open. */
+export async function buildFreezePotTx(
+  program: Program<any>,
+  pot: PublicKey,
+  signer: PublicKey,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .freezePot()
+    .accounts({ pot, signer })
+    .transaction()
+}
+
+/** Unfreeze the pot — authority ONLY (the sentinel cannot self-serve). */
+export async function buildUnfreezePotTx(
+  program: Program<any>,
+  pot: PublicKey,
+  authority: PublicKey,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .unfreezePot()
+    .accounts({ pot, signer: authority })
+    .transaction()
+}
+
+/** Cancel an Active/Passed proposal — sentinel, authority or proposer. */
+export async function buildCancelProposalTx(
+  program: Program<any>,
+  pot: PublicKey,
+  proposal: PublicKey,
+  signer: PublicKey,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .cancelProposal()
+    .accounts({ pot, proposal, signer })
+    .transaction()
+}
+
+/** Set the program-id allowlist for external CPI targets (max 8). */
+export async function buildSetAllowedProgramsTx(
+  program: Program<any>,
+  pot: PublicKey,
+  authority: PublicKey,
+  programs: PublicKey[],
+): Promise<Transaction> {
+  return await (program as any).methods
+    .setAllowedPrograms({ programs })
+    .accounts({ pot, authority })
+    .transaction()
+}
+
+/** Configure the risk-param timelock + per-asset exposure cap.
+ *  Tightening applies instantly; loosening waits out the current timelock. */
+export async function buildSetRiskTimelockTx(
+  program: Program<any>,
+  pot: PublicKey,
+  authority: PublicKey,
+  riskParamTimelockSecs: number,
+  maxAssetExposureBps: number,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .setRiskTimelock({
+      riskParamTimelockSecs: new BN(riskParamTimelockSecs),
+      maxAssetExposureBps,
+    })
+    .accounts({ pot, authority })
+    .transaction()
+}
+
+/** Permissionless crank: apply a staged risky-param change after its delay. */
+export async function buildApplyPendingParamsTx(
+  program: Program<any>,
+  pot: PublicKey,
+  cranker: PublicKey,
+): Promise<Transaction> {
+  return await (program as any).methods
+    .applyPendingParams()
+    .accounts({ pot, cranker })
+    .transaction()
+}
+
 // ── Analytics helpers ─────────────────────────────────────────────────────────
 
 export interface VaultAnalytics {

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -690,6 +690,11 @@
           "signer": true
         },
         {
+          "name": "recipient",
+          "writable": true,
+          "optional": true
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -717,7 +722,7 @@
           "name": "pot",
           "docs": [
             "Parent pot. Authority / agent_authority are validated dynamically",
-            "inside `authorize_mode` — we can't bind via `has_one` here because",
+            "inside `authorize_mode` \u2014 we can't bind via `has_one` here because",
             "the required signer varies by mode."
           ],
           "writable": true,
@@ -840,9 +845,9 @@
           "name": "authority",
           "docs": [
             "Signer interpretation:",
-            "AdminDirect      → must equal pot.authority",
-            "Proposal         → must equal pot.authority (Phase 2: or Member NFT)",
-            "StrategyTrigger  → must equal pot.agent_authority"
+            "AdminDirect      \u2192 must equal pot.authority",
+            "Proposal         \u2192 must equal pot.authority (Phase 2: or Member NFT)",
+            "StrategyTrigger  \u2192 must equal pot.agent_authority"
           ],
           "writable": true,
           "signer": true
@@ -1596,7 +1601,7 @@
     {
       "name": "pause_pot",
       "docs": [
-        "Emergency pause — blocks all execute_swap calls on this pot."
+        "Emergency pause \u2014 blocks all execute_swap calls on this pot."
       ],
       "discriminator": [
         240,
@@ -1625,7 +1630,7 @@
       "docs": [
         "Register (or re-register) a delegate wallet that may sign votes for this",
         "member. `rules_uri` is an off-chain URI describing the delegate's",
-        "voting policy — purely for transparency, not enforced on-chain."
+        "voting policy \u2014 purely for transparency, not enforced on-chain."
       ],
       "discriminator": [
         218,
@@ -2234,7 +2239,7 @@
         {
           "name": "voter_record",
           "docs": [
-            "VoterRecord PDA — `init` (NOT init_if_needed) means tx fails if already exists.",
+            "VoterRecord PDA \u2014 `init` (NOT init_if_needed) means tx fails if already exists.",
             "This is the on-chain double-vote prevention mechanism."
           ],
           "writable": true,
@@ -2369,8 +2374,8 @@
         {
           "name": "voter_record",
           "docs": [
-            "VoterRecord PDA — keyed by member.wallet (NOT delegate_signer.key).",
-            "`init` (not `init_if_needed`) → fails if the member or any prior",
+            "VoterRecord PDA \u2014 keyed by member.wallet (NOT delegate_signer.key).",
+            "`init` (not `init_if_needed`) \u2192 fails if the member or any prior",
             "delegate already voted on this proposal. Same double-vote prevention",
             "as the original `vote` instruction."
           ],
@@ -2497,6 +2502,358 @@
           "name": "shares",
           "type": "u64"
         }
+      ]
+    },
+    {
+      "name": "set_sentinel",
+      "discriminator": [
+        94,
+        200,
+        82,
+        129,
+        53,
+        149,
+        232,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_sentinel",
+          "type": {
+            "option": "pubkey"
+          }
+        }
+      ],
+      "docs": [
+        "Assign or clear the sentinel/guardian wallet. The sentinel can freeze the pot and cancel proposals but can NEVER move funds."
+      ]
+    },
+    {
+      "name": "freeze_pot",
+      "discriminator": [
+        214,
+        106,
+        66,
+        139,
+        63,
+        30,
+        222,
+        108
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Freeze the pot (sentinel or authority). Blocks deposits, proposal execution, swaps and strategy creation. Member withdrawals stay open."
+      ]
+    },
+    {
+      "name": "unfreeze_pot",
+      "discriminator": [
+        56,
+        13,
+        215,
+        37,
+        23,
+        228,
+        254,
+        118
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Unfreeze the pot \u2014 authority only."
+      ]
+    },
+    {
+      "name": "cancel_proposal",
+      "discriminator": [
+        106,
+        74,
+        128,
+        146,
+        19,
+        65,
+        39,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Cancel an Active or Passed proposal (sentinel, authority or proposer)."
+      ]
+    },
+    {
+      "name": "set_allowed_programs",
+      "discriminator": [
+        242,
+        240,
+        178,
+        3,
+        188,
+        33,
+        161,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetAllowedProgramsArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Set the program-id allowlist for external CPI targets."
+      ]
+    },
+    {
+      "name": "set_risk_timelock",
+      "discriminator": [
+        57,
+        91,
+        75,
+        195,
+        185,
+        80,
+        142,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetRiskTimelockArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Configure the risk-param timelock and per-asset exposure cap."
+      ]
+    },
+    {
+      "name": "apply_pending_params",
+      "discriminator": [
+        11,
+        15,
+        47,
+        58,
+        28,
+        220,
+        231,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "cranker",
+          "signer": true
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Permissionless crank: apply a staged risky-param change once its timelock has elapsed."
+      ]
+    },
+    {
+      "name": "fund_fee_reserve",
+      "discriminator": [
+        218,
+        216,
+        202,
+        40,
+        206,
+        195,
+        149,
+        71
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "FundFeeReserveArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Fund the pot's keeper-gas reserve."
+      ]
+    },
+    {
+      "name": "redeem_tokens",
+      "discriminator": [
+        246,
+        98,
+        134,
+        41,
+        152,
+        33,
+        120,
+        69
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Burn SPL share-tokens and receive SOL from the vault at NAV."
+      ]
+    },
+    {
+      "name": "route_to_yield",
+      "discriminator": [
+        82,
+        31,
+        61,
+        118,
+        105,
+        209,
+        221,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RouteToYieldArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
     }
   ],
@@ -2762,6 +3119,84 @@
         85,
         49
       ]
+    },
+    {
+      "name": "SentinelUpdated",
+      "discriminator": [
+        47,
+        118,
+        194,
+        209,
+        176,
+        50,
+        176,
+        137
+      ]
+    },
+    {
+      "name": "PotFrozenEvent",
+      "discriminator": [
+        228,
+        183,
+        174,
+        100,
+        119,
+        9,
+        61,
+        57
+      ]
+    },
+    {
+      "name": "ProposalCancelled",
+      "discriminator": [
+        253,
+        59,
+        104,
+        46,
+        129,
+        78,
+        9,
+        14
+      ]
+    },
+    {
+      "name": "AllowedProgramsUpdated",
+      "discriminator": [
+        114,
+        253,
+        112,
+        200,
+        132,
+        74,
+        185,
+        113
+      ]
+    },
+    {
+      "name": "PendingParamsApplied",
+      "discriminator": [
+        197,
+        32,
+        230,
+        125,
+        18,
+        42,
+        85,
+        234
+      ]
+    },
+    {
+      "name": "YieldRouted",
+      "discriminator": [
+        10,
+        238,
+        211,
+        233,
+        196,
+        63,
+        203,
+        70
+      ]
     }
   ],
   "errors": [
@@ -2883,7 +3318,7 @@
     {
       "code": 6023,
       "name": "TimelockNotExpired",
-      "msg": "Timelock period has not elapsed — wait before executing this proposal"
+      "msg": "Timelock period has not elapsed \u2014 wait before executing this proposal"
     },
     {
       "code": 6024,
@@ -2963,7 +3398,7 @@
     {
       "code": 6039,
       "name": "ProposalMismatch",
-      "msg": "Proposal mismatch — proposal_id or pot does not match attached spec"
+      "msg": "Proposal mismatch \u2014 proposal_id or pot does not match attached spec"
     },
     {
       "code": 6040,
@@ -3079,6 +3514,96 @@
       "code": 6062,
       "name": "MathOverflow",
       "msg": "Arithmetic overflow during fixed-point math"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidBurnAmount",
+      "msg": "Burn amount must be > 0"
+    },
+    {
+      "code": 6064,
+      "name": "InsufficientReserve",
+      "msg": "Redemption would violate 20% reserve guard"
+    },
+    {
+      "code": 6065,
+      "name": "RedemptionPausedWhilePotPaused",
+      "msg": "Cannot redeem while pot is paused"
+    },
+    {
+      "code": 6066,
+      "name": "RedemptionInsufficientVault",
+      "msg": "Insufficient vault balance for redemption"
+    },
+    {
+      "code": 6067,
+      "name": "YieldTargetNoneNotRoutable",
+      "msg": "YieldTarget None is not routable"
+    },
+    {
+      "code": 6068,
+      "name": "WithdrawalReserveBreached",
+      "msg": "Redemption exceeds 80% vault liquidity reserve"
+    },
+    {
+      "code": 6069,
+      "name": "PotPaused",
+      "msg": "Pot is paused -- redemptions blocked"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidAmount",
+      "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 6071,
+      "name": "NotSentinelOrAuthority",
+      "msg": "Signer is neither the pot authority nor the sentinel"
+    },
+    {
+      "code": 6072,
+      "name": "PotFrozen",
+      "msg": "Pot is frozen \u2014 this action is blocked until unfreeze"
+    },
+    {
+      "code": 6073,
+      "name": "SentinelCannotUnfreeze",
+      "msg": "Only the pot authority can unfreeze the pot"
+    },
+    {
+      "code": 6074,
+      "name": "ProposalNotCancellable",
+      "msg": "Proposal is not in a cancellable state"
+    },
+    {
+      "code": 6075,
+      "name": "RecipientMismatch",
+      "msg": "Recipient account does not match the proposal beneficiary"
+    },
+    {
+      "code": 6076,
+      "name": "RecipientMissing",
+      "msg": "Recipient account is required for this proposal type"
+    },
+    {
+      "code": 6077,
+      "name": "PendingChangeNotReady",
+      "msg": "Pending parameter change has not reached effective_at yet"
+    },
+    {
+      "code": 6078,
+      "name": "NoPendingChange",
+      "msg": "No pending parameter change staged for this pot"
+    },
+    {
+      "code": 6079,
+      "name": "ProgramNotAllowed",
+      "msg": "Program is not in the pot's protocol allowlist"
+    },
+    {
+      "code": 6080,
+      "name": "AssetExposureExceeded",
+      "msg": "Daily exposure cap for this asset exceeded"
     }
   ],
   "types": [
@@ -3289,7 +3814,7 @@
           {
             "name": "min_out",
             "docs": [
-              "Minimum acceptable output — hard floor enforced on-chain."
+              "Minimum acceptable output \u2014 hard floor enforced on-chain."
             ],
             "type": "u64"
           },
@@ -3303,7 +3828,7 @@
           {
             "name": "is_entry",
             "docs": [
-              "Entry (Pending→Active) or exit (Active/Parked→Closed)."
+              "Entry (Pending\u2192Active) or exit (Active/Parked\u2192Closed)."
             ],
             "type": "bool"
           },
@@ -3479,7 +4004,7 @@
             "name": "rules_uri",
             "docs": [
               "IPFS / Arweave / https URI describing the agent's voting policy.",
-              "On-chain program does NOT enforce this — it's a transparency artefact",
+              "On-chain program does NOT enforce this \u2014 it's a transparency artefact",
               "that lets other members audit the AI's behaviour and revoke if needed."
             ],
             "type": "string"
@@ -3696,7 +4221,7 @@
             "name": "agent_authority",
             "docs": [
               "Keeper agent authority for StrategyTrigger mode.",
-              "This is the keeper's hot wallet pubkey — separate from agent_pubkey.",
+              "This is the keeper's hot wallet pubkey \u2014 separate from agent_pubkey.",
               "Set via set_allowed_mints."
             ],
             "type": "pubkey"
@@ -3764,6 +4289,68 @@
               "Keeper gas reserve (lamports). Keeper draws from this for trigger gas."
             ],
             "type": "u64"
+          },
+          {
+            "name": "sentinel",
+            "docs": [
+              "Optional sentinel/guardian wallet. Can freeze the pot and cancel proposals; has NO instruction that can move funds."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "risk_param_timelock_secs",
+            "docs": [
+              "Timelock (seconds) applied when a risky governance parameter is LOOSENED. 0 = disabled."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "pending_params",
+            "docs": [
+              "Staged loosening change awaiting its timelock."
+            ],
+            "type": {
+              "defined": {
+                "name": "PendingRiskParams"
+              }
+            }
+          },
+          {
+            "name": "allowed_programs",
+            "docs": [
+              "Program-id allowlist for external CPI targets. count == 0 = open mode."
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                8
+              ]
+            }
+          },
+          {
+            "name": "allowed_programs_count",
+            "type": "u8"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "docs": [
+              "Max cumulative daily spend toward one output mint, bps of vault. 0 = unlimited."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "per_mint_daily_spent",
+            "docs": [
+              "Daily spend per allowed_mints slot."
+            ],
+            "type": {
+              "array": [
+                "u64",
+                16
+              ]
+            }
           }
         ]
       }
@@ -3868,7 +4455,7 @@
           {
             "name": "passed_at",
             "docs": [
-              "Timestamp when proposal transitioned to Passed — used for timelock enforcement.",
+              "Timestamp when proposal transitioned to Passed \u2014 used for timelock enforcement.",
               "0 if not yet passed."
             ],
             "type": "i64"
@@ -3927,6 +4514,9 @@
           },
           {
             "name": "Expired"
+          },
+          {
+            "name": "Cancelled"
           }
         ]
       }
@@ -3959,14 +4549,14 @@
           {
             "name": "max_in",
             "docs": [
-              "Maximum input the executor may spend. Enforced on-chain: spent ≤ max_in."
+              "Maximum input the executor may spend. Enforced on-chain: spent \u2264 max_in."
             ],
             "type": "u64"
           },
           {
             "name": "min_out",
             "docs": [
-              "Minimum output the executor must receive. Enforced: received ≥ min_out."
+              "Minimum output the executor must receive. Enforced: received \u2265 min_out."
             ],
             "type": "u64"
           },
@@ -3980,7 +4570,7 @@
           {
             "name": "price_feed_id",
             "docs": [
-              "Optional Pyth feed id — if set, execute_swap verifies execution price",
+              "Optional Pyth feed id \u2014 if set, execute_swap verifies execution price",
               "is within oracle_deviation_bps of the oracle mid at execution time."
             ],
             "type": {
@@ -4996,7 +5586,7 @@
       "docs": [
         "Tracks that a specific wallet has already voted on a specific proposal.",
         "PDA: [b\"voter\", proposal_pubkey, voter_pubkey]",
-        "Using `init` (not `init_if_needed`) means the tx fails if this already exists —",
+        "Using `init` (not `init_if_needed`) means the tx fails if this already exists \u2014",
         "which is exactly the double-vote prevention mechanism."
       ],
       "type": {
@@ -5173,6 +5763,251 @@
                 "type": "pubkey"
               }
             ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingRiskParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_pending",
+            "type": "bool"
+          },
+          {
+            "name": "effective_at",
+            "type": "i64"
+          },
+          {
+            "name": "trade_level",
+            "type": "u8"
+          },
+          {
+            "name": "withdraw_level",
+            "type": "u8"
+          },
+          {
+            "name": "max_trade_size_bps",
+            "type": "u16"
+          },
+          {
+            "name": "single_swap_cap_bps",
+            "type": "u16"
+          },
+          {
+            "name": "daily_budget_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "risk_param_timelock_secs",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetAllowedProgramsArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "programs",
+            "type": {
+              "vec": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetRiskTimelockArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "risk_param_timelock_secs",
+            "type": "i64"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FundFeeReserveArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SentinelUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "sentinel",
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PotFrozenEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "by",
+            "type": "pubkey"
+          },
+          {
+            "name": "frozen",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCancelled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal_id",
+            "type": "u64"
+          },
+          {
+            "name": "by",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllowedProgramsUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "count",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingParamsApplied",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "applied_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RouteToYieldArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "yield_target",
+            "type": {
+              "defined": {
+                "name": "YieldRouteTarget"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldRouteTarget",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Kamino"
+          },
+          {
+            "name": "MeteoraStable"
+          },
+          {
+            "name": "MeteoraDynamic"
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldRouted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "target",
+            "type": {
+              "defined": {
+                "name": "YieldRouteTarget"
+              }
+            }
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "executed",
+            "type": "bool"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }


### PR DESCRIPTION
## Что это

Phase A+B мастер-плана: хардненинг `pot_vault` перед mainnet + полный тестовый гейт. **14 тестов зелёные на localnet** (7 новых security-сценариев), web lint+build чистые.

## 🔴 Критические фиксы (найдены в ходе работ)

1. **Governance-выплаты уходили любому исполнителю.** `execute_proposal` для `Withdraw`/`TransferFunds` переводил лампорты на `executor` (любой подписант!), а beneficiary только логировался. Теперь обязательный аккаунт `recipient`, валидируемый против пропозала.
2. **Выплаты из волта вообще не работали он-чейн.** `withdraw` и `execute_proposal` дебетовали System-owned PDA напрямую (`try_borrow_mut_lamports`) — рантайм такое запрещает. Заменено на seeds-signed CPI (паттерн `redeem_tokens`). Та же бага в `tokenize_shares` (фикс).
3. **12 инструкций превышали лимит стека 4KB** (UB-риск) — `Box<Account<PotAccount>>` повсюду; остался один доисторический оффендер `mint_tamagotchi_nft` (6288→4848, нужен сплит инструкции — post-hackathon).

## Новое в программе

- **Sentinel-роль**: `set_sentinel` / `freeze_pot` (sentinel|authority) / `unfreeze_pot` (только authority) / `cancel_proposal` (sentinel|authority|proposer). У стража нет ни одной fund-moving инструкции.
- **Заморозка** блокирует deposit, execute_proposal, execute_swap, create_strategy, route_to_yield. **Выход членов (withdraw + redeem_tokens) не блокируется никогда** — non-custodial инвариант.
- **Timelock на ослабление риск-параметров**: ужесточение мгновенно, ослабление ждёт `risk_param_timelock_secs` в `pending_params` + permissionless `apply_pending_params`.
- **Per-protocol allowlist** (`set_allowed_programs`, до 8 program-id) + **per-asset дневной кап экспозиции** (`max_asset_exposure_bps`, слоты `allowed_mints`).
- Подключена ранее не экспонированная `fund_fee_reserve`.

## SDK / IDL

- IDL-генерация Anchor 0.30.1 сломана на rustc≥1.85 → `scripts/patch_idl.py` детерминированно расширяет IDL (алгоритм дискриминаторов само-проверен на всех 48 существующих записях). IDL также получил `redeem_tokens`/`route_to_yield` и 18 error-кодов, отсутствовавших с мая.
- `client.ts`: типизированные билдеры для sentinel/freeze/cancel/allowlist/timelock.

## ⚠️ Layout

`PotAccount` вырос (~+460 байт) — существующие devnet-поты несовместимы, нужен redeploy devnet + пересоздание сид-потов. Mainnet ещё не задеплоен — миграция не требуется.

## Аудит

Прогнан adversarial-проход по чек-листу `solana-security-review`: 0 Critical, 1 High (закрыт: freeze блокировал redeem-выход), 2 Medium (закрыты: сброс счётчиков экспозиции; документирована SOL-деноминация капов), 2 Low (закрыты/документированы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)