### PR TITLE
docs: Phases D+E+F — investor readiness, GTM plan, mainnet gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The vault is a Solana program account from day one — no custodian, no operator
 A POT is a program-controlled treasury on Solana. Members deposit SOL, USDC, LSTs, LP positions or any tokenized asset, and receive proportional shares (NAV-priced). Every change to the treasury — swap, withdrawal, settings update — is a proposal that members vote on. The vault PDA signs the execution.
 
 - **Programmable ownership** — SPL-tokenized shares, redeemable any time
-- **Onchain governance** — five levels from Autocracy (L0) to Consensus (L4), plus optional risk caps (`max_swap_pct`, `max_budget_grant_pct`, `require_admin_cosign`, `timelock_seconds`)
+- **Onchain governance** — five levels from Autocracy (L0) to Consensus (L4), plus optional risk caps (`max_swap_pct`, `max_budget_grant_pct`, `require_admin_cosign`, `timelock_seconds`) and one-click presets (😎 Chill · ⚖️ Balanced · 🏛 Institutional)
+- **Security layer** — optional sentinel/guardian wallet (can freeze a pot and cancel proposals, can never move funds), risk-param timelock (loosening changes wait, tightening is instant), per-protocol CPI allowlist, per-asset daily exposure caps. Member exits are never blockable — withdraw and share redemption stay open even while frozen
 - **AI orchestration** — the BOT proposes, executes once quorum is reached, and can be delegated to vote on rules you set
 - **Composable** — Jupiter v6 / Ultra swaps, Squads v4 multisig authority, MCP for any AI agent, Solana Blinks for tweet-native deposits and votes
 - **Identity** — every POT can claim a `<name>.potbot.sol` SNS subdomain
@@ -118,12 +119,26 @@ https://potbot.fun/api/actions/<potPubkey>/vote
 
 ---
 
-## Revenue model
+## Monetization
+
+**Subscriptions** — [potbot.fun/pricing](https://potbot.fun/pricing):
+
+| Tier | Price | Highlights |
+|---|---|---|
+| 🌱 Early Supporter | Free during beta | Unlimited pots & members, manual proposals, basic governance |
+| ⚡ Pro | $29/mo | AI Agent automation, Strategy Autopilot, visual customization, priority support |
+| 🏆 Pro+ | $99/mo | Everything in Pro, unlimited members, custom governance, white-label, dedicated RPC |
+
+Stripe checkout is wired behind `NEXT_PUBLIC_STRIPE_KEY`; paid billing activates alongside the mainnet launch.
+
+**Protocol fees** — accrue to the PotBot treasury (not to validators or the network):
 
 | Stream | Rate | Status |
 |---|---|---|
-| Swap fee | 0.30% on every trade routed through a pot | 🟢 Live |
-| Performance fee | 10% on Strategy Vault returns, split with strategy creator | 🟡 Devnet |
+| Pot creation fee | 0.01 SOL, charged onchain in `create_pot` | 🟡 Devnet |
+| Swap fee | 0.30% on every trade routed through a pot | 🟡 Devnet |
+| Strategy Vault entry fee | 20% protocol share (70% to the strategy creator, 10% to the referrer) | 🟡 Devnet |
+| Performance fee | 25% protocol share — the creator sets the rate per vault (capped at 50%) | 🟡 Devnet |
 
 No token, no airdrop farming.
 
@@ -195,9 +210,14 @@ Set `NEXT_PUBLIC_PRIVY_APP_ID` to enable email / Google / Twitter / LinkedIn log
 
 ## Current status
 
+🟢 live · 🟡 devnet · 🔵 Phase 2 Q3'26 · 🟣 Phase 3 Q4'26 · ⚪ vision
+
 | Layer | Status |
 |---|---|
 | `pot_vault` Anchor program (30+ instructions: deposit · propose · vote · execute_swap) | 🟡 Devnet live |
+| Sentinel/guardian role — `freeze_pot` / `cancel_proposal`; member exits never blocked | 🟡 Devnet (pending redeploy) |
+| Risk-param timelock — loosening staged, applied via permissionless `apply_pending_params` | 🟡 Devnet (pending redeploy) |
+| Per-protocol CPI allowlist (8 slots) + per-asset daily exposure caps | 🟡 Devnet (pending redeploy) |
 | Jupiter v6 / Ultra swap CPI (vault PDA signer) | 🟡 Devnet live |
 | Solana Blinks (deposit + vote endpoints) | 🟢 Live |
 | MCP server `@potbot/mcp@0.2.0` on npm (18 tools, x402 paid tier) | 🟢 Live |
@@ -212,13 +232,18 @@ Set `NEXT_PUBLIC_PRIVY_APP_ID` to enable email / Google / Twitter / LinkedIn log
 | Normie mode — Privy email / Google / Twitter / LinkedIn + embedded Solana wallet | 🟢 Live |
 | Light theme + plain-English copy + USD-first prices | 🟢 Live |
 | Account dashboard (profile · live SOL balance · Add SOL airdrop · Quick Trade) | 🟢 Live |
+| `/learn` education page + `/pricing` (Free beta · Pro $29 · Pro+ $99) | 🟢 Live |
+| Governance presets — 😎 Chill / ⚖️ Balanced / 🏛 Institutional | 🟢 Live |
+| Proposal card v2 (risk check · quorum bar · countdown) + trust surfaces (vault PDA + explorer, frozen/sentinel chips) | 🟢 Live |
 | `pot_duel` program — 1v1 vault challenges (unlocks at Bud stage) | 🟡 Devnet live |
 | Pyth in-program oracle guard (re-reads price feeds inside `execute_swap`) | 🔵 Phase 2 |
 | Meteora DLMM + Kamino yield strategies | 🔵 Phase 2 |
 | Light Protocol ZK-compressed audit log | 🔵 Phase 2 |
 | Tamagotchi NFT mint (Bloom unlock, Metaplex) | 🟣 Phase 3 |
 | STAMPPOT privacy mode (PrivacyCash ZK proofs) | 🟣 Phase 3 |
-| Mainnet deploy | 🔵 Post security pass |
+| Mainnet deploy | 🔵 Security pass done (14 localnet tests green, 7 security scenarios) — blocked on deployer + executor wallet funding |
+
+Devnet program: `GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK`. Devnet pots were recreated after the security hardening grew the `PotAccount` layout.
 
 Every feature with its lifecycle chip: [potbot.fun/roadmap](https://potbot.fun/roadmap)
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PotBot is a **group trading vault platform** on Solana. Members pool SOL, govern collective trades via on-chain proposals, and earn yield together. A Tamagotchi mascot evolves with the vault's performance.
+PotBot is a **group trading vault platform** on Solana. Members pool SOL, govern collective trades via on-chain proposals, and earn yield together. A Money Tree mascot (Season 1) evolves with the vault's performance.
 
 The system is designed in three layers:
 
@@ -13,9 +13,9 @@ The system is designed in three layers:
                  │ browser / Telegram
 ┌────────────────▼─────────────────────────────┐
 │          Application Layer                    │
-│  Next.js DApp (app.potbot.fun)               │
-│  Telegram Bot (grammy)                        │
-│  Landing Page (potbot.fun)                   │
+│  Next.js DApp + API (potbot.fun)             │
+│  MCP server (@potbot/mcp — AI agents)        │
+│  Solana Blinks (deposit / vote in-tweet)     │
 └────────────────┬─────────────────────────────┘
                  │ Anchor SDK / @solana/web3.js
 ┌────────────────▼─────────────────────────────┐
@@ -66,7 +66,7 @@ When a vote tips past the required threshold (configurable per governance level)
 
 The DApp auto-detects whether the on-chain program is deployed by checking if the program account is executable. If not, it falls back to a Zustand in-memory store with realistic seed data. This means the UI is always usable — even before devnet deploy.
 
-See [MOCK_MODE.md](MOCK_MODE.md) for details.
+Implementation: `apps/web/src/lib/mock-store.ts` (auto-switch lives in `apps/web/src/hooks/usePots.ts`).
 
 ---
 
@@ -146,9 +146,9 @@ apps/web/src/
 
 ---
 
-## Tamagotchi XP System
+## Money Tree XP System
 
-XP is calculated off-chain from on-chain stats and displayed in the UI. It will be persisted on-chain via the `update_tamagotchi` instruction (permissionless crank).
+XP is calculated off-chain from on-chain stats and displayed in the UI. It will be persisted on-chain via the `update_tamagotchi` instruction (permissionless crank — the historical instruction/field names keep the Tamagotchi prefix for ABI stability).
 
 ```
 totalXP = volumeXP + memberXP + winXP + yieldXP + ageXP
@@ -160,13 +160,13 @@ where:
   yieldXP   = annualYieldPct * 100
   ageXP     = daysAlive * 5
 
-Evolution stages:
-  Egg    🥚  [0, 100)
-  Chick  🐣  [100, 500)
-  Baby   🐤  [500, 2000)
-  Eagle  🦅  [2000, 8000)
-  Dragon 🐉  [8000, 25000)
-  Legend 👑  [25000, ∞)
+Evolution stages (Season 1 — Plants):
+  Seedling    🌱  [0, 100)
+  Sprout      🌿  [100, 500)
+  Bud         🌳  [500, 2000)
+  Bloom       🌺  [2000, 8000)
+  Full Bloom  🌸  [8000, 25000)
+  Mature Tree 🌴  [25000, ∞)
 ```
 
 ---
@@ -176,14 +176,20 @@ Evolution stages:
 - **Re-entrancy**: Not possible in Solana's account model (no recursive CPIs in v1)
 - **Signer checks**: Every instruction verifies `authority` or `member.wallet` is a signer
 - **PDA ownership**: All accounts are `init`-ed with `seeds` — cannot be spoofed
-- **Slippage on swaps**: Proposal includes `min_out_amount`; CPI reverts if unmet
+- **Vault transfers**: lamports leave the vault PDA only via seeds-signed system-program transfers; fund-moving proposals pay the recorded beneficiary, never the executor
+- **Slippage on swaps**: Proposal includes `min_out_amount`; CPI reverts if unmet — plus a program-wide 5% slippage ceiling
 - **Governance bypass**: `execute_proposal` checks `status == Passed` on-chain
+- **Sentinel circuit-breaker**: optional guardian wallet can freeze the pot and cancel proposals but can never move funds; member exits (`withdraw`, `redeem_tokens`) stay open even while frozen
+- **Risk-param timelock**: loosening governance/risk parameters is staged and applied only after a delay via permissionless `apply_pending_params`; tightening applies instantly
+- **CPI + asset guards**: per-pot program-id allowlist (8 slots) for external CPI targets, mint allowlist, per-swap size cap, daily budget, and per-asset daily exposure caps
+
+Details: [`program.md` § Security layer](program.md#security-layer-sentinel--freeze--timelocks--allowlists).
 
 ---
 
-## Future: POT Duels
+## POT Duels
 
-A separate `pot_duel` program (planned Week 2) introduces:
+A separate `pot_duel` program (devnet; unlocks at the Bud stage) introduces:
 - Two vaults stake a % of their SOL into an escrow PDA
 - Both vaults trade freely for N hours
 - A Pyth oracle CPI determines final P&L

--- a/docs/architecture/governance.md
+++ b/docs/architecture/governance.md
@@ -22,6 +22,8 @@ Each POT configures two independent governance levels at creation:
 
 Most vaults will use **L2 Majority** as a balance of speed and democracy. Institutional pots and family offices typically pick **L3 Supermajority** + the optional timelock.
 
+The create flow ships three one-click presets — 😎 **Chill**, ⚖️ **Balanced**, 🏛 **Institutional** — that bundle trade/withdraw levels, quorum, timelock and max-swap caps. Full mapping in [`docs/product/governance-presets.md`](../product/governance-presets.md).
+
 ### Optional risk caps (stackable on any level)
 
 Set in `GovernanceConfig` at pot creation, changeable later by governance proposal:
@@ -30,6 +32,19 @@ Set in `GovernanceConfig` at pot creation, changeable later by governance propos
 - `max_budget_grant_pct` — no budget grant may exceed X% of vault balance
 - `require_admin_cosign` — proposals above a configurable threshold require the authority to co-sign before execution (does not override the vote; just adds a second signature gate)
 - `timelock_seconds` — after a proposal passes, execution is delayed by N seconds (cooling-off / unwind window)
+
+### Risk-param timelock (asymmetric)
+
+On top of the per-proposal timelock, the pot can configure `risk_param_timelock_secs` — a delay that applies to changes of the risk parameters themselves (approval levels, swap-size caps, daily budget, the timelock itself):
+
+- **Tightening applies instantly** — raising approval levels or lowering caps never waits.
+- **Loosening is staged** in `pot.pending_params` and only takes effect after the delay, via the **permissionless** `apply_pending_params` instruction. Anyone can crank it; nobody can fast-track it.
+
+This closes the "vote once to remove the guardrails, then drain" pattern: members always get the full timelock window to exit before looser rules take effect. Semantics in [`program.md` § Security layer](program.md#security-layer-sentinel--freeze--timelocks--allowlists).
+
+### Sentinel / guardian
+
+The pot authority can register one **sentinel** wallet (`set_sentinel`) — a circuit-breaker that can `freeze_pot` (sentinel or authority; only the authority can unfreeze) and `cancel_proposal` (sentinel, authority, or the proposer), but has **no instruction that can move funds**. A frozen pot blocks deposits, proposal execution, swaps and strategy creation — while member `withdraw` and `redeem_tokens` stay open unconditionally. Cancelled proposals land in the terminal `Cancelled` status.
 
 ---
 
@@ -68,7 +83,10 @@ create_proposal()
     │                               │
     │                           Rejected
     │
-    └─── expires_at reached ──▶ Rejected (permissionless close)
+    ├─── expires_at reached ──▶ Rejected (permissionless close)
+    │
+    └─── cancel_proposal() ───▶ Cancelled (terminal — sentinel, authority, or proposer;
+                                 also possible from Passed, before execution)
 ```
 
 ---
@@ -182,7 +200,7 @@ Proposal: "[BUDGET GRANT] 5 SOL → wallet.sol for 30d · marketing campaign"
   purpose:   "Marketing Q3 2026"
 ```
 
-Subject to `max_budget_grant_pct` cap if set.
+Subject to `max_budget_grant_pct` cap if set. On execution the payout goes to the **beneficiary recorded in the proposal** via a seeds-signed vault transfer — the executor only cranks the instruction and must pass a `recipient` account matching the beneficiary (`RecipientMismatch` otherwise).
 
 ### Custom
 

--- a/docs/architecture/program.md
+++ b/docs/architecture/program.md
@@ -1,9 +1,13 @@
 # Solana Program Reference — `pot_vault`
 
-Program ID (devnet, placeholder — update after mainnet deploy):
+Program ID (devnet — a fresh keypair will be generated for mainnet):
 ```
-Hyi1PNxPMUqwdDukhB2a4fvcBxQHmbXy3CZ95mgyFHA3
+GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK
 ```
+
+> **Account-layout note (June 2026):** the security hardening pass added new fields to `PotAccount` (sentinel, risk-param timelock, pending params, program allowlist, exposure counters — see [Security layer](#security-layer-sentinel--freeze--timelocks--allowlists)). The account grew, so pre-existing devnet pots were incompatible and have been recreated against the new layout.
+>
+> **IDL workflow:** Anchor's IDL generation is broken on modern toolchains for this program — build with `anchor build --no-idl`, then run `scripts/patch_idl.py` to produce the client IDL.
 
 > This file documents **`packages/program/programs/pot_vault`** — the core Anchor program that owns every POT vault. A companion program `pot_duel` covers 1v1 duel vaults (not fully documented here yet; unlocks at Bloom+). See [OVERVIEW.md](OVERVIEW.md) for the full product context.
 
@@ -36,6 +40,19 @@ Stores the full configuration, stats and Money Tree state of a vault.
 | `created_at` | `i64` | Unix timestamp |
 | `bump` | `u8` | PDA bump seed |
 
+**Security-hardening fields** (added June 2026 — see [Security layer](#security-layer-sentinel--freeze--timelocks--allowlists)):
+
+| Field | Type | Description |
+|---|---|---|
+| `paused` | `bool` | Frozen flag. Set by `freeze_pot` (sentinel or authority), cleared by `unfreeze_pot` (authority only) |
+| `sentinel` | `Option<Pubkey>` | Optional guardian wallet. Can freeze the pot and cancel proposals; has **no** instruction that can move funds |
+| `risk_param_timelock_secs` | `i64` | Delay applied when a risky governance parameter is *loosened*. Tightening applies instantly. `0` = disabled |
+| `pending_params` | `PendingRiskParams` | Staged loosening change awaiting its timelock; applied by the permissionless `apply_pending_params` |
+| `allowed_programs` | `[Pubkey; 8]` | Program-id allowlist for external CPI targets (Jupiter, yield protocols). `allowed_programs_count == 0` = open mode |
+| `allowed_programs_count` | `u8` | Number of used allowlist slots |
+| `max_asset_exposure_bps` | `u16` | Max cumulative *daily* spend toward any single output mint, as bps of vault balance. `0` = unlimited |
+| `per_mint_daily_spent` | `[u64; 16]` | Daily spend tracked per `allowed_mints` slot; resets with the UTC-day window |
+
 ### `MemberAccount`
 
 One per (POT × wallet) pair.
@@ -64,7 +81,7 @@ One per governance proposal.
 | `description` | `String` | Human-readable description |
 | `yes_votes` | `u64` | Share-weighted yes votes |
 | `no_votes` | `u64` | Share-weighted no votes |
-| `status` | `ProposalStatus` | Active / Passed / Rejected / Executed |
+| `status` | `ProposalStatus` | Active / Passed / Rejected / Executed / Expired / Cancelled (terminal — set by `cancel_proposal`) |
 | `risk_class` | `u8` | 0 = normal, 1 = defensive-only (set automatically when pot is in low-HP risk mode) |
 | `created_at` | `i64` | Unix timestamp |
 | `expires_at` | `i64` | Auto-reject deadline |
@@ -90,7 +107,7 @@ Records a member's decision to let an AI agent wallet vote on their behalf in a 
 
 ```typescript
 import { PublicKey } from '@solana/web3.js'
-const PROGRAM_ID = new PublicKey('Hyi1PNxPMUqwdDukhB2a4fvcBxQHmbXy3CZ95mgyFHA3')
+const PROGRAM_ID = new PublicKey('GJap9DjUoKZ9dhXMqGCPTeTzY6kPyBJ51SXL1pi8AmiK')
 
 // POT config account
 const [potPDA] = PublicKey.findProgramAddressSync(
@@ -197,6 +214,8 @@ else:
 ```
 
 Side effects: updates `peak_balance`, recomputes `health_hp` via the crank-style inline update, resets `is_dead = false` if it was true (for resurrection path).
+
+Blocked while the pot is frozen (`PotFrozen`) — a frozen pot accepts no new capital. `withdraw` (below) deliberately has **no** freeze check: member exit is never blockable.
 
 ---
 
@@ -353,6 +372,10 @@ Execute a `Passed` proposal. For `ExecuteSwap`, this performs a Jupiter CPI from
 
 Side effects: increments `trade_count`, updates `peak_balance` if post-swap valuation is higher, recomputes `health_hp`.
 
+**Fund-moving proposals pay the beneficiary, never the executor.** For `Withdraw` / `TransferFunds` actions the caller must pass a `recipient` account that exactly matches the beneficiary recorded in the proposal (`RecipientMismatch` otherwise); lamports leave the vault via a seeds-signed system-program transfer. (Earlier builds paid the executor and used a direct lamport debit that the runtime rejects for System-owned PDAs — both fixed in the June 2026 hardening pass.)
+
+Blocked while the pot is frozen (`PotFrozen`).
+
 ---
 
 ### `update_tamagotchi` — 🟡 planned Q2 2026
@@ -402,6 +425,59 @@ Implemented in a sibling sub-module `strategy_vault/` inside `pot_vault`. Full s
 - `join_strategy_vault` — ✅ implemented (with on-chain 2-level referral)
 - `exit_strategy_vault` — ✅ implemented (with performance fee on profit)
 - `evolve_tamagotchi` — 🟡 planned (same crank semantics as `update_tamagotchi` but evaluates Strategy-specific thresholds)
+
+---
+
+## Security layer (sentinel · freeze · timelocks · allowlists)
+
+Added in the June 2026 hardening pass — ✅ implemented, 14 tests green on localnet (7 dedicated security scenarios). Devnet redeploy pending.
+
+### Sentinel / guardian role
+
+A pot's authority can assign one optional **sentinel** wallet. The sentinel is a pure circuit-breaker: it can stop things, but there is *no* instruction through which it can move funds.
+
+| Instruction | Who can call | Effect |
+|---|---|---|
+| `set_sentinel(Option<Pubkey>)` | authority | Assign or clear the sentinel wallet |
+| `freeze_pot` | sentinel **or** authority | Sets `pot.paused = true` |
+| `unfreeze_pot` | authority **only** (`SentinelCannotUnfreeze`) | Clears `pot.paused` |
+| `cancel_proposal` | sentinel, authority, or the proposer | Moves an `Active`/`Passed` proposal to `Cancelled` (terminal) |
+
+### Freeze surface — what's blocked vs always open
+
+| While frozen | Status |
+|---|---|
+| `deposit` (new capital in) | ❌ blocked (`PotFrozen`) |
+| `execute_proposal` (incl. payouts to third parties) | ❌ blocked |
+| `execute_swap` | ❌ blocked |
+| `create_strategy` | ❌ blocked |
+| `withdraw` (member pro-rata exit) | ✅ **always open** |
+| `redeem_tokens` (tokenized-share exit) | ✅ **always open** |
+
+Non-custodial exit is the invariant: neither the authority nor the sentinel can ever trap a member's funds. Freeze stops capital coming *in* and funds moving *out to third parties* — never a member's own exit.
+
+### Risk-param timelock
+
+`risk_param_timelock_secs` (configured via `set_risk_timelock`) governs changes to the risky parameters: `trade_level`, `withdraw_level`, `max_trade_size_bps`, `single_swap_cap_bps`, `daily_budget_lamports`, and the timelock itself.
+
+- **Tightening applies instantly** (raising approval levels, lowering caps, raising the timelock).
+- **Loosening is staged** into `pot.pending_params` with `effective_at = now + timelock`, replacing any previously staged change. A fully-tightening change clears any stale staged loosening.
+- **`apply_pending_params`** is a permissionless crank — anyone can apply the staged change once `effective_at` has passed (`PendingChangeNotReady` before that, `NoPendingChange` if nothing is staged).
+- With timelock `0` (disabled) everything applies immediately. Lowering the timelock is itself a loosening change and waits out the *current* timelock.
+
+The same stage-or-apply path is used whether the change comes from admin instructions (`set_spending_policy`, `set_risk_timelock`) or from governance proposals (`ChangeSettings`, `UpdateRiskConfig`).
+
+### Per-protocol program allowlist
+
+`set_allowed_programs` (authority) stores up to **8 program ids** that execute paths may CPI into. An empty list = open mode (backward compatible). Once non-empty, *every* CPI target must be listed — including Jupiter v6, or every swap reverts with `ProgramNotAllowed`; clients should auto-include Jupiter.
+
+### Per-asset daily exposure caps
+
+`max_asset_exposure_bps` (set via `set_risk_timelock`) caps the cumulative *daily* spend toward any single output mint at X bps of the vault balance, tracked per `allowed_mints` slot in `per_mint_daily_spent` (shared UTC-day window with the daily budget). Enforced on strategy **entries only** — exits reduce exposure and are never blocked. Requires the mint allowlist to be configured; counters reset whenever the mint list changes. Known limitation: amounts are compared in input-mint base units vs a lamport-denominated cap, so the cap is faithful for wSOL-denominated entries; token→token strategies need oracle normalization (Phase 2).
+
+### New error codes
+
+`NotSentinelOrAuthority` · `PotFrozen` · `SentinelCannotUnfreeze` · `ProposalNotCancellable` · `RecipientMismatch` · `RecipientMissing` · `PendingChangeNotReady` · `NoPendingChange` · `ProgramNotAllowed` · `AssetExposureExceeded`
 
 ---
 

--- a/docs/operations/READINESS.md
+++ b/docs/operations/READINESS.md
@@ -1,0 +1,44 @@
+# Mainnet Readiness — pot_vault
+
+*Status as of 2026-06-10. Companion to `docs/operations/deploy.md` (runbook) and
+`docs/operations/POTBOT_DEPLOY_PROMPT.md` (the deploy session). Update this file as items close.*
+
+**Bottom line: deploy is blocked ONLY by wallet funding (~5 SOL) and three 10-minute owner decisions (program keypair, upgrade authority, RPC key). Everything code-side is done.**
+
+---
+
+## Pre-flight checklist (from deploy.md §1)
+
+| # | Item | Status | Owner / next action |
+|---|---|---|---|
+| 1 | `anchor build` clean | ✅ DONE | `anchor build --no-idl` clean on rustc 1.86; 1 known stack warning in `mint_tamagotchi_nft` (pre-existing, improved 6288→4848 bytes, cosmetic premium feature — split instruction post-launch) |
+| 2 | `anchor test` green incl. security tests | ✅ DONE | 14 passing on localnet: sentinel/freeze, risk-param timelock, caps, double-execute, recipient enforcement, NAV/redeem, PDA snapshot (PR #69) |
+| 3 | Security review — no Critical/High open | ✅ DONE | Adversarial pass on `solana-security-review` checklist: 0 Critical; 1 High + 2 Medium found and fixed in PR #69; formal third-party audit planned post-launch |
+| 4 | `declare_id!` matches mainnet program keypair | ❌ TODO | **YD**: `solana-keygen new -o target/deploy/pot_vault-mainnet.json` → update `declare_id!` + `Anchor.toml [programs.mainnet]` → rebuild (deploy-mainnet.sh auto-syncs). 10 min, do in deploy session |
+| 5 | SDK IDL + PDAs regenerated and matching | ✅ DONE | IDL refreshed via `packages/program/scripts/patch_idl.py` (anchor 0.30.1 IDL gen is broken on modern toolchains — see script header); synced to `packages/sdk` + `apps/web`. Re-run after the `declare_id` change (address field) |
+| 6 | No secrets/keypairs in git | ✅ DONE | Env values scrubbed in `6385864`; `.env*` gitignored; verify once more in deploy session (`git log -S` spot check) |
+| 7 | Upgrade authority chosen and documented | ❌ TODO | **YD decision**: recommended Squads v4 multisig (even 1-of-1 initially — upgradeable to real multisig later); alternative: cold keypair. Document choice here |
+| 8 | Mock mode still works (demos/judges) | ✅ DONE | All pages 200 without wallet; mock store untouched by hardening; verified on PR #70 |
+| 9 | Reliable mainnet RPC | ❌ TODO | **YD**: Helius paid tier (~$50/mo per economics model); put key in env, never in git |
+| 10 | Deployer wallet funded | ❌ **THE blocker** | **YD**: ~3.5 SOL program rent + ~1.5 SOL buffer/priority fees |
+| 11 | Executor/keeper wallet funded | ❌ **THE blocker** | **YD**: generate dedicated hot wallet (minimal scope, rotate-able), fund ~0.5 SOL — clears the Jupiter CPI gate |
+
+## Post-merge prerequisites (before the deploy session)
+
+- [ ] Merge PR #68 (ops package), PR #69 (security hardening), PR #70 (product/UX); main green.
+- [ ] **Devnet re-deploy + pot recreation**: PotAccount layout grew in PR #69 — existing devnet pots are unreadable. `anchor deploy --provider.cluster devnet`, recreate seed/demo pots.
+- [ ] Re-run `npm run build` + `anchor test` on merged main (CI covers this).
+
+## Launch-day security tasks
+
+- [ ] **Rotate Supabase keys** (service_role + anon) — they were exposed in a chat on 2026-04-26; rotation was deliberately deferred to release. Do it the same hour as launch.
+- [ ] Set a **sentinel** on the flagship pot (separate key from authority) and configure `risk_param_timelock_secs` ≥ 24h + spending caps — eat our own dogfood, it's also the marketing story.
+- [ ] Verify program on Explorer; pin program ID in README + site footer.
+
+## Cost estimate
+
+~3.5 SOL program rent (largely refundable on close) + ~1.5 SOL redeploy/priority-fee buffer + ~0.5 SOL executor + dust for PDA/mint rents ≈ **5–5.5 SOL total**.
+
+## Deploy session
+
+When wallets are funded: open a fresh Claude Code session with `docs/operations/POTBOT_DEPLOY_PROMPT.md` and follow `deploy.md` step by step. Items 4, 7, 9 above are resolved inside that session; this file is the entry gate.

--- a/docs/product/gtm.md
+++ b/docs/product/gtm.md
@@ -1,0 +1,77 @@
+# PotBot — Go-To-Market Plan
+
+*June 2026. Execution-ready. Anchored to **L = mainnet launch day** (working target: 2026-07-01 — the only gate is wallet funding, see `docs/operations/READINESS.md`). All dated targets shift with L.*
+
+---
+
+## 1. Positioning
+
+> **Non-custodial group vaults on Solana. AI proposes, members vote, the program executes — no one holds the keys.**
+
+Differentiator = **trust by architecture**, in a market that keeps burning users with custodial bots (Axiom insider scandal, $40M+ agent/vault drains in 2026). We don't compete with terminals on execution speed; we compete on *together + safe + transparent*. Every surface shows, not claims: vault PDA with Explorer link, on-chain vote history, visible risk caps, sentinel status, honest audit line.
+
+One-liners per audience:
+- Trader chats: *"Copy-trade together — with a vote, not a custodian."*
+- Creators/KOLs: *"Run a vault, earn fees, never touch other people's keys."*
+- Normies: *"A shared piggy bank that trades — email login, no seed phrase."*
+- Agent devs: *"Give your AI a treasury it can propose to but can't rug."*
+
+## 2. ICPs (in priority order)
+
+1. **Solana trading group chats / friend groups** (5–30 people) — the hero flow; convert one chat at a time.
+2. **Trader-creators & KOLs** — want fee income without custody → Strategy Vaults (70% of entry fees + perf share).
+3. **Communities / DAOs / Superteam circles** — treasuries with governance needs but no trading primitive.
+4. **AI-agent developers** — `@potbot/mcp` (60+ actions): agents that manage treasuries within governance bounds.
+
+## 3. Channels
+
+| Channel | Motion | Cadence |
+|---|---|---|
+| X: @PotBot_sol + @CryptoYDao | build-in-public, leaderboard threads, trust-narrative content | 4–5 posts/wk |
+| Blinks | deposit/vote cards shared in X & Telegram — the viral loop: every proposal share is a CTA | per-proposal, automatic |
+| Telegram trading communities | seed 1 pot per community, founder-led onboarding | 2 new communities/wk |
+| Superteam NL + global / grant ecosystem | grant updates, demo days, Solana Frontier 2026 visibility | monthly |
+| MCP / agent-dev community | "agent with a treasury" demos, npm + registry listings | bi-weekly |
+| `name.potbot.sol` subdomains | identity hook — pots claim names, names spread the brand | built-in |
+
+## 4. Launch motions
+
+1. **L-7 → L:** pre-launch thread series ("why custodial bots keep robbing you"), waitlist push, line up first 5 pots from existing communities.
+2. **L-day — Flagship pot:** public pot with real capital and live TVL on the landing page. Proof, not promises. Daily PnL screenshot thread for week 1.
+3. **L → L+90 — Founding-creator program:** first 20 Strategy Vaults get **0% protocol entry-fee share for 90 days** (creators keep 90%: 70% + our waived 20%). Application thread + direct KOL outreach (target: 2 outreaches/wk).
+4. **2-tier referral** (already on-chain): every member has a referral link from day one; 10% / 5% of entry fees, instant, on-chain.
+5. **Weekly pot leaderboard** thread (TVL, 30d PnL, win streaks) — the recurring content engine; pots compete to appear.
+
+## 5. Partnerships (sequenced)
+
+- **Now (integration already live):** Jupiter (swaps — deepen with Limit/DCA), Helius (RPC/webhooks), Privy (email onboarding), SNS.
+- **L+30:** Kamino (idle-capital yield — "your pot earns while it waits"), MoonPay (fiat at join → co-marketing the normie flow).
+- **L+60:** wallet Blinks placement (Phantom/Backpack featured actions), Squads (joint "institutional pot" story), Meteora (LP yield).
+- **Opportunistic:** Symmetry (basket rebalancing for multi-asset pots — integrate, don't rebuild).
+
+## 6. KPIs & targets
+
+| KPI | L+30 | L+60 | L+90 |
+|---|---|---|---|
+| TVL | $50k | $150k | $400k |
+| Active pots (≥3 members, ≥1 proposal/wk) | 15 | 40 | 80 |
+| Proposals + votes / week | 60 | 200 | 500 |
+| Voter retention (W4) | 35% | 40% | 45% |
+| Creator Strategy Vaults launched | 5 | 12 | 20 (founding cohort full) |
+| Fee revenue run-rate (annualized) | $3k | $12k | $30k |
+| `@potbot/mcp` weekly active agents | 5 | 15 | 40 |
+
+Base-case sanity check: 80 active pots × $5k avg TVL ≈ $400k TVL → on the economics model (`economics.xlsx`) that's ~$1.5–2.5k/mo gross — L+90 target is aggressive-but-reachable with the creator program compounding.
+
+## 7. Content pillars (potbot-content voice)
+
+1. **Trust** — anatomy of custodial failures vs. PDA custody (evergreen, ride news cycles).
+2. **Proof** — flagship pot live numbers, leaderboards, on-chain receipts.
+3. **Education** — /learn-derived threads: what's a pot, how voting works, what the AI can't do.
+4. **Creators** — vault spotlights, fee earnings screenshots, founding-program countdown.
+
+## 8. Risks & counters
+
+- **Terminal adds "group mode"** → speed: lock the social moat (creator economy + referrals + Blinks) before they bolt on custody-free governance, which is hard to retrofit.
+- **Cold-start liquidity** → flagship pot + founding creators + waived fees concentrate early TVL where it's visible.
+- **Regulatory optics on pooled funds** → non-custodial framing, no fund management by PotBot, fees as protocol fees; institutional pots route via Squads.

--- a/docs/product/investor-onepager.md
+++ b/docs/product/investor-onepager.md
@@ -1,0 +1,58 @@
+# PotBot — Investor One-Pager
+
+*June 2026 · potbot.fun · @PotBot_sol · Solana Frontier 2026*
+
+**Non-custodial group trading vaults on Solana. AI proposes, members vote, the program executes — no one holds the keys.**
+
+---
+
+## Problem
+
+Groups already trade together — in Telegram chats, friend circles, KOL communities. Today they do it through custodial bots and "trusted" wallet holders, and it keeps ending badly: the 2026 Axiom insider front-running scandal, $40M+ in agent/vault drains, and the daily quiet rug of "the guy with the keys disappeared." There is no safe primitive for *a group* to pool capital, decide together, and let software execute — without trusting a person.
+
+## Solution
+
+A **POT**: a program-owned vault (PDA) on Solana. Members deposit and receive shares; every trade is a proposal; share-weighted votes (5 governance levels, L0 Autocracy → L4 Consensus) gate execution; Jupiter executes swaps inside on-chain risk caps. A bounded **AI agent can only propose** — it has no key that moves funds. Security model borrowed from Morpho Vault V2: **sentinel/guardian role** (can freeze, can never withdraw), **timelocks on loosening risk parameters**, per-protocol and per-asset exposure caps. Member exit is never blockable — even in a frozen pot.
+
+Consumer-grade onboarding: email login (Privy), no seed phrase, join a pot in under 2 minutes.
+
+## Why now
+
+- Custodial trading bots keep burning users → trust-by-architecture is a timely wedge.
+- The category is funded and proven adjacent: Morpho ($10B+ TVL), Squads ($18M raised, $10B+ secured), Midas ($50M raised). **None of them do social + group governance + bounded AI + consumer onboarding.** PotBot owns that gap.
+- Solana agents/MCP ecosystem is exploding — PotBot ships an MCP server (`@potbot/mcp`, 60+ actions) so any AI agent can operate pots within governance bounds.
+
+## Traction
+
+- **Live on devnet** end-to-end: create → deposit → propose → vote → execute, DApp at potbot.fun (mock demo mode works without a wallet).
+- **Security hardening shipped**: sentinel role, risk-param timelocks, exposure caps; 14 program tests green; adversarial AI security review passed (0 critical open); formal audit planned.
+- `@potbot/mcp` published on npm; 2-tier on-chain referral system built; SNS subdomain identity (`name.potbot.sol`) live.
+- Superteam grant recipient; building in public ahead of Solana Frontier 2026.
+
+## Market
+
+Solana DEX volume routinely exceeds $3–5B/day; trading bots/terminals (Axiom, Trojan, Photon, BullX) capture hundreds of millions in annualized fees from *single-player* flows. PotBot targets the unserved multiplayer slice: trading group chats, KOL communities, DAOs/Superteam circles, and AI-agent operators — plus the next cohort that needs email-grade onboarding.
+
+## Business model (gross protocol revenue)
+
+| Stream | Take |
+|---|---|
+| Protocol swap fee on pot volume | 0.30% |
+| Strategy Vault entry fees | 20% of entry fee (70% creator / 10% referrer) |
+| Performance fee share | 25% of creator perf fee (on profit) |
+| Premium subscriptions (Pro $29 / Pro+ $99) | 100% |
+| Pot creation fee | 0.01 SOL flat |
+
+**Scenarios (monthly run-rate):** Conservative — 50 pots, $150k TVL → ~$0.4k/mo. **Base — 250 pots, $2M TVL → ~$8k/mo (~$95k/yr).** Aggressive — 1,200 pots, $24M TVL → ~$170k/mo (~$2M/yr). Lean cost base: ~$430/mo opex (solo founder + AI tooling).
+
+## Roadmap
+
+- **Now:** mainnet deploy (gated only on wallet funding, ~5 SOL), flagship pot with public live TVL.
+- **Q3'26:** Strategy Vaults creator economy (founding-creator program), Kamino/Meteora yield routing, Blinks share cards (deposit/vote in X/TG).
+- **Q4'26:** multi-asset pots, NFT strategy shares, Squads-secured institutional pots, privacy mode (Light Protocol ZK).
+
+## Ask
+
+Pre-seed conversation: capital + distribution partners (wallets for Blinks placement, KOLs to seed founding Strategy Vaults). The protocol is mainnet-ready; the next dollar goes to launch, audit, and creator acquisition — not to figuring out what to build.
+
+*Detail: `docs/product/competitive-analysis.md` (landscape), `docs/product/economics.xlsx` (model), `docs/operations/READINESS.md` (mainnet gate).*


### PR DESCRIPTION
## Что это

Фазы D, E, F мастер-плана — по коммиту на фазу. Рекомендуется мержить **после** #68/#69/#70 (доки описывают их содержимое как текущее состояние).

- **Phase D** — README обновлён (security-слой, честная монетизация: подписки + протокольные комиссии в трежери, всё помечено 🟡 devnet); `docs/architecture/*` отражают sentinel/timelock/allowlist/фикс выплат; **`docs/product/investor-onepager.md`** — одна страница, числа вперёд (Base-сценарий ~$95k/yr при 250 потах).
- **Phase E** — **`docs/product/gtm.md`**: позиционирование «trust by architecture», 4 ICP, каналы, launch-моушены (flagship pot, founding-creator 0% fees / 90 дней, реферралка, недельный лидерборд), партнёрства по очереди, KPI на 30/60/90 дней от дня запуска.
- **Phase F** — **`docs/operations/READINESS.md`**: каждый пункт pre-flight из deploy.md закрыт или TODO-с-владельцем. Итог: **деплой блокируют только кошельки (~5 SOL)** + три 10-минутных решения (mainnet keypair, upgrade authority, RPC). Включены: пересоздание devnet-потов после смены layout и ротация Supabase-ключей в день запуска.

🤖 Generated with [Claude Code](https://claude.com/claude-code)