### PR TITLE
fix: address Codex review findings from PRs #68-71

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Stripe checkout is wired behind `NEXT_PUBLIC_STRIPE_KEY`; paid billing activates
 | Stream | Rate | Status |
 |---|---|---|
 | Pot creation fee | 0.01 SOL, charged onchain in `create_pot` | 🟡 Devnet |
-| Swap fee | 0.30% on every trade routed through a pot | 🟡 Devnet |
-| Strategy Vault entry fee | 20% protocol share (70% to the strategy creator, 10% to the referrer) | 🟡 Devnet |
-| Performance fee | 25% protocol share — the creator sets the rate per vault (capped at 50%) | 🟡 Devnet |
+| Swap fee | 0.30% on every trade routed through a pot — fee switch ships with the mainnet program iteration | 🔵 Planned |
+| Strategy Vault entry fee | 20% protocol share (70% creator / 10% referrer split is live onchain; the treasury leg is not collected yet) | 🔵 Planned |
+| Performance fee | 25% protocol share — creator-set rate (capped at 50%) currently pays out 100% to the creator | 🔵 Planned |
 
 No token, no airdrop farming.
 

--- a/apps/web/src/app/vaults/page.tsx
+++ b/apps/web/src/app/vaults/page.tsx
@@ -45,6 +45,15 @@ const FILTER_STRATEGY: Record<string, number[]> = {
   aggressive:   [3, 4],
 }
 
+/** Mock pots carry numeric yieldStrategy ids; live on-chain pots are mapped
+ *  by usePots() to the anchor enum KEY string ('conservative' | 'balanced' |
+ *  'aggressive' | 'none'). Normalize both shapes to the filter bucket. */
+function strategyMatchesFilter(value: unknown, bucket: string): boolean {
+  if (typeof value === 'number') return FILTER_STRATEGY[bucket]?.includes(value) ?? false
+  if (typeof value === 'string') return value.toLowerCase() === bucket
+  return false
+}
+
 /** Deterministic upward-trending sparkline derived from the pot pubkey. */
 function Sparkline({ seed, className = '' }: { seed: string; className?: string }) {
   const points = useMemo(() => {
@@ -106,7 +115,7 @@ export default function VaultsPage() {
       .filter((p: any) => {
         if (filter === 'all') return true
         if (filter === 'verified') return p.trustLevel && p.trustLevel !== 'unverified'
-        return FILTER_STRATEGY[filter]?.includes(p.yieldStrategy)
+        return strategyMatchesFilter(p.yieldStrategy, filter)
       })
       .filter((p: any) => {
         if (!profitableOnly) return true

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -5803,6 +5803,10 @@
           {
             "name": "risk_param_timelock_secs",
             "type": "i64"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "type": "u16"
           }
         ]
       }

--- a/apps/web/src/lib/mock-store.ts
+++ b/apps/web/src/lib/mock-store.ts
@@ -404,7 +404,7 @@ const SEED_POTS: MockPot[] = [
     maxSwapPct: 5,
   },
   {
-    pubkey: 'PotBotFeatBal11111111111111111111111111111111',
+    pubkey: 'PotBotFeatBa1111111111111111111111111111111',
     name: 'PotBot Balanced Index',
     emoji: '⚖️',
     balance: 320.0,

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -114,11 +114,20 @@ Open Solana Explorer (mainnet) and confirm the program id, authority, and recent
 
 `apps/web/.env.local`:
 ```
+NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta   # REQUIRED — defaults to devnet; drives explorer
+                                          # links, cluster labels and health checks
 NEXT_PUBLIC_RPC_URL=https://mainnet.helius-rpc.com/?api-key=<KEY>
 NEXT_PUBLIC_PROGRAM_ID=<PROGRAM_ID>
 ```
-Set the same `RPC_URL` + `PROGRAM_ID` for `apps/api` and `apps/keeper`, and the executor key as a
-secret (never in git). `useIsProgramLive()` should now flip the DApp to on-chain mode.
+
+`apps/keeper` reads DIFFERENT env names (with devnet fallbacks — if you skip
+these, the keeper silently keeps polling devnet while mainnet looks wired):
+```
+SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=<KEY>
+POTBOT_PROGRAM_ID=<PROGRAM_ID>
+```
+Set the equivalent vars for `apps/api`, and the executor key as a secret
+(never in git). `useIsProgramLive()` should now flip the DApp to on-chain mode.
 
 Restart api + keeper; confirm the agent cron / crank point at mainnet.
 

--- a/docs/product/investor-onepager.md
+++ b/docs/product/investor-onepager.md
@@ -33,7 +33,7 @@ Consumer-grade onboarding: email login (Privy), no seed phrase, join a pot in un
 
 Solana DEX volume routinely exceeds $3–5B/day; trading bots/terminals (Axiom, Trojan, Photon, BullX) capture hundreds of millions in annualized fees from *single-player* flows. PotBot targets the unserved multiplayer slice: trading group chats, KOL communities, DAOs/Superteam circles, and AI-agent operators — plus the next cohort that needs email-grade onboarding.
 
-## Business model (gross protocol revenue)
+## Business model (gross protocol revenue — fee switch ships with mainnet)
 
 | Stream | Take |
 |---|---|
@@ -42,6 +42,8 @@ Solana DEX volume routinely exceeds $3–5B/day; trading bots/terminals (Axiom, 
 | Performance fee share | 25% of creator perf fee (on profit) |
 | Premium subscriptions (Pro $29 / Pro+ $99) | 100% |
 | Pot creation fee | 0.01 SOL flat |
+
+*Today only the 0.01 SOL creation fee is collected onchain; the swap/entry/perf protocol shares below are the designed fee switch, activating with the mainnet program iteration.*
 
 **Scenarios (monthly run-rate):** Conservative — 50 pots, $150k TVL → ~$0.4k/mo. **Base — 250 pots, $2M TVL → ~$8k/mo (~$95k/yr).** Aggressive — 1,200 pots, $24M TVL → ~$170k/mo (~$2M/yr). Lean cost base: ~$430/mo opex (solo founder + AI tooling).
 

--- a/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_proposal.rs
@@ -171,6 +171,7 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 single_swap_cap_bps: pot.single_swap_cap_bps,
                 daily_budget_lamports: pot.daily_budget_lamports,
                 risk_param_timelock_secs: pot.risk_param_timelock_secs,
+                max_asset_exposure_bps: pot.max_asset_exposure_bps,
             };
             let staged = pot.stage_or_apply_risk_params(target, clock.unix_timestamp)?;
             msg!(
@@ -203,6 +204,7 @@ pub fn handler(ctx: Context<ExecuteProposal>) -> Result<()> {
                 single_swap_cap_bps: pot.single_swap_cap_bps,
                 daily_budget_lamports: pot.daily_budget_lamports,
                 risk_param_timelock_secs: pot.risk_param_timelock_secs,
+                max_asset_exposure_bps: pot.max_asset_exposure_bps,
             };
             let staged = pot.stage_or_apply_risk_params(target, clock.unix_timestamp)?;
             msg!(

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -114,6 +114,7 @@ pub fn set_spending_policy(
                 single_swap_cap_bps: args.single_swap_cap_bps,
                 daily_budget_lamports: args.daily_budget_lamports,
                 risk_param_timelock_secs: pot.risk_param_timelock_secs,
+                max_asset_exposure_bps: pot.max_asset_exposure_bps,
         };
         let staged = pot.stage_or_apply_risk_params(target, now)?;
         msg!(
@@ -195,16 +196,9 @@ pub fn set_risk_timelock(
         let pot = &mut ctx.accounts.pot;
         let now = Clock::get()?.unix_timestamp;
 
-        // Exposure cap: apply tightening instantly; loosening only when no
-        // timelock is configured (otherwise keep the tighter current value —
-        // loosening exposure caps goes through governance, not admin).
-        let old_exposure = pot.max_asset_exposure_bps;
-        let tightening = args.max_asset_exposure_bps != 0
-                && (old_exposure == 0 || args.max_asset_exposure_bps < old_exposure);
-        if tightening || pot.risk_param_timelock_secs <= 0 {
-                    pot.max_asset_exposure_bps = args.max_asset_exposure_bps;
-        }
-
+        // Both the timelock and the exposure cap go through the standard
+        // stage-or-apply path: tightening lands instantly, loosening is
+        // staged into pending_params and applied after the delay.
         let target = PendingRiskParams {
                 is_pending: false,
                 effective_at: 0,
@@ -214,6 +208,7 @@ pub fn set_risk_timelock(
                 single_swap_cap_bps: pot.single_swap_cap_bps,
                 daily_budget_lamports: pot.daily_budget_lamports,
                 risk_param_timelock_secs: args.risk_param_timelock_secs,
+                max_asset_exposure_bps: args.max_asset_exposure_bps,
         };
         let staged = pot.stage_or_apply_risk_params(target, now)?;
         msg!(

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -159,6 +159,7 @@ pub struct PendingRiskParams {
     pub single_swap_cap_bps: u16,
     pub daily_budget_lamports: u64,
     pub risk_param_timelock_secs: i64,
+    pub max_asset_exposure_bps: u16,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, PartialEq)]
@@ -486,6 +487,13 @@ impl PotAccount {
             any_loosening = true;
         }
 
+        // Per-asset exposure cap: 0 = unlimited (loosest); lower = tighter.
+        if !cap_is_looser(self.max_asset_exposure_bps as u64, target.max_asset_exposure_bps as u64) {
+            self.max_asset_exposure_bps = target.max_asset_exposure_bps;
+        } else {
+            any_loosening = true;
+        }
+
         // Timelock itself: HIGHER = tighter; 0 = disabled (loosest).
         if !timelock_is_looser(self.risk_param_timelock_secs, target.risk_param_timelock_secs) {
             self.risk_param_timelock_secs = target.risk_param_timelock_secs;
@@ -534,6 +542,7 @@ impl PotAccount {
         self.single_swap_cap_bps = p.single_swap_cap_bps;
         self.daily_budget_lamports = p.daily_budget_lamports;
         self.risk_param_timelock_secs = p.risk_param_timelock_secs;
+        self.max_asset_exposure_bps = p.max_asset_exposure_bps;
     }
 }
 

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -124,7 +124,16 @@ def add_type(name, fields):
         return
     idl["types"].append({"name": name, "type": {"kind": "struct", "fields": fields}})
 
-add_type("PendingRiskParams", [
+def upsert_type(name, fields):
+    """Replace the struct definition if present (keeps re-runs idempotent
+    when a type gains fields), else append it."""
+    for t in idl["types"]:
+        if t["name"] == name:
+            t["type"]["fields"] = fields
+            return
+    idl["types"].append({"name": name, "type": {"kind": "struct", "fields": fields}})
+
+upsert_type("PendingRiskParams", [
     {"name": "is_pending", "type": "bool"},
     {"name": "effective_at", "type": "i64"},
     {"name": "trade_level", "type": "u8"},
@@ -133,6 +142,7 @@ add_type("PendingRiskParams", [
     {"name": "single_swap_cap_bps", "type": "u16"},
     {"name": "daily_budget_lamports", "type": "u64"},
     {"name": "risk_param_timelock_secs", "type": "i64"},
+    {"name": "max_asset_exposure_bps", "type": "u16"},
 ])
 add_type("SetAllowedProgramsArgs", [
     {"name": "programs", "type": {"vec": "pubkey"}},

--- a/packages/program/tests/security.test.ts
+++ b/packages/program/tests/security.test.ts
@@ -305,6 +305,24 @@ describe('security hardening (Phase A)', () => {
     potState = await (program.account as any).potAccount.fetch(pot)
     expect(potState.singleSwapCapBps).to.equal(1000)
     expect(potState.pendingParams.isPending).to.equal(false)
+
+    // Exposure-cap loosening (3000 → 6000) is staged too — not silently
+    // dropped (codex review finding) — and applies after the delay.
+    await (program.methods as any)
+      .setRiskTimelock({ riskParamTimelockSecs: new BN(2), maxAssetExposureBps: 6000 })
+      .accounts({ pot, authority })
+      .rpc()
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.maxAssetExposureBps).to.equal(3000) // unchanged yet
+    expect(potState.pendingParams.isPending).to.equal(true)
+    expect(potState.pendingParams.maxAssetExposureBps).to.equal(6000)
+    await new Promise((r) => setTimeout(r, 3000))
+    await (program.methods as any)
+      .applyPendingParams()
+      .accounts({ pot, cranker: authority })
+      .rpc()
+    potState = await (program.account as any).potAccount.fetch(pot)
+    expect(potState.maxAssetExposureBps).to.equal(6000)
   })
 
   // ── 5. cap breach ────────────────────────────────────────────────────────

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -5803,6 +5803,10 @@
           {
             "name": "risk_param_timelock_secs",
             "type": "i64"
+          },
+          {
+            "name": "max_asset_exposure_bps",
+            "type": "u16"
           }
         ]
       }


### PR DESCRIPTION
Разбор всех 8 инлайн-комментариев Codex по смерженным PR. 6 валидных — исправлены; 2 устарели (Codex ревьюил docs-ветку до мержа #69).

| # | PR | Severity | Вердикт | Действие |
|---|---|---|---|---|
| 1 | #68 | P1 | ✅ валидно | deploy.md: киперные env — реальные `SOLANA_RPC_URL`/`POTBOT_PROGRAM_ID` (с devnet-фоллбэками кипер молча оставался на devnet) |
| 2 | #68 | P2 | ✅ валидно | deploy.md: добавлен обязательный `NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta` |
| 3 | #69 | P1 | ⚠️ известно/намеренно | Layout-миграция: mainnet не задеплоен; devnet redeploy + пересоздание потов уже в READINESS.md |
| 4 | #69 | P2 | ✅ валидно | Ослабление exposure-капа теперь стейджится через timelock (поле в PendingRiskParams), тест расширен |
| 5 | #70 | P2 | ✅ валидно | Pubkey featured-волта был невалидным base58 (lowercase 'l', 45 симв.) → «Vault not found»; исправлен |
| 6 | #70 | P2 | ✅ валидно | Риск-фильтры /vaults понимают и строковые enum-ключи живых потов, и числовые id моков |
| 7 | #71 | P1 | ❌ устарело | «Hardening не существует в коде» — Codex смотрел ветку до мержа #69 |
| 8 | #71 | P1 | ❌ устарело | То же про beneficiary-enforcement — закрыто мержем #69 |
| 9 | #71 | P2 | ✅ валидно | README/one-pager: swap/entry/perf доли перемаркированы 🔵 Planned — ончейн сегодня собирается только 0.01 SOL creation fee |

Проверки: anchor tests 14 passing · tsc 0 ошибок · next build зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)