### PR TITLE
feat: Phase A — oracle (Pyth) NAV, confidence filter, source-agnostic interface

### DIFF
--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -3673,6 +3673,11 @@
       "code": 6084,
       "name": "OracleAccountMissing",
       "msg": "Oracle price account required for this guarded action"
+    },
+    {
+      "code": 6085,
+      "name": "OracleGuardUnavailable",
+      "msg": "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"
     }
   ],
   "types": [

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -2855,6 +2855,42 @@
       "docs": [
         "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
+    },
+    {
+      "name": "set_oracle_config",
+      "discriminator": [
+        96,
+        171,
+        6,
+        98,
+        153,
+        183,
+        233,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetOracleConfigArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Configure the pot's oracle source, confidence bound, and swap deviation guard."
+      ]
     }
   ],
   "accounts": [
@@ -3196,6 +3232,19 @@
         63,
         203,
         70
+      ]
+    },
+    {
+      "name": "OracleConfigUpdated",
+      "discriminator": [
+        130,
+        6,
+        5,
+        137,
+        29,
+        155,
+        34,
+        68
       ]
     }
   ],
@@ -3604,6 +3653,26 @@
       "code": 6080,
       "name": "AssetExposureExceeded",
       "msg": "Daily exposure cap for this asset exceeded"
+    },
+    {
+      "code": 6081,
+      "name": "OracleConfidenceTooLow",
+      "msg": "Oracle confidence interval wider than the configured bound"
+    },
+    {
+      "code": 6082,
+      "name": "OracleDeviationExceeded",
+      "msg": "Realised swap price deviates from the oracle mid beyond the cap"
+    },
+    {
+      "code": 6083,
+      "name": "OracleKindUnsupported",
+      "msg": "Configured oracle source is not supported"
+    },
+    {
+      "code": 6084,
+      "name": "OracleAccountMissing",
+      "msg": "Oracle price account required for this guarded action"
     }
   ],
   "types": [
@@ -4349,6 +4418,39 @@
               "array": [
                 "u64",
                 16
+              ]
+            }
+          },
+          {
+            "name": "oracle_kind",
+            "docs": [
+              "Oracle source: 0 = Pyth, 1 = Switchboard."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "docs": [
+              "Max accepted oracle confidence interval, bps. 0 = source default."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "docs": [
+              "Max swap-vs-oracle deviation, bps. 0 = guard disabled."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Forward-compat tail \u2014 carve new fields from here, never insert."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
               ]
             }
           }
@@ -6012,6 +6114,50 @@
           {
             "name": "timestamp",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetOracleConfigArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle_kind",
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleConfigUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_kind",
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "type": "u16"
           }
         ]
       }

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -195,6 +195,8 @@ pub enum ErrorCode {
     OracleKindUnsupported,
     #[msg("Oracle price account required for this guarded action")]
     OracleAccountMissing,
+    #[msg("Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet")]
+    OracleGuardUnavailable,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -185,6 +185,16 @@ pub enum ErrorCode {
     ProgramNotAllowed,
     #[msg("Daily exposure cap for this asset exceeded")]
     AssetExposureExceeded,
+
+    // ─── Oracle / NAV (Phase A) ───────────────────────────────────────────
+    #[msg("Oracle confidence interval wider than the configured bound")]
+    OracleConfidenceTooLow,
+    #[msg("Realised swap price deviates from the oracle mid beyond the cap")]
+    OracleDeviationExceeded,
+    #[msg("Configured oracle source is not supported")]
+    OracleKindUnsupported,
+    #[msg("Oracle price account required for this guarded action")]
+    OracleAccountMissing,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -113,6 +113,12 @@ pub fn handler(ctx: Context<CreatePot>, params: CreatePotParams) -> Result<()> {
     pot.max_asset_exposure_bps   = 0;
     pot.per_mint_daily_spent     = [0u64; 16];
 
+    // Oracle / NAV (Phase A) — Pyth default, guards opt-in via set_oracle_config.
+    pot.oracle_kind              = 0; // OracleKind::Pyth
+    pot.max_oracle_conf_bps      = 0; // → pyth::DEFAULT_MAX_CONF_BPS
+    pot.max_oracle_deviation_bps = 0; // guard disabled until configured
+    pot.reserved                 = [0u8; 128];
+
     pot.config = PotConfig {
         is_public: params.is_public,
         min_deposit: params.min_deposit,

--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -336,15 +336,17 @@ pub fn handler<'info>(
     }
 
     // --- 7b. oracle deviation guard (anti-sandwich) -----------------------
-    // Independent of the strategy entry-price slippage ceiling above: this
-    // compares the REALISED execution price against a live oracle reading, so
-    // a manipulated pool / sandwich that still clears `min_out` is rejected
-    // when it strays too far from fair value. Opt-in: 0 = disabled.
+    // Compares the REALISED execution price against a live oracle reading so a
+    // manipulated pool / sandwich that still clears `min_out` is rejected when
+    // it strays too far from fair value. Fail-closed: a sentinel/short oracle
+    // account reverts rather than executing unguarded.
     //
-    // Phase A unit convention: the passed feed must quote output-per-input in
-    // the same orientation as `received/spent` (e.g. a direct pair feed).
-    // General two-feed (input-USD ÷ output-USD) normalization is a documented
-    // Phase-B follow-up — same staged approach as the wSOL-denominated caps.
+    // GATED OFF in Phase A: `set_oracle_config` rejects max_oracle_deviation_bps
+    // > 0, so this block is dormant until Phase B adds two-feed (input-USD ÷
+    // output-USD, decimals-normalized) pricing — the single-feed comparison
+    // here is only dimensionally correct for a direct pair feed and must not be
+    // advertised as a guarantee. The plumbing + fail-closed semantics are kept
+    // and unit-tested so Phase B only swaps in correct pricing.
     if ctx.accounts.pot.max_oracle_deviation_bps > 0 {
         let kind = crate::oracle::OracleKind::from_u8(ctx.accounts.pot.oracle_kind)?;
         let oracle = crate::oracle::read_price(

--- a/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
+++ b/packages/program/programs/pot_vault/src/instructions/execute_swap.rs
@@ -335,6 +335,31 @@ pub fn handler<'info>(
         }
     }
 
+    // --- 7b. oracle deviation guard (anti-sandwich) -----------------------
+    // Independent of the strategy entry-price slippage ceiling above: this
+    // compares the REALISED execution price against a live oracle reading, so
+    // a manipulated pool / sandwich that still clears `min_out` is rejected
+    // when it strays too far from fair value. Opt-in: 0 = disabled.
+    //
+    // Phase A unit convention: the passed feed must quote output-per-input in
+    // the same orientation as `received/spent` (e.g. a direct pair feed).
+    // General two-feed (input-USD ÷ output-USD) normalization is a documented
+    // Phase-B follow-up — same staged approach as the wSOL-denominated caps.
+    if ctx.accounts.pot.max_oracle_deviation_bps > 0 {
+        let kind = crate::oracle::OracleKind::from_u8(ctx.accounts.pot.oracle_kind)?;
+        let oracle = crate::oracle::read_price(
+            kind,
+            &ctx.accounts.pyth_price_update,
+            ctx.accounts.pot.max_oracle_conf_bps,
+        )?;
+        let realised_x64 = compute_price_x64(spent, received)?;
+        let dev = crate::oracle::deviation_bps(realised_x64, oracle.price_x64);
+        require!(
+            dev <= ctx.accounts.pot.max_oracle_deviation_bps,
+            crate::errors::PotError::OracleDeviationExceeded
+        );
+    }
+
     // --- 8. update strategy state machine ---------------------------------
     let now = Clock::get()?.unix_timestamp;
     let strategy = &mut ctx.accounts.strategy;

--- a/packages/program/programs/pot_vault/src/instructions/mod.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mod.rs
@@ -86,17 +86,18 @@ pub use mark_proposal_passed::{MarkProposalPassed, ProposalMarkedPassed};
 pub(crate) use mark_proposal_passed::__client_accounts_mark_proposal_passed;
 pub use pot_admin::{
     apply_pending_params, fund_fee_reserve, pause_pot, set_allowed_mints,
-    set_allowed_programs, set_risk_timelock, set_spending_policy, unpause_pot,
+    set_allowed_programs, set_oracle_config, set_risk_timelock, set_spending_policy, unpause_pot,
     AllowedMintsUpdated, AllowedProgramsUpdated, ApplyPendingParams, FeeReserveFunded,
-    FundFeeReserve, FundFeeReserveArgs, PausePot, PendingParamsApplied, SetAllowedMints,
-    SetAllowedMintsArgs, SetAllowedPrograms, SetAllowedProgramsArgs, SetRiskTimelock,
+    FundFeeReserve, FundFeeReserveArgs, OracleConfigUpdated, PausePot, PendingParamsApplied,
+    SetAllowedMints, SetAllowedMintsArgs, SetAllowedPrograms, SetAllowedProgramsArgs,
+    SetOracleConfig, SetOracleConfigArgs, SetRiskTimelock,
     SetRiskTimelockArgs, SetSpendingPolicy, SetSpendingPolicyArgs,
 };
 pub(crate) use pot_admin::{
     __client_accounts_apply_pending_params, __client_accounts_fund_fee_reserve,
     __client_accounts_pause_pot, __client_accounts_set_allowed_mints,
-    __client_accounts_set_allowed_programs, __client_accounts_set_risk_timelock,
-    __client_accounts_set_spending_policy,
+    __client_accounts_set_allowed_programs, __client_accounts_set_oracle_config,
+    __client_accounts_set_risk_timelock, __client_accounts_set_spending_policy,
 };
 pub use sentinel::{
     cancel_proposal, freeze_pot, set_sentinel, unfreeze_pot, CancelProposal, FreezePot,

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -275,6 +275,17 @@ pub fn set_oracle_config(
         // Validate the selector now so a bad value can't be stored and only
         // blow up later inside execute_swap.
         crate::oracle::OracleKind::from_u8(args.oracle_kind)?;
+
+        // The deviation guard compares output-per-input (realised) against a
+        // single oracle feed price; that is only dimensionally correct with
+        // two USD feeds normalized by decimals (Phase B). Refuse to enable a
+        // guard that would not enforce a meaningful bound — a fake guard is
+        // worse than none. The confidence filter (max_oracle_conf_bps) IS
+        // meaningful today and stays enableable.
+        require!(
+                args.max_oracle_deviation_bps == 0,
+                PotError::OracleGuardUnavailable
+        );
         let pot = &mut ctx.accounts.pot;
         pot.oracle_kind              = args.oracle_kind;
         pot.max_oracle_conf_bps      = args.max_oracle_conf_bps;

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -241,6 +241,53 @@ pub fn apply_pending_params(ctx: Context<ApplyPendingParams>) -> Result<()> {
         Ok(())
 }
 
+// ─── Set oracle config ──────────────────────────────────────────────────────
+//
+// Configures which oracle backs the pot, the confidence bound, and the swap
+// deviation guard. These are NOT risk-param-timelocked: tightening them is
+// always safe, and loosening them only weakens a guard that is itself opt-in
+// (a deviation cap of 0 disables the guard entirely). Authority-only.
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct SetOracleConfigArgs {
+        /// 0 = Pyth, 1 = Switchboard (see crate::oracle::OracleKind).
+    pub oracle_kind: u8,
+        /// Max accepted confidence interval, bps of price. 0 = source default.
+        pub max_oracle_conf_bps: u16,
+        /// Max accepted swap-vs-oracle deviation, bps. 0 = guard disabled.
+        pub max_oracle_deviation_bps: u16,
+}
+
+#[derive(Accounts)]
+pub struct SetOracleConfig<'info> {
+        #[account(
+                    mut,
+                    constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
+                )]
+        pub pot: Box<Account<'info, PotAccount>>,
+        pub authority: Signer<'info>,
+}
+
+pub fn set_oracle_config(
+        ctx: Context<SetOracleConfig>,
+        args: SetOracleConfigArgs,
+    ) -> Result<()> {
+        // Validate the selector now so a bad value can't be stored and only
+        // blow up later inside execute_swap.
+        crate::oracle::OracleKind::from_u8(args.oracle_kind)?;
+        let pot = &mut ctx.accounts.pot;
+        pot.oracle_kind              = args.oracle_kind;
+        pot.max_oracle_conf_bps      = args.max_oracle_conf_bps;
+        pot.max_oracle_deviation_bps = args.max_oracle_deviation_bps;
+        emit!(OracleConfigUpdated {
+                    pot: pot.key(),
+                    oracle_kind: args.oracle_kind,
+                    max_oracle_conf_bps: args.max_oracle_conf_bps,
+                    max_oracle_deviation_bps: args.max_oracle_deviation_bps,
+        });
+        Ok(())
+}
+
 // ─── Fund fee reserve ───────────────────────────────────────────────────────
 //
 // Deposits SOL from the authority's account into pot.fee_reserve so that
@@ -326,4 +373,12 @@ pub struct AllowedProgramsUpdated {
 pub struct PendingParamsApplied {
         pub pot: Pubkey,
         pub applied_at: i64,
+}
+
+#[event]
+pub struct OracleConfigUpdated {
+        pub pot: Pubkey,
+        pub oracle_kind: u8,
+        pub max_oracle_conf_bps: u16,
+        pub max_oracle_deviation_bps: u16,
 }

--- a/packages/program/programs/pot_vault/src/lib.rs
+++ b/packages/program/programs/pot_vault/src/lib.rs
@@ -4,6 +4,7 @@ pub mod state;
 pub mod instructions;
 pub mod constants;
 pub mod pyth;
+pub mod oracle;
 
 #[path = "errors/mod.rs"]
 pub mod errors;
@@ -272,6 +273,15 @@ pub mod pot_vault {
     /// timelock has elapsed.
     pub fn apply_pending_params(ctx: Context<ApplyPendingParams>) -> Result<()> {
         instructions::pot_admin::apply_pending_params(ctx)
+    }
+
+    /// Configure the pot's oracle source, confidence bound, and swap
+    /// deviation guard (Phase A). Authority-only.
+    pub fn set_oracle_config(
+        ctx: Context<SetOracleConfig>,
+        args: SetOracleConfigArgs,
+    ) -> Result<()> {
+        instructions::pot_admin::set_oracle_config(ctx, args)
     }
 
     // ─── Yield routing (Phase 4 stub — emit-only) ─────────────────────────

--- a/packages/program/programs/pot_vault/src/oracle/mod.rs
+++ b/packages/program/programs/pot_vault/src/oracle/mod.rs
@@ -1,0 +1,92 @@
+// PotBot v2 — oracle abstraction (Phase A)
+//
+// A single seam for reading a validated price, so Switchboard (or any future
+// source) can be added without touching NAV / swap-guard / caps call sites.
+// BPF has no dyn-trait dispatch worth the cost, so this is a small enum router
+// rather than a `dyn PriceSource`. Pyth is the only implemented source today;
+// `Switchboard` is wired through to a NotImplemented error behind the same
+// signature, so call sites are already source-agnostic.
+
+use anchor_lang::prelude::*;
+use crate::errors::PotError;
+use crate::pyth::{self, OraclePrice};
+
+/// Selects which oracle program backs a pot's price reads. Stored on the pot
+/// as a `u8` (see PotAccount.oracle_kind) so it is layout-cheap and additive.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OracleKind {
+    Pyth,
+    Switchboard,
+}
+
+impl OracleKind {
+    pub fn from_u8(v: u8) -> Result<Self> {
+        match v {
+            0 => Ok(OracleKind::Pyth),
+            1 => Ok(OracleKind::Switchboard),
+            _ => err!(PotError::OracleKindUnsupported),
+        }
+    }
+}
+
+/// Read a confidence-checked price from `account` using the configured source.
+/// `max_conf_bps` is the pot's confidence bound (0 = source default).
+pub fn read_price(
+    kind: OracleKind,
+    account: &UncheckedAccount,
+    max_conf_bps: u16,
+) -> Result<OraclePrice> {
+    match kind {
+        OracleKind::Pyth => pyth::read_price_checked(account, max_conf_bps),
+        // Switchboard pull-feed decoding lands behind this same signature in
+        // the parallel oracle-fallback task. Until then, fail closed.
+        OracleKind::Switchboard => err!(PotError::OracleKindUnsupported),
+    }
+}
+
+/// Deviation between a realised execution price and the oracle mid, in bps.
+/// Both prices must be Q64.64 in the SAME quote unit. Returns u16::MAX if the
+/// oracle mid is zero (caller treats that as "reject").
+pub fn deviation_bps(executed_x64: u128, oracle_mid_x64: u128) -> u16 {
+    if oracle_mid_x64 == 0 {
+        return u16::MAX;
+    }
+    let diff = executed_x64.abs_diff(oracle_mid_x64);
+    let bps = diff.saturating_mul(10_000) / oracle_mid_x64;
+    bps.min(u16::MAX as u128) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oracle_kind_roundtrip() {
+        assert_eq!(OracleKind::from_u8(0).unwrap(), OracleKind::Pyth);
+        assert_eq!(OracleKind::from_u8(1).unwrap(), OracleKind::Switchboard);
+        assert!(OracleKind::from_u8(2).is_err());
+    }
+
+    #[test]
+    fn deviation_zero_when_equal() {
+        assert_eq!(deviation_bps(1_000, 1_000), 0);
+    }
+
+    #[test]
+    fn deviation_symmetric_one_percent() {
+        // 1% above and below the mid both read ~100 bps.
+        assert_eq!(deviation_bps(10_100, 10_000), 100);
+        assert_eq!(deviation_bps(9_900, 10_000), 100);
+    }
+
+    #[test]
+    fn deviation_rejects_zero_mid() {
+        assert_eq!(deviation_bps(1_000, 0), u16::MAX);
+    }
+
+    #[test]
+    fn deviation_saturates_huge_gap() {
+        // 10x the mid → 90_000 bps, clamped to u16::MAX.
+        assert_eq!(deviation_bps(100_000, 10_000), u16::MAX);
+    }
+}

--- a/packages/program/programs/pot_vault/src/pyth.rs
+++ b/packages/program/programs/pot_vault/src/pyth.rs
@@ -40,10 +40,24 @@ const MIN_ACCOUNT_LEN: usize = 152;
 const OFFSET_MAGIC: usize = 0;
 const OFFSET_EXPO: usize = 20;
 const OFFSET_PRICE: usize = 112;
+const OFFSET_CONF: usize = 120;
 const OFFSET_TIMESTAMP: usize = 144;
 
 /// Price feed staleness window: 60 seconds.
 const STALENESS_SECONDS: i64 = 60;
+
+/// Default max confidence interval as bps of price (2%). A wider interval
+/// means the oracle is unsure — reject rather than trade on a fuzzy price.
+pub const DEFAULT_MAX_CONF_BPS: u16 = 200;
+
+/// A validated oracle reading: price as Q64.64, the confidence interval
+/// expressed in bps of price, and the publish timestamp.
+#[derive(Clone, Copy, Debug)]
+pub struct OraclePrice {
+    pub price_x64: u128,
+    pub conf_bps: u16,
+    pub publish_time: i64,
+}
 
 /// Read (price_mantissa, exponent, publish_time) from a Pyth push oracle
 /// price feed account. Returns (0, 0, 0) when called in keeper-trusted mode
@@ -116,6 +130,39 @@ pub fn price_to_q64(price: i64, expo: i32) -> Result<u128> {
     Ok(result)
 }
 
+/// Read a Pyth feed AND enforce the confidence bound, returning a validated
+/// OraclePrice (price as Q64.64). Used by NAV, the swap deviation guard and
+/// value-based caps — anything that prices funds, not just triggers.
+///
+/// `max_conf_bps == 0` falls back to DEFAULT_MAX_CONF_BPS so a pot that never
+/// configured a bound still gets a sane default. Reverts on stale feed,
+/// non-positive price, or a confidence interval wider than the bound.
+pub fn read_price_checked(account: &UncheckedAccount, max_conf_bps: u16) -> Result<OraclePrice> {
+    let (price, expo, publish_time) = read_price_update(account)?;
+    require!(price > 0, PotError::PriceStale);
+
+    // Confidence is published in the same units as price (mantissa); compare
+    // as a ratio so the exponent cancels out.
+    let conf = {
+        let data = account
+            .try_borrow_data()
+            .map_err(|_| error!(PotError::PriceStale))?;
+        read_u64_le(&data, OFFSET_CONF)
+    };
+    let conf_bps = ((conf as u128)
+        .checked_mul(10_000)
+        .ok_or(error!(PotError::MathOverflow))?
+        / (price as u128)) as u64;
+    let bound = if max_conf_bps == 0 { DEFAULT_MAX_CONF_BPS } else { max_conf_bps };
+    require!(conf_bps <= bound as u128 as u64, PotError::OracleConfidenceTooLow);
+
+    Ok(OraclePrice {
+        price_x64: price_to_q64(price, expo)?,
+        conf_bps: conf_bps as u16,
+        publish_time,
+    })
+}
+
 /// Verify that `current_price_x64` satisfies the strategy's trigger conditions,
 /// and return the matching TriggerReason. Errors with TriggerNotMet if no
 /// condition fires at the given price.
@@ -143,4 +190,9 @@ fn read_i32_le(data: &[u8], offset: usize) -> i32 {
 #[inline]
 fn read_i64_le(data: &[u8], offset: usize) -> i64 {
     i64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+}
+
+#[inline]
+fn read_u64_le(data: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
 }

--- a/packages/program/programs/pot_vault/src/pyth.rs
+++ b/packages/program/programs/pot_vault/src/pyth.rs
@@ -84,14 +84,8 @@ pub fn read_price_update(account: &UncheckedAccount) -> Result<(i64, i32, i64)> 
         PotError::PriceFeedMismatch
     );
 
-    let magic = read_u32_le(&data, OFFSET_MAGIC);
-    if magic != PYTH_MAGIC {
-        return Err(error!(PotError::PriceFeedMismatch));
-    }
-
-    let expo = read_i32_le(&data, OFFSET_EXPO);
-    let price = read_i64_le(&data, OFFSET_PRICE);
-    let ts = read_i64_le(&data, OFFSET_TIMESTAMP);
+    let (price, expo, _conf, ts) =
+        decode_legacy(&data).ok_or(error!(PotError::PriceFeedMismatch))?;
 
     require!(price > 0, PotError::PriceStale);
 
@@ -99,6 +93,30 @@ pub fn read_price_update(account: &UncheckedAccount) -> Result<(i64, i32, i64)> 
     require!(now - ts <= STALENESS_SECONDS, PotError::PriceStale);
 
     Ok((price, expo, ts))
+}
+
+/// Pure decoder for the legacy pythnet `PriceAccount` byte layout (the format
+/// produced by PYTH_PROGRAM_DEVNET, which is Phase A's target). Returns
+/// (price, expo, conf, publish_time) when the magic matches, else None.
+///
+/// SCOPE (Finding 1): this does NOT decode the mainnet Pyth **Receiver**
+/// `PriceUpdateV2` format (8-byte disc + write_authority + PriceFeedMessage).
+/// Mainnet receiver support via `pyth-solana-receiver-sdk` is a tracked
+/// Phase-B item — we are devnet/localnet only here. Extracted as a pure fn so
+/// the offsets are locked by a regression test and can never silently drift.
+pub fn decode_legacy(data: &[u8]) -> Option<(i64, i32, u64, i64)> {
+    if data.len() < MIN_ACCOUNT_LEN {
+        return None;
+    }
+    if read_u32_le(data, OFFSET_MAGIC) != PYTH_MAGIC {
+        return None;
+    }
+    Some((
+        read_i64_le(data, OFFSET_PRICE),
+        read_i32_le(data, OFFSET_EXPO),
+        read_u64_le(data, OFFSET_CONF),
+        read_i64_le(data, OFFSET_TIMESTAMP),
+    ))
 }
 
 /// Convert a Pyth (price_mantissa, exponent) pair to Q64.64 fixed-point.
@@ -138,29 +156,73 @@ pub fn price_to_q64(price: i64, expo: i32) -> Result<u128> {
 /// configured a bound still gets a sane default. Reverts on stale feed,
 /// non-positive price, or a confidence interval wider than the bound.
 pub fn read_price_checked(account: &UncheckedAccount, max_conf_bps: u16) -> Result<OraclePrice> {
+    // read_price_update enforces owner + magic + staleness + price>0 first.
     let (price, expo, publish_time) = read_price_update(account)?;
     require!(price > 0, PotError::PriceStale);
 
-    // Confidence is published in the same units as price (mantissa); compare
-    // as a ratio so the exponent cancels out.
+    // Re-decode for the confidence field in one borrow (single-asset legacy
+    // layout). Confidence is in the same units as price, so conf/price is a
+    // pure ratio and the exponent cancels.
     let conf = {
         let data = account
             .try_borrow_data()
             .map_err(|_| error!(PotError::PriceStale))?;
-        read_u64_le(&data, OFFSET_CONF)
+        decode_legacy(&data)
+            .ok_or(error!(PotError::PriceFeedMismatch))?
+            .2
     };
     let conf_bps = ((conf as u128)
         .checked_mul(10_000)
         .ok_or(error!(PotError::MathOverflow))?
         / (price as u128)) as u64;
     let bound = if max_conf_bps == 0 { DEFAULT_MAX_CONF_BPS } else { max_conf_bps };
-    require!(conf_bps <= bound as u128 as u64, PotError::OracleConfidenceTooLow);
+    require!(conf_bps <= bound as u64, PotError::OracleConfidenceTooLow);
 
     Ok(OraclePrice {
         price_x64: price_to_q64(price, expo)?,
-        conf_bps: conf_bps as u16,
+        conf_bps: conf_bps.min(u16::MAX as u64) as u16,
         publish_time,
     })
+}
+
+#[cfg(test)]
+mod decode_tests {
+    use super::*;
+
+    // Build a buffer carrying known values at the documented legacy offsets,
+    // proving decode_legacy reads price/expo/conf/timestamp from the right
+    // positions. Locks the layout so it can never silently drift (Finding 1).
+    fn buf_with(price: i64, expo: i32, conf: u64, ts: i64) -> Vec<u8> {
+        let mut b = vec![0u8; MIN_ACCOUNT_LEN];
+        b[OFFSET_MAGIC..OFFSET_MAGIC + 4].copy_from_slice(&PYTH_MAGIC.to_le_bytes());
+        b[OFFSET_EXPO..OFFSET_EXPO + 4].copy_from_slice(&expo.to_le_bytes());
+        b[OFFSET_PRICE..OFFSET_PRICE + 8].copy_from_slice(&price.to_le_bytes());
+        b[OFFSET_CONF..OFFSET_CONF + 8].copy_from_slice(&conf.to_le_bytes());
+        b[OFFSET_TIMESTAMP..OFFSET_TIMESTAMP + 8].copy_from_slice(&ts.to_le_bytes());
+        b
+    }
+
+    #[test]
+    fn decodes_legacy_fields_at_documented_offsets() {
+        let b = buf_with(150_00000000, -8, 5_000000, 1_700_000_000);
+        let (price, expo, conf, ts) = decode_legacy(&b).unwrap();
+        assert_eq!(price, 150_00000000);
+        assert_eq!(expo, -8);
+        assert_eq!(conf, 5_000000);
+        assert_eq!(ts, 1_700_000_000);
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut b = buf_with(1, -8, 0, 0);
+        b[0] ^= 0xff;
+        assert!(decode_legacy(&b).is_none());
+    }
+
+    #[test]
+    fn rejects_short_buffer() {
+        assert!(decode_legacy(&[0u8; 10]).is_none());
+    }
 }
 
 /// Verify that `current_price_x64` satisfies the strategy's trigger conditions,

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -117,6 +117,26 @@ pub struct PotAccount {
     /// Daily spend (input lamport-equivalents) per allowed_mints slot.
     /// Resets together with daily_spend_day.
     pub per_mint_daily_spent: [u64; 16],
+
+    // ─── Oracle / NAV (Phase A) ──────────────────────────────────────────
+
+    /// Which oracle backs this pot's price reads (0 = Pyth, 1 = Switchboard).
+    /// See `crate::oracle::OracleKind`.
+    pub oracle_kind: u8,
+
+    /// Max accepted confidence interval on an oracle price, as bps of price.
+    /// 0 = source default (pyth::DEFAULT_MAX_CONF_BPS).
+    pub max_oracle_conf_bps: u16,
+
+    /// Max accepted deviation between a realised swap price and the oracle
+    /// mid, as bps. 0 = guard disabled (no oracle account required).
+    pub max_oracle_deviation_bps: u16,
+
+    /// Forward-compatibility tail. New fields are carved from here so the
+    /// serialized layout never shifts and old accounts stay readable — this
+    /// is the LAST layout-breaking change before that guarantee holds.
+    /// Reduce this array by exactly the InitSpace of any field you add.
+    pub reserved: [u8; 128],
 }
 
 // ─── Config structs ───────────────────────────────────────────────────────
@@ -172,7 +192,30 @@ pub enum YieldStrategy {
 
 // ─── impl PotAccount ─────────────────────────────────────────────────────
 
+/// One priced leg of a pot's holdings for NAV: a token balance valued at an
+/// oracle price. Amounts/prices are caller-normalized to lamports of quote.
+pub struct NavLeg {
+    /// Lamport-equivalent value of this leg (token_amount × oracle_price,
+    /// already converted to the SOL quote by the caller/SDK).
+    pub lamport_value: u64,
+}
+
 impl PotAccount {
+    /// True NAV per share (×10^9), counting idle SOL PLUS the oracle-priced
+    /// value of every token leg the vault holds. This is the multi-asset
+    /// generalization of `share_price`, which only saw idle SOL and therefore
+    /// under-reported NAV for any pot mid-strategy. Pure function: the caller
+    /// supplies oracle-priced legs (on-chain from `oracle::read_price`, or in
+    /// the SDK from the Pyth Price API) so this stays layout-free.
+    pub fn nav_per_share(&self, vault_lamports: u64, legs: &[NavLeg]) -> u64 {
+        let total_value = legs
+            .iter()
+            .fold(vault_lamports as u128, |acc, leg| {
+                acc.saturating_add(leg.lamport_value as u128)
+            });
+        nav_per_share_raw(self.total_shares, total_value)
+    }
+
     /// Calculate the share price: vault_lamports / total_shares (scaled ×10^9).
     /// Saturating semantics: overflow paths return 0 — unreachable for any
     /// realistic vault size (mul would need vault > 1.8e10 SOL to overflow u128).
@@ -546,6 +589,20 @@ impl PotAccount {
     }
 }
 
+/// Pure NAV math: total holdings value (lamports) over total shares, scaled
+/// ×10^9. Seeds at 1.0 when there are no shares. Extracted so it can be unit
+/// tested without constructing a full PotAccount (which holds String fields).
+pub fn nav_per_share_raw(total_shares: u64, total_value: u128) -> u64 {
+    if total_shares == 0 {
+        return 1_000_000_000;
+    }
+    total_value
+        .checked_mul(1_000_000_000)
+        .unwrap_or(0)
+        .checked_div(total_shares as u128)
+        .unwrap_or(0) as u64
+}
+
 /// 0 = unlimited (loosest). Otherwise a higher cap is looser.
 fn cap_is_looser(old: u64, new: u64) -> bool {
     if old == new {
@@ -572,4 +629,34 @@ fn timelock_is_looser(old: i64, new: i64) -> bool {
         return false;
     }
     new < old
+}
+
+#[cfg(test)]
+mod nav_tests {
+    use super::nav_per_share_raw;
+
+    #[test]
+    fn nav_seeds_at_one_when_no_shares() {
+        assert_eq!(nav_per_share_raw(0, 0), 1_000_000_000);
+    }
+
+    #[test]
+    fn nav_counts_idle_sol_only() {
+        // 10 SOL vault, 10e9 shares → 1.0 NAV/share (×1e9).
+        assert_eq!(nav_per_share_raw(10_000_000_000, 10_000_000_000), 1_000_000_000);
+    }
+
+    #[test]
+    fn nav_includes_token_legs() {
+        // 4 SOL idle + a token leg worth 6 SOL = 10 SOL total, 10e9 shares
+        // → 1.0 NAV. share_price would have seen only the 4 SOL → 0.4, the
+        // exact under-reporting the oracle NAV fixes.
+        assert_eq!(nav_per_share_raw(10_000_000_000, 10_000_000_000), 1_000_000_000);
+        assert_eq!(nav_per_share_raw(10_000_000_000, 4_000_000_000), 400_000_000);
+    }
+
+    #[test]
+    fn nav_doubles_when_value_doubles() {
+        assert_eq!(nav_per_share_raw(10_000_000_000, 20_000_000_000), 2_000_000_000);
+    }
 }

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -246,6 +246,7 @@ TAIL_ERRORS = [
     ("OracleDeviationExceeded", "Realised swap price deviates from the oracle mid beyond the cap"),
     ("OracleKindUnsupported", "Configured oracle source is not supported"),
     ("OracleAccountMissing", "Oracle price account required for this guarded action"),
+    ("OracleGuardUnavailable", "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"),
 ]
 have = {e["name"] for e in idl["errors"]}
 next_code = max(e["code"] for e in idl["errors"]) + 1

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -69,6 +69,9 @@ add_ix("fund_fee_reserve",
         {"name": "system_program", "address": "11111111111111111111111111111111"}],
        [{"name": "args", "type": {"defined": {"name": "FundFeeReserveArgs"}}}],
        ["Fund the pot's keeper-gas reserve."])
+add_ix("set_oracle_config", [POT_W, AUTH_S],
+       [{"name": "args", "type": {"defined": {"name": "SetOracleConfigArgs"}}}],
+       ["Configure the pot's oracle source, confidence bound, and swap deviation guard."])
 
 # ── instructions missing from the stale May-2026 IDL ────────────────────────
 add_ix("redeem_tokens",
@@ -105,6 +108,10 @@ NEW_POT_FIELDS = [
     {"name": "allowed_programs_count", "type": "u8"},
     {"name": "max_asset_exposure_bps", "docs": ["Max cumulative daily spend toward one output mint, bps of vault. 0 = unlimited."], "type": "u16"},
     {"name": "per_mint_daily_spent", "docs": ["Daily spend per allowed_mints slot."], "type": {"array": ["u64", 16]}},
+    {"name": "oracle_kind", "docs": ["Oracle source: 0 = Pyth, 1 = Switchboard."], "type": "u8"},
+    {"name": "max_oracle_conf_bps", "docs": ["Max accepted oracle confidence interval, bps. 0 = source default."], "type": "u16"},
+    {"name": "max_oracle_deviation_bps", "docs": ["Max swap-vs-oracle deviation, bps. 0 = guard disabled."], "type": "u16"},
+    {"name": "reserved", "docs": ["Forward-compat tail — carve new fields from here, never insert."], "type": {"array": ["u8", 128]}},
 ]
 for t in idl["types"]:
     if t["name"] == "PotAccount":
@@ -154,6 +161,17 @@ add_type("SetRiskTimelockArgs", [
 add_type("FundFeeReserveArgs", [
     {"name": "amount", "type": "u64"},
 ])
+add_type("SetOracleConfigArgs", [
+    {"name": "oracle_kind", "type": "u8"},
+    {"name": "max_oracle_conf_bps", "type": "u16"},
+    {"name": "max_oracle_deviation_bps", "type": "u16"},
+])
+add_type("OracleConfigUpdated", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "oracle_kind", "type": "u8"},
+    {"name": "max_oracle_conf_bps", "type": "u16"},
+    {"name": "max_oracle_deviation_bps", "type": "u16"},
+])
 # event payload types
 add_type("SentinelUpdated", [
     {"name": "pot", "type": "pubkey"},
@@ -197,7 +215,8 @@ add_type("YieldRouted", [
 # ── events ──────────────────────────────────────────────────────────────────
 event_names = {e["name"] for e in idl["events"]}
 for ev in ["SentinelUpdated", "PotFrozenEvent", "ProposalCancelled",
-           "AllowedProgramsUpdated", "PendingParamsApplied", "YieldRouted"]:
+           "AllowedProgramsUpdated", "PendingParamsApplied", "YieldRouted",
+           "OracleConfigUpdated"]:
     if ev not in event_names:
         idl["events"].append({"name": ev, "discriminator": disc("event", ev)})
 
@@ -223,6 +242,10 @@ TAIL_ERRORS = [
     ("NoPendingChange", "No pending parameter change staged for this pot"),
     ("ProgramNotAllowed", "Program is not in the pot's protocol allowlist"),
     ("AssetExposureExceeded", "Daily exposure cap for this asset exceeded"),
+    ("OracleConfidenceTooLow", "Oracle confidence interval wider than the configured bound"),
+    ("OracleDeviationExceeded", "Realised swap price deviates from the oracle mid beyond the cap"),
+    ("OracleKindUnsupported", "Configured oracle source is not supported"),
+    ("OracleAccountMissing", "Oracle price account required for this guarded action"),
 ]
 have = {e["name"] for e in idl["errors"]}
 next_code = max(e["code"] for e in idl["errors"]) + 1

--- a/packages/program/tests/oracle_config.test.ts
+++ b/packages/program/tests/oracle_config.test.ts
@@ -68,23 +68,22 @@ describe('oracle config (Phase A)', () => {
     expect(s.reserved.length).to.equal(128)
   })
 
-  it('stores and round-trips an oracle config', async () => {
+  it('stores and round-trips the confidence bound', async () => {
     const pot = await createPot(`orc-set-${Date.now() % 1e6}`)
     await (program.methods as any)
-      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 150, maxOracleDeviationBps: 100 })
+      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 150, maxOracleDeviationBps: 0 })
       .accounts({ pot, authority })
       .rpc()
     let s: any = await (program.account as any).potAccount.fetch(pot)
     expect(s.maxOracleConfBps).to.equal(150)
-    expect(s.maxOracleDeviationBps).to.equal(100)
 
-    // Not risk-param-timelocked: a looser deviation cap applies immediately.
+    // Not risk-param-timelocked: a different bound applies immediately.
     await (program.methods as any)
-      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 200, maxOracleDeviationBps: 300 })
+      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 250, maxOracleDeviationBps: 0 })
       .accounts({ pot, authority })
       .rpc()
     s = await (program.account as any).potAccount.fetch(pot)
-    expect(s.maxOracleDeviationBps).to.equal(300)
+    expect(s.maxOracleConfBps).to.equal(250)
   })
 
   it('rejects an unsupported oracle_kind', async () => {
@@ -95,6 +94,17 @@ describe('oracle config (Phase A)', () => {
         .accounts({ pot, authority })
         .rpc(),
       'OracleKindUnsupported',
+    )
+  })
+
+  it('refuses to enable the deviation guard until Phase B two-feed pricing', async () => {
+    const pot = await createPot(`orc-dev-${Date.now() % 1e6}`)
+    await expectError(
+      (program.methods as any)
+        .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 0, maxOracleDeviationBps: 100 })
+        .accounts({ pot, authority })
+        .rpc(),
+      'OracleGuardUnavailable',
     )
   })
 })

--- a/packages/program/tests/oracle_config.test.ts
+++ b/packages/program/tests/oracle_config.test.ts
@@ -1,0 +1,100 @@
+// tests/oracle_config.test.ts
+//
+// Phase A — oracle config instruction coverage (localnet). The NAV math and
+// deviation/confidence helpers are unit-tested in Rust (cargo test); here we
+// verify the on-chain config surface:
+//   - defaults are Pyth / zeroed guards after create_pot
+//   - set_oracle_config stores values and round-trips
+//   - an unsupported oracle_kind is rejected
+//   - tightening then loosening the guard both persist (it is not timelocked)
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import { PublicKey, SystemProgram } from '@solana/web3.js'
+import { expect } from 'chai'
+
+const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+
+describe('oracle config (Phase A)', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+  const program = (anchor.workspace as any).PotVault as Program
+  const authority = provider.wallet.publicKey
+
+  function pdas(name: string) {
+    const [pot] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), authority.toBuffer(), Buffer.from(name)],
+      program.programId,
+    )
+    const [vault] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), pot.toBuffer()],
+      program.programId,
+    )
+    return { pot, vault }
+  }
+
+  async function createPot(name: string) {
+    const { pot, vault } = pdas(name)
+    await (program.methods as any)
+      .createPot({
+        name, emoji: '🔮', isPublic: true,
+        minDeposit: new BN(0), lockupSeconds: new BN(0), yieldStrategy: 0,
+        maxYieldAllocationBps: 0, maxTradeSizeBps: 0, maxMembers: 16,
+        tradeLevel: 0, withdrawLevel: 0, memberChangeLevel: 0,
+        settingsChangeLevel: 0, yieldChangeLevel: 0,
+        voteTimeoutSeconds: new BN(3600), quorumBps: 0, timelockSeconds: new BN(0),
+        protocolFeeBps: 0,
+      })
+      .accounts({ pot, vault, treasury: TREASURY, authority, systemProgram: SystemProgram.programId })
+      .rpc()
+    return pot
+  }
+
+  async function expectError(p: Promise<any>, code: string) {
+    try {
+      await p
+      expect.fail(`expected ${code}, but the tx succeeded`)
+    } catch (e: any) {
+      expect(String(e.error?.errorCode?.code ?? e), `expected ${code}`).to.include(code)
+    }
+  }
+
+  it('defaults to Pyth with guards disabled after create_pot', async () => {
+    const pot = await createPot(`orc-def-${Date.now() % 1e6}`)
+    const s: any = await (program.account as any).potAccount.fetch(pot)
+    expect(s.oracleKind).to.equal(0)
+    expect(s.maxOracleConfBps).to.equal(0)
+    expect(s.maxOracleDeviationBps).to.equal(0)
+    expect(s.reserved.length).to.equal(128)
+  })
+
+  it('stores and round-trips an oracle config', async () => {
+    const pot = await createPot(`orc-set-${Date.now() % 1e6}`)
+    await (program.methods as any)
+      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 150, maxOracleDeviationBps: 100 })
+      .accounts({ pot, authority })
+      .rpc()
+    let s: any = await (program.account as any).potAccount.fetch(pot)
+    expect(s.maxOracleConfBps).to.equal(150)
+    expect(s.maxOracleDeviationBps).to.equal(100)
+
+    // Not risk-param-timelocked: a looser deviation cap applies immediately.
+    await (program.methods as any)
+      .setOracleConfig({ oracleKind: 0, maxOracleConfBps: 200, maxOracleDeviationBps: 300 })
+      .accounts({ pot, authority })
+      .rpc()
+    s = await (program.account as any).potAccount.fetch(pot)
+    expect(s.maxOracleDeviationBps).to.equal(300)
+  })
+
+  it('rejects an unsupported oracle_kind', async () => {
+    const pot = await createPot(`orc-bad-${Date.now() % 1e6}`)
+    await expectError(
+      (program.methods as any)
+        .setOracleConfig({ oracleKind: 7, maxOracleConfBps: 0, maxOracleDeviationBps: 0 })
+        .accounts({ pot, authority })
+        .rpc(),
+      'OracleKindUnsupported',
+    )
+  })
+})

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -247,6 +247,90 @@ export async function fetchAllStrategyVaults(
   return accounts
 }
 
+// ── Oracle / NAV (Phase A) helpers ───────────────────────────────────────────
+//
+// On-chain the program reads Pyth with a confidence bound + a swap deviation
+// guard. Off-chain the UI prices NAV from the Pyth Price API (Hermes) — the
+// same source, no manual price entry anywhere. NAV counts idle SOL PLUS every
+// token leg the vault holds, fixing the SOL-only under-reporting of the old
+// share_price.
+
+/** One priced holding for NAV: a token amount and its USD price. */
+export interface NavHolding {
+  /** UI amount (already scaled out of base units). */
+  amount: number
+  /** USD price per unit (from Pyth Price API). */
+  priceUsd: number
+}
+
+export interface NavResult {
+  navUsd: number
+  navPerShareUsd: number
+}
+
+/**
+ * Compute pot NAV and NAV/share from idle SOL + token holdings, all priced
+ * via the Pyth Price API. `solPriceUsd` and each holding's `priceUsd` come
+ * from `fetchPythPrices`. Mirrors the on-chain `nav_per_share` semantics
+ * (seeds at 1.0 when there are no shares).
+ */
+export function computeNav(
+  idleSol: number,
+  solPriceUsd: number,
+  holdings: NavHolding[],
+  totalShares: number,
+): NavResult {
+  const navUsd =
+    idleSol * solPriceUsd +
+    holdings.reduce((acc, h) => acc + h.amount * h.priceUsd, 0)
+  const navPerShareUsd = totalShares > 0 ? navUsd / totalShares : solPriceUsd
+  return { navUsd, navPerShareUsd }
+}
+
+/**
+ * Fetch USD prices for a set of Pyth price-feed ids from the Hermes API.
+ * Returns a map feedId → priceUsd. Network failures resolve to an empty map
+ * so callers can render a graceful "—" rather than throw.
+ */
+export async function fetchPythPrices(
+  feedIds: string[],
+  hermesUrl = 'https://hermes.pyth.network',
+): Promise<Record<string, number>> {
+  if (feedIds.length === 0) return {}
+  try {
+    const qs = feedIds.map((id) => `ids[]=${id}`).join('&')
+    const res = await fetch(`${hermesUrl}/v2/updates/price/latest?${qs}`)
+    if (!res.ok) return {}
+    const json = (await res.json()) as any
+    const out: Record<string, number> = {}
+    for (const p of json.parsed ?? []) {
+      // price.price is an integer mantissa; expo is negative (e.g. -8).
+      const px = Number(p.price.price) * Math.pow(10, p.price.expo)
+      out[p.id] = px
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/** Configure the pot's oracle source + confidence/deviation guards (authority). */
+export async function buildSetOracleConfigTx(
+  program: Program<any>,
+  pot: PublicKey,
+  authority: PublicKey,
+  opts: { oracleKind?: number; maxOracleConfBps?: number; maxOracleDeviationBps?: number },
+): Promise<Transaction> {
+  return await (program as any).methods
+    .setOracleConfig({
+      oracleKind: opts.oracleKind ?? 0,
+      maxOracleConfBps: opts.maxOracleConfBps ?? 0,
+      maxOracleDeviationBps: opts.maxOracleDeviationBps ?? 0,
+    })
+    .accounts({ pot, authority })
+    .transaction()
+}
+
 // ── Security hardening (Phase A) helpers ─────────────────────────────────────
 //
 // Sentinel role, freeze/unfreeze, proposal cancellation, protocol allowlist

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -3673,6 +3673,11 @@
       "code": 6084,
       "name": "OracleAccountMissing",
       "msg": "Oracle price account required for this guarded action"
+    },
+    {
+      "code": 6085,
+      "name": "OracleGuardUnavailable",
+      "msg": "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"
     }
   ],
   "types": [

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -2855,6 +2855,42 @@
       "docs": [
         "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
+    },
+    {
+      "name": "set_oracle_config",
+      "discriminator": [
+        96,
+        171,
+        6,
+        98,
+        153,
+        183,
+        233,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetOracleConfigArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Configure the pot's oracle source, confidence bound, and swap deviation guard."
+      ]
     }
   ],
   "accounts": [
@@ -3196,6 +3232,19 @@
         63,
         203,
         70
+      ]
+    },
+    {
+      "name": "OracleConfigUpdated",
+      "discriminator": [
+        130,
+        6,
+        5,
+        137,
+        29,
+        155,
+        34,
+        68
       ]
     }
   ],
@@ -3604,6 +3653,26 @@
       "code": 6080,
       "name": "AssetExposureExceeded",
       "msg": "Daily exposure cap for this asset exceeded"
+    },
+    {
+      "code": 6081,
+      "name": "OracleConfidenceTooLow",
+      "msg": "Oracle confidence interval wider than the configured bound"
+    },
+    {
+      "code": 6082,
+      "name": "OracleDeviationExceeded",
+      "msg": "Realised swap price deviates from the oracle mid beyond the cap"
+    },
+    {
+      "code": 6083,
+      "name": "OracleKindUnsupported",
+      "msg": "Configured oracle source is not supported"
+    },
+    {
+      "code": 6084,
+      "name": "OracleAccountMissing",
+      "msg": "Oracle price account required for this guarded action"
     }
   ],
   "types": [
@@ -4349,6 +4418,39 @@
               "array": [
                 "u64",
                 16
+              ]
+            }
+          },
+          {
+            "name": "oracle_kind",
+            "docs": [
+              "Oracle source: 0 = Pyth, 1 = Switchboard."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "docs": [
+              "Max accepted oracle confidence interval, bps. 0 = source default."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "docs": [
+              "Max swap-vs-oracle deviation, bps. 0 = guard disabled."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Forward-compat tail \u2014 carve new fields from here, never insert."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
               ]
             }
           }
@@ -6012,6 +6114,50 @@
           {
             "name": "timestamp",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetOracleConfigArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle_kind",
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleConfigUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_kind",
+            "type": "u8"
+          },
+          {
+            "name": "max_oracle_conf_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_oracle_deviation_bps",
+            "type": "u16"
           }
         ]
       }


### PR DESCRIPTION
Phase A первого промпта (Oracle + frictionless liquid vaults). **Devnet/localnet only — никакого mainnet.** План был согласован; адверсариальный security-review проведён, Critical/High закрыты до PR.

## Что добавлено

- **Pyth confidence-фильтр** (`read_price_checked`) поверх существующих owner/magic/staleness — отклоняет цену, если `conf/price` > порога (дефолт 2%). Confidence — единственный guard, который **реально осмыслен сегодня**, и он включаем.
- **Оракул-интерфейс** (`oracle::{OracleKind, read_price, deviation_bps}`) — единая точка вызова для NAV/guard/caps; Switchboard подключится за тем же контрактом (параллельная задача) без правок мест вызова. Fail-closed: неподдерживаемый источник → revert.
- **NAV через оракул** (`nav_per_share` / `nav_per_share_raw`) — считает idle SOL **плюс** стоимость всех токен-ног, закрывая SOL-only недооценку `share_price` для пота в середине стратегии.
- **`set_oracle_config`** (authority-only) — источник + confidence-порог. SDK: `computeNav`, `fetchPythPrices` (Hermes), `buildSetOracleConfigTx`. Никакого ручного ввода цены нигде.
- **reserved[128]-хвост** в `PotAccount` — **последнее ломающее layout изменение**: дальше поля режутся из reserved, старые аккаунты остаются читаемыми. Закрывает весь класс Codex-замечаний про миграцию.

## Что НЕ включено / честные ограничения (по итогам аудита)

- **Deviation swap-guard плумбинг готов и fail-closed, но GATED OFF**: `set_oracle_config` отклоняет `deviation_bps > 0` (`OracleGuardUnavailable`). Сравнение output-per-input с одним USD-фидом дименсионально некорректно — «защита, которая не защищает» хуже, чем её отсутствие. Корректная two-feed (input-USD ÷ output-USD, нормализация по decimals) — Phase B. Код guard'а + семантика fail-closed сохранены и протестированы.
- **On-chain Pyth-чтение нацелено на legacy devnet-layout** (= devnet Pyth program, цель Phase A). Mainnet Receiver `PriceUpdateV2` (другой layout) — tracked Phase-B item через `pyth-solana-receiver-sdk`. Мы devnet-only, mainnet-чтение не шипится. Регрессионный тест `decode_legacy` фиксирует оффсеты.
- value-based per-asset cap честен только для wSOL-входов — оракул-нормализация token→token тоже Phase B (тот же staged-подход).

## Тесты
- **17 cargo unit** (deviation_bps, NAV math, OracleKind, decode_legacy offsets/magic/short-buffer).
- **18 localnet** (config defaults/round-trip/bad-kind/guard-gated + весь прежний security/redeem/smoke набор).
- tsc (web+sdk) 0 ошибок · next build · lint зелёные.

## Аудит — резолюция
1 HIGH (layout — devnet-correct, mainnet tracked, regression-locked), 1 MEDIUM (deviation guard — gated off), Finding 4 неактуально (`create_private_pot` отключён в mod.rs), 3/5/7 — позитивные подтверждения (fail-closed, confidence-математика, NAV-overflow), 6/8 — учтены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
