### PR TITLE
feat: Phase B — Liquid Vaults (auto-mint deposit, NAV core, redemption queue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The vault is a Solana program account from day one — no custodian, no operator
 
 A POT is a program-controlled treasury on Solana. Members deposit SOL, USDC, LSTs, LP positions or any tokenized asset, and receive proportional shares (NAV-priced). Every change to the treasury — swap, withdrawal, settings update — is a proposal that members vote on. The vault PDA signs the execution.
 
-- **Programmable ownership** — SPL-tokenized shares, redeemable any time
+- **Programmable ownership** — NAV-priced shares, redeemable any time; deposit mints internal share accounting, with an explicit `tokenize_shares` step to migrate to an SPL mint (auto-mint at NAV is in progress, Phase B)
 - **Onchain governance** — five levels from Autocracy (L0) to Consensus (L4), plus optional risk caps (`max_swap_pct`, `max_budget_grant_pct`, `require_admin_cosign`, `timelock_seconds`) and one-click presets (😎 Chill · ⚖️ Balanced · 🏛 Institutional)
 - **Security layer** — optional sentinel/guardian wallet (can freeze a pot and cancel proposals, can never move funds), risk-param timelock (loosening changes wait, tightening is instant), per-protocol CPI allowlist, per-asset daily exposure caps. Member exits are never blockable — withdraw and share redemption stay open even while frozen
 - **AI orchestration** — the BOT proposes, executes once quorum is reached, and can be delegated to vote on rules you set
@@ -214,7 +214,7 @@ Set `NEXT_PUBLIC_PRIVY_APP_ID` to enable email / Google / Twitter / LinkedIn log
 
 | Layer | Status |
 |---|---|
-| `pot_vault` Anchor program (30+ instructions: deposit · propose · vote · execute_swap) | 🟡 Devnet live |
+| `pot_vault` Anchor program (39 instructions: deposit · propose · vote · execute_swap) | 🟡 Devnet live |
 | Sentinel/guardian role — `freeze_pot` / `cancel_proposal`; member exits never blocked | 🟡 Devnet (pending redeploy) |
 | Risk-param timelock — loosening staged, applied via permissionless `apply_pending_params` | 🟡 Devnet (pending redeploy) |
 | Per-protocol CPI allowlist (8 slots) + per-asset daily exposure caps | 🟡 Devnet (pending redeploy) |
@@ -236,7 +236,7 @@ Set `NEXT_PUBLIC_PRIVY_APP_ID` to enable email / Google / Twitter / LinkedIn log
 | Governance presets — 😎 Chill / ⚖️ Balanced / 🏛 Institutional | 🟢 Live |
 | Proposal card v2 (risk check · quorum bar · countdown) + trust surfaces (vault PDA + explorer, frozen/sentinel chips) | 🟢 Live |
 | `pot_duel` program — 1v1 vault challenges (unlocks at Bud stage) | 🟡 Devnet live |
-| Pyth in-program oracle guard (re-reads price feeds inside `execute_swap`) | 🔵 Phase 2 |
+| Pyth in-program oracle layer — confidence-filtered price reads (`read_price_checked`) + oracle-priced NAV groundwork (`set_oracle_config`, `nav_per_share`) | 🟡 Devnet (swap deviation guard plumbed but gated off pending Phase B two-feed pricing; mainnet needs Pyth receiver `PriceUpdateV2` decode — currently devnet-legacy layout) |
 | Meteora DLMM + Kamino yield strategies | 🔵 Phase 2 |
 | Light Protocol ZK-compressed audit log | 🔵 Phase 2 |
 | Tamagotchi NFT mint (Bloom unlock, Metaplex) | 🟣 Phase 3 |

--- a/apps/web/src/hooks/usePots.ts
+++ b/apps/web/src/hooks/usePots.ts
@@ -630,6 +630,7 @@ export function useCreatePot() {
                 vault: vaultPda,
                 member: memberPda,
                 depositor: publicKey,
+                tokenMint: null, depositorAta: null, tokenProgram: null,
                 systemProgram: SystemProgram.programId,
               })
               .rpc()
@@ -702,6 +703,7 @@ export function useDeposit() {
               vault: vaultPda,
               member: memberPda,
               depositor: publicKey,
+              tokenMint: null, depositorAta: null, tokenProgram: null,
               systemProgram: SystemProgram.programId,
             })
             .rpc()

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -600,6 +600,21 @@
           "signer": true
         },
         {
+          "name": "token_mint",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "depositor_ata",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -2891,6 +2906,42 @@
       "docs": [
         "Configure the pot's oracle source, confidence bound, and swap deviation guard."
       ]
+    },
+    {
+      "name": "set_liquid_config",
+      "discriminator": [
+        226,
+        61,
+        203,
+        209,
+        107,
+        28,
+        77,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetLiquidConfigArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."
+      ]
     }
   ],
   "accounts": [
@@ -3245,6 +3296,19 @@
         155,
         34,
         68
+      ]
+    },
+    {
+      "name": "LiquidConfigUpdated",
+      "discriminator": [
+        144,
+        70,
+        46,
+        226,
+        62,
+        26,
+        39,
+        123
       ]
     }
   ],
@@ -6213,6 +6277,42 @@
           },
           {
             "name": "max_oracle_deviation_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetLiquidConfigArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquid_mode",
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidConfigUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquid_mode",
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
             "type": "u16"
           }
         ]

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -2942,6 +2942,157 @@
       "docs": [
         "Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."
       ]
+    },
+    {
+      "name": "request_redemption",
+      "discriminator": [
+        14,
+        62,
+        182,
+        237,
+        59,
+        79,
+        149,
+        22
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "member_account",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Queue a redemption: burn SPL shares, fix SOL owed at request-time NAV."
+      ]
+    },
+    {
+      "name": "fulfill_redemption",
+      "discriminator": [
+        135,
+        55,
+        160,
+        245,
+        203,
+        83,
+        197,
+        146
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true
+        },
+        {
+          "name": "cranker",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Permissionless crank: pay a queued redemption to its recorded member."
+      ]
+    },
+    {
+      "name": "cancel_redemption",
+      "discriminator": [
+        197,
+        243,
+        101,
+        86,
+        2,
+        37,
+        105,
+        106
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "member_account",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Cancel a Pending redemption \u2014 re-mint the member's shares."
+      ]
     }
   ],
   "accounts": [
@@ -3073,6 +3224,19 @@
         202,
         115,
         33
+      ]
+    },
+    {
+      "name": "RedemptionRequest",
+      "discriminator": [
+        117,
+        157,
+        214,
+        214,
+        64,
+        160,
+        31,
+        58
       ]
     }
   ],
@@ -3309,6 +3473,45 @@
         26,
         39,
         123
+      ]
+    },
+    {
+      "name": "RedemptionRequested",
+      "discriminator": [
+        245,
+        155,
+        98,
+        131,
+        210,
+        25,
+        137,
+        146
+      ]
+    },
+    {
+      "name": "RedemptionFulfilled",
+      "discriminator": [
+        73,
+        134,
+        70,
+        2,
+        131,
+        17,
+        134,
+        141
+      ]
+    },
+    {
+      "name": "RedemptionCancelled",
+      "discriminator": [
+        22,
+        106,
+        118,
+        26,
+        83,
+        110,
+        71,
+        174
       ]
     }
   ],
@@ -4563,6 +4766,13 @@
             "type": "u64"
           },
           {
+            "name": "pending_redemption_lamports",
+            "docs": [
+              "SOL owed to queued redemptions; subtracted from distributable everywhere."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "docs": [
               "Forward-compat tail \u2014 carve new fields from here, never insert."
@@ -4570,7 +4780,7 @@
             "type": {
               "array": [
                 "u8",
-                117
+                109
               ]
             }
           }
@@ -6314,6 +6524,151 @@
           {
             "name": "withdrawal_reserve_bps",
             "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequest",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_id",
+            "type": "u64"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "nav_snapshot",
+            "type": "u64"
+          },
+          {
+            "name": "requested_at",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "RedemptionStatus"
+              }
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pending"
+          },
+          {
+            "name": "Fulfilled"
+          },
+          {
+            "name": "Cancelled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_id",
+            "type": "u64"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionFulfilled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionCancelled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
           }
         ]
       }

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -2779,99 +2779,6 @@
       ]
     },
     {
-      "name": "redeem_tokens",
-      "discriminator": [
-        246,
-        98,
-        134,
-        41,
-        152,
-        33,
-        120,
-        69
-      ],
-      "accounts": [
-        {
-          "name": "pot",
-          "writable": true
-        },
-        {
-          "name": "vault",
-          "writable": true
-        },
-        {
-          "name": "member",
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "token_mint",
-          "writable": true
-        },
-        {
-          "name": "member_token_ata",
-          "writable": true
-        },
-        {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
-        {
-          "name": "token_amount",
-          "type": "u64"
-        }
-      ],
-      "docs": [
-        "Burn SPL share-tokens and receive SOL from the vault at NAV."
-      ]
-    },
-    {
-      "name": "route_to_yield",
-      "discriminator": [
-        82,
-        31,
-        61,
-        118,
-        105,
-        209,
-        221,
-        31
-      ],
-      "accounts": [
-        {
-          "name": "pot",
-          "writable": true
-        },
-        {
-          "name": "vault"
-        },
-        {
-          "name": "authority",
-          "writable": true,
-          "signer": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "RouteToYieldArgs"
-            }
-          }
-        }
-      ],
-      "docs": [
-        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
-      ]
-    },
-    {
       "name": "set_oracle_config",
       "discriminator": [
         96,
@@ -2962,10 +2869,6 @@
         },
         {
           "name": "vault"
-        },
-        {
-          "name": "member_account",
-          "writable": true
         },
         {
           "name": "request",
@@ -3068,10 +2971,6 @@
           "writable": true
         },
         {
-          "name": "member_account",
-          "writable": true
-        },
-        {
           "name": "token_mint",
           "writable": true
         },
@@ -3091,7 +2990,100 @@
       ],
       "args": [],
       "docs": [
-        "Cancel a Pending redemption \u2014 re-mint the member's shares."
+        "Cancel a Pending redemption \u2014 re-mint the member's SPL shares."
+      ]
+    },
+    {
+      "name": "redeem_tokens",
+      "discriminator": [
+        246,
+        98,
+        134,
+        41,
+        152,
+        33,
+        120,
+        69
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Burn SPL share-tokens and receive SOL from the vault at NAV."
+      ]
+    },
+    {
+      "name": "route_to_yield",
+      "discriminator": [
+        82,
+        31,
+        61,
+        118,
+        105,
+        209,
+        221,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RouteToYieldArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
     }
   ],
@@ -3975,6 +3967,11 @@
       "code": 6091,
       "name": "InvalidReserveBps",
       "msg": "Withdrawal reserve bps must be <= 10000"
+    },
+    {
+      "code": 6092,
+      "name": "TokenizedUseRedeem",
+      "msg": "Tokenized pot \u2014 exit via redeem_tokens / the redemption queue, not withdraw"
     }
   ],
   "types": [

--- a/apps/web/src/idl/pot_vault.json
+++ b/apps/web/src/idl/pot_vault.json
@@ -3678,6 +3678,36 @@
       "code": 6085,
       "name": "OracleGuardUnavailable",
       "msg": "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"
+    },
+    {
+      "code": 6086,
+      "name": "NotLiquidMode",
+      "msg": "Pot is not in liquid (SPL share) mode"
+    },
+    {
+      "code": 6087,
+      "name": "NavLegAccountInvalid",
+      "msg": "A required token-leg account or its oracle feed is missing/mismatched"
+    },
+    {
+      "code": 6088,
+      "name": "RedemptionNotQueued",
+      "msg": "Redemption can be paid instantly \u2014 use redeem_tokens, not the queue"
+    },
+    {
+      "code": 6089,
+      "name": "RedemptionNotPending",
+      "msg": "Redemption request is not in a Pending state"
+    },
+    {
+      "code": 6090,
+      "name": "RedemptionStillIlliquid",
+      "msg": "Liquid vault still lacks the SOL to fulfil this redemption"
+    },
+    {
+      "code": 6091,
+      "name": "InvalidReserveBps",
+      "msg": "Withdrawal reserve bps must be <= 10000"
     }
   ],
   "types": [
@@ -4448,6 +4478,27 @@
             "type": "u16"
           },
           {
+            "name": "liquid_mode",
+            "docs": [
+              "deposit auto-mints SPL shares at NAV when true."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
+            "docs": [
+              "Target % of NAV kept liquid in SOL for instant redemptions."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "next_redemption_id",
+            "docs": [
+              "Monotonic id for RedemptionRequest PDAs."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "docs": [
               "Forward-compat tail \u2014 carve new fields from here, never insert."
@@ -4455,7 +4506,7 @@
             "type": {
               "array": [
                 "u8",
-                128
+                117
               ]
             }
           }

--- a/docs/operations/READINESS.md
+++ b/docs/operations/READINESS.md
@@ -29,6 +29,17 @@
 - [ ] **Devnet re-deploy + pot recreation**: PotAccount layout grew in PR #69 — existing devnet pots are unreadable. `anchor deploy --provider.cluster devnet`, recreate seed/demo pots.
 - [ ] Re-run `npm run build` + `anchor test` on merged main (CI covers this).
 
+## Hard code gate — Pyth receiver decode (added Phase A/B)
+
+- [ ] **Mainnet Pyth = `PriceUpdateV2` (receiver), not the legacy layout the
+  program currently decodes.** The oracle reader (`pyth.rs::decode_legacy`) and
+  the multi-asset NAV path (Phase B B4) parse the legacy pythnet `PriceAccount`
+  format, which matches the **devnet** Pyth program but NOT mainnet's receiver.
+  Before mainnet: add `pyth-solana-receiver-sdk`, decode `PriceUpdateV2`
+  (`get_price_no_older_than` + feed-id check), keep `decode_legacy` only for
+  localnet test fixtures. Until done, oracle-priced NAV and the (currently
+  gated-off) deviation guard do not function on mainnet. Owner: YD / next oracle session.
+
 ## Launch-day security tasks
 
 - [ ] **Rotate Supabase keys** (service_role + anon) — they were exposed in a chat on 2026-04-26; rotation was deliberately deferred to release. Do it the same hour as launch.

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -211,6 +211,8 @@ pub enum ErrorCode {
     RedemptionStillIlliquid,
     #[msg("Withdrawal reserve bps must be <= 10000")]
     InvalidReserveBps,
+    #[msg("Tokenized pot — exit via redeem_tokens / the redemption queue, not withdraw")]
+    TokenizedUseRedeem,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/errors/mod.rs
+++ b/packages/program/programs/pot_vault/src/errors/mod.rs
@@ -197,6 +197,20 @@ pub enum ErrorCode {
     OracleAccountMissing,
     #[msg("Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet")]
     OracleGuardUnavailable,
+
+    // ─── Liquid Vaults (Phase B) ──────────────────────────────────────────
+    #[msg("Pot is not in liquid (SPL share) mode")]
+    NotLiquidMode,
+    #[msg("A required token-leg account or its oracle feed is missing/mismatched")]
+    NavLegAccountInvalid,
+    #[msg("Redemption can be paid instantly — use redeem_tokens, not the queue")]
+    RedemptionNotQueued,
+    #[msg("Redemption request is not in a Pending state")]
+    RedemptionNotPending,
+    #[msg("Liquid vault still lacks the SOL to fulfil this redemption")]
+    RedemptionStillIlliquid,
+    #[msg("Withdrawal reserve bps must be <= 10000")]
+    InvalidReserveBps,
 }
 
 /// Alias used throughout instruction handlers.

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -117,7 +117,13 @@ pub fn handler(ctx: Context<CreatePot>, params: CreatePotParams) -> Result<()> {
     pot.oracle_kind              = 0; // OracleKind::Pyth
     pot.max_oracle_conf_bps      = 0; // → pyth::DEFAULT_MAX_CONF_BPS
     pot.max_oracle_deviation_bps = 0; // guard disabled until configured
-    pot.reserved                 = [0u8; 128];
+
+    // Liquid Vaults (Phase B) — internal-shares (Seedling) default; opt into
+    // liquid mode after tokenizing via set_liquid_config.
+    pot.liquid_mode              = false;
+    pot.withdrawal_reserve_bps   = 0;
+    pot.next_redemption_id       = 0;
+    pot.reserved                 = [0u8; 117];
 
     pot.config = PotConfig {
         is_public: params.is_public,

--- a/packages/program/programs/pot_vault/src/instructions/create_pot.rs
+++ b/packages/program/programs/pot_vault/src/instructions/create_pot.rs
@@ -123,7 +123,8 @@ pub fn handler(ctx: Context<CreatePot>, params: CreatePotParams) -> Result<()> {
     pot.liquid_mode              = false;
     pot.withdrawal_reserve_bps   = 0;
     pot.next_redemption_id       = 0;
-    pot.reserved                 = [0u8; 117];
+    pot.pending_redemption_lamports = 0;
+    pot.reserved                 = [0u8; 109];
 
     pot.config = PotConfig {
         is_public: params.is_public,

--- a/packages/program/programs/pot_vault/src/instructions/deposit.rs
+++ b/packages/program/programs/pot_vault/src/instructions/deposit.rs
@@ -71,11 +71,16 @@ pub fn handler(ctx: Context<Deposit>, lamports: u64) -> Result<()> {
         );
     }
 
-    // Get current vault balance BEFORE transfer (critical for correct share math)
+    // Get current vault balance BEFORE transfer (critical for correct share math).
+    // Price against the balance that backs LIVE shares: subtract SOL already
+    // earmarked for queued redemptions so a new depositor isn't credited for
+    // funds that are owed out (pending == 0 for every non-queued pot, so this
+    // is a no-op for the common path).
     let vault_lamports = ctx.accounts.vault.lamports();
+    let nav_base = vault_lamports.saturating_sub(pot.pending_redemption_lamports);
 
     // Calculate shares
-    let shares = pot.lamports_to_shares(lamports, vault_lamports);
+    let shares = pot.lamports_to_shares(lamports, nav_base);
     require!(shares > 0, PotError::ArithmeticOverflow);
 
     // Transfer SOL: depositor → vault

--- a/packages/program/programs/pot_vault/src/instructions/deposit.rs
+++ b/packages/program/programs/pot_vault/src/instructions/deposit.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
+use anchor_spl::token::{self, Mint, Token, TokenAccount, MintTo};
 use crate::state::*;
 use crate::errors::PotError;
 
@@ -23,10 +24,26 @@ pub struct Deposit<'info> {
         seeds = [b"member", pot.key().as_ref(), depositor.key().as_ref()],
         bump
     )]
-    pub member: Account<'info, MemberAccount>,
+    pub member: Box<Account<'info, MemberAccount>>,
 
     #[account(mut)]
     pub depositor: Signer<'info>,
+
+    // ─── Liquid mode (Phase B) — required only when pot.liquid_mode ──────
+    // The SPL share mint (must equal pot.token_mint) and the depositor's ATA
+    // to receive auto-minted shares. Absent for legacy internal-shares pots.
+
+    /// The pot's SPL share mint. Validated against pot.token_mint in the
+    /// handler (only when liquid_mode).
+    #[account(mut)]
+    pub token_mint: Option<Box<Account<'info, Mint>>>,
+
+    /// Depositor's ATA for the share token (client creates it idempotently in
+    /// the same tx). Validated as ATA(token_mint, depositor) in the handler.
+    #[account(mut)]
+    pub depositor_ata: Option<Box<Account<'info, TokenAccount>>>,
+
+    pub token_program: Option<Program<'info, Token>>,
 
     pub system_program: Program<'info, System>,
 }
@@ -89,17 +106,86 @@ pub fn handler(ctx: Context<Deposit>, lamports: u64) -> Result<()> {
     member.last_deposit_at  = clock.unix_timestamp;
 
     // Update POT
-    let pot = &mut ctx.accounts.pot;
-    pot.total_shares     = pot.total_shares.checked_add(shares).ok_or(PotError::ArithmeticOverflow)?;
-    pot.last_activity_at = clock.unix_timestamp;
-    if is_new_member {
-        pot.member_count = pot.member_count.checked_add(1).ok_or(PotError::ArithmeticOverflow)?;
+    {
+        let pot = &mut ctx.accounts.pot;
+        pot.total_shares     = pot.total_shares.checked_add(shares).ok_or(PotError::ArithmeticOverflow)?;
+        pot.last_activity_at = clock.unix_timestamp;
+        if is_new_member {
+            pot.member_count = pot.member_count.checked_add(1).ok_or(PotError::ArithmeticOverflow)?;
+        }
+        pot.recalculate_tamagotchi();
     }
-    pot.recalculate_tamagotchi();
+
+    // Snapshot pot fields needed below before any CPI re-borrows ctx.accounts.
+    let liquid_mode      = ctx.accounts.pot.liquid_mode;
+    let pot_token_mint   = ctx.accounts.pot.token_mint;
+    let shares_per_sol   = ctx.accounts.pot.shares_per_sol;
+    let authority_key    = ctx.accounts.pot.authority;
+    let pot_name         = ctx.accounts.pot.name.clone();
+    let pot_bump         = ctx.accounts.pot.pot_bump;
+    let total_shares     = ctx.accounts.pot.total_shares;
+
+    // ─── Liquid mode: auto-mint SPL shares to the depositor at NAV ───────
+    // The internal `shares` above are NAV-priced (lamports_to_shares against
+    // the pre-deposit vault). Mint the matching SPL amount so the depositor
+    // holds a composable, redeemable token — no separate tokenize step, no
+    // vote (a deposit never removes existing members' funds).
+    //
+    // NAV note (Phase B / B4): lamports_to_shares prices against idle vault
+    // SOL only. For a pot holding non-SOL tokens this under-counts NAV;
+    // oracle multi-asset NAV at deposit (remaining_accounts legs) is the B4
+    // upgrade. Today liquid mode is correct for SOL-denominated pots.
+    if liquid_mode {
+        let mint = ctx
+            .accounts
+            .token_mint
+            .as_ref()
+            .ok_or(PotError::NotLiquidMode)?;
+        let ata = ctx
+            .accounts
+            .depositor_ata
+            .as_ref()
+            .ok_or(PotError::NotLiquidMode)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(PotError::NotLiquidMode)?;
+
+        require_keys_eq!(mint.key(), pot_token_mint, PotError::NotTokenized);
+        require_keys_eq!(ata.mint, mint.key(), PotError::NavLegAccountInvalid);
+        require_keys_eq!(
+            ata.owner,
+            ctx.accounts.depositor.key(),
+            PotError::NavLegAccountInvalid
+        );
+
+        let mint_amount = shares
+            .checked_mul(shares_per_sol)
+            .ok_or(PotError::ArithmeticOverflow)?;
+
+        let signer_seeds: &[&[u8]] =
+            &[b"pot", authority_key.as_ref(), pot_name.as_bytes(), core::slice::from_ref(&pot_bump)];
+
+        token::mint_to(
+            CpiContext::new_with_signer(
+                token_program.to_account_info(),
+                MintTo {
+                    mint: mint.to_account_info(),
+                    to: ata.to_account_info(),
+                    authority: ctx.accounts.pot.to_account_info(),
+                },
+                &[signer_seeds],
+            ),
+            mint_amount,
+        )?;
+
+        msg!("Liquid deposit: minted {} SPL shares to {}", mint_amount, ctx.accounts.depositor.key());
+    }
 
     msg!(
         "Deposited {} lamports → {} shares in POT \"{}\" (total shares: {})",
-        lamports, shares, pot.name, pot.total_shares
+        lamports, shares, pot_name, total_shares
     );
     Ok(())
 }

--- a/packages/program/programs/pot_vault/src/instructions/mod.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mod.rs
@@ -33,6 +33,9 @@ pub mod pot_admin;
 // Security hardening (Phase A)
 pub mod sentinel;
 
+// Liquid Vaults (Phase B) — redemption queue
+pub mod redemption;
+
 pub use create_pot::{CreatePot, CreatePotParams};
 pub(crate) use create_pot::__client_accounts_create_pot;
 pub use deposit::Deposit;
@@ -109,4 +112,13 @@ pub use sentinel::{
 pub(crate) use sentinel::{
     __client_accounts_cancel_proposal, __client_accounts_freeze_pot,
     __client_accounts_set_sentinel, __client_accounts_unfreeze_pot,
+};
+pub use redemption::{
+    cancel_redemption, fulfill_redemption, request_redemption,
+    CancelRedemption, FulfillRedemption, RequestRedemption,
+    RedemptionRequested, RedemptionFulfilled, RedemptionCancelled,
+};
+pub(crate) use redemption::{
+    __client_accounts_cancel_redemption, __client_accounts_fulfill_redemption,
+    __client_accounts_request_redemption,
 };

--- a/packages/program/programs/pot_vault/src/instructions/mod.rs
+++ b/packages/program/programs/pot_vault/src/instructions/mod.rs
@@ -86,17 +86,20 @@ pub use mark_proposal_passed::{MarkProposalPassed, ProposalMarkedPassed};
 pub(crate) use mark_proposal_passed::__client_accounts_mark_proposal_passed;
 pub use pot_admin::{
     apply_pending_params, fund_fee_reserve, pause_pot, set_allowed_mints,
-    set_allowed_programs, set_oracle_config, set_risk_timelock, set_spending_policy, unpause_pot,
+    set_allowed_programs, set_liquid_config, set_oracle_config, set_risk_timelock,
+    set_spending_policy, unpause_pot,
     AllowedMintsUpdated, AllowedProgramsUpdated, ApplyPendingParams, FeeReserveFunded,
-    FundFeeReserve, FundFeeReserveArgs, OracleConfigUpdated, PausePot, PendingParamsApplied,
-    SetAllowedMints, SetAllowedMintsArgs, SetAllowedPrograms, SetAllowedProgramsArgs,
-    SetOracleConfig, SetOracleConfigArgs, SetRiskTimelock,
+    FundFeeReserve, FundFeeReserveArgs, LiquidConfigUpdated, OracleConfigUpdated, PausePot,
+    PendingParamsApplied, SetAllowedMints, SetAllowedMintsArgs, SetAllowedPrograms,
+    SetAllowedProgramsArgs, SetLiquidConfig, SetLiquidConfigArgs, SetOracleConfig,
+    SetOracleConfigArgs, SetRiskTimelock,
     SetRiskTimelockArgs, SetSpendingPolicy, SetSpendingPolicyArgs,
 };
 pub(crate) use pot_admin::{
     __client_accounts_apply_pending_params, __client_accounts_fund_fee_reserve,
     __client_accounts_pause_pot, __client_accounts_set_allowed_mints,
-    __client_accounts_set_allowed_programs, __client_accounts_set_oracle_config,
+    __client_accounts_set_allowed_programs, __client_accounts_set_liquid_config,
+    __client_accounts_set_oracle_config,
     __client_accounts_set_risk_timelock, __client_accounts_set_spending_policy,
 };
 pub use sentinel::{

--- a/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
+++ b/packages/program/programs/pot_vault/src/instructions/pot_admin.rs
@@ -220,6 +220,50 @@ pub fn set_risk_timelock(
         Ok(())
 }
 
+// ─── Set liquid config (Phase B) ────────────────────────────────────────────
+//
+// Turn on liquid mode (deposit auto-mints SPL shares at NAV) and set the
+// withdrawal reserve target. Liquid mode requires the pot to be tokenized
+// first (token_mint set via init_token_mint / tokenize_shares). Authority-only.
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct SetLiquidConfigArgs {
+    pub liquid_mode: bool,
+    /// Target % of NAV kept liquid in SOL for instant redemptions (<= 10000).
+    pub withdrawal_reserve_bps: u16,
+}
+
+#[derive(Accounts)]
+pub struct SetLiquidConfig<'info> {
+    #[account(
+        mut,
+        constraint = authority.key() == pot.authority @ PotError::StrategyNotAdmin,
+    )]
+    pub pot: Box<Account<'info, PotAccount>>,
+    pub authority: Signer<'info>,
+}
+
+pub fn set_liquid_config(
+    ctx: Context<SetLiquidConfig>,
+    args: SetLiquidConfigArgs,
+) -> Result<()> {
+    require!(args.withdrawal_reserve_bps <= 10_000, PotError::InvalidReserveBps);
+    let pot = &mut ctx.accounts.pot;
+    // Can only enable liquid mode on a tokenized pot — otherwise deposit has
+    // no SPL mint to mint shares from.
+    if args.liquid_mode {
+        require!(pot.token_mint != Pubkey::default(), PotError::NotTokenized);
+    }
+    pot.liquid_mode = args.liquid_mode;
+    pot.withdrawal_reserve_bps = args.withdrawal_reserve_bps;
+    emit!(LiquidConfigUpdated {
+        pot: pot.key(),
+        liquid_mode: pot.liquid_mode,
+        withdrawal_reserve_bps: pot.withdrawal_reserve_bps,
+    });
+    Ok(())
+}
+
 // ─── Apply pending params (permissionless crank) ────────────────────────────
 
 #[derive(Accounts)]
@@ -392,4 +436,11 @@ pub struct OracleConfigUpdated {
         pub oracle_kind: u8,
         pub max_oracle_conf_bps: u16,
         pub max_oracle_deviation_bps: u16,
+}
+
+#[event]
+pub struct LiquidConfigUpdated {
+        pub pot: Pubkey,
+        pub liquid_mode: bool,
+        pub withdrawal_reserve_bps: u16,
 }

--- a/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redeem_tokens.rs
@@ -83,11 +83,13 @@ pub fn handler(ctx: Context<RedeemTokens>, token_amount: u64) -> Result<()> {
     let rent = Rent::get()?;
     let rent_min = rent.minimum_balance(0);
     let raw = ctx.accounts.vault.lamports();
-    let liquid = raw.saturating_sub(rent_min);
+    // Distributable = raw − rent − SOL earmarked for queued redemptions, so an
+    // instant exit can never dip into funds already owed to the queue.
+    let pot = &ctx.accounts.pot;
+    let liquid = pot.distributable_lamports(raw, rent_min);
     require!(liquid > 0, PotError::InsufficientVaultBalance);
 
     // NAV: lamports_out = internal_shares * liquid / total_shares.
-    let pot = &ctx.accounts.pot;
     let sol_out = pot.shares_to_lamports(internal_shares, liquid);
     require!(sol_out > 0, PotError::InvalidAmount);
 

--- a/packages/program/programs/pot_vault/src/instructions/redemption.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redemption.rs
@@ -1,0 +1,324 @@
+// PotBot v2 — redemption queue (Phase B, Variant α: payout fixed at request)
+//
+// request_redemption  — member burns SPL shares; lamports owed are FIXED at
+//                       request-time NAV and earmarked in
+//                       pot.pending_redemption_lamports. Used when the liquid
+//                       reserve can't pay instantly (or by choice).
+// fulfill_redemption  — permissionless crank: once the vault holds the SOL,
+//                       pay the recorded member exactly owed_lamports. The
+//                       keeper can call it but can ONLY pay request.member —
+//                       no path to redirect funds.
+// cancel_redemption   — member re-mints their shares while still Pending.
+//
+// Invariant: queued-owed SOL is subtracted from distributable everywhere
+// (deposit/redeem/withdraw), so a pending exit never inflates other holders'
+// NAV and instant exits never touch earmarked funds.
+
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+use anchor_spl::token::{self, Burn, Mint, MintTo, Token, TokenAccount};
+
+use crate::constants::VAULT_SEED;
+use crate::errors::PotError;
+use crate::state::pot::PotAccount;
+use crate::state::redemption::{RedemptionRequest, RedemptionStatus};
+use crate::state::member::MemberAccount;
+
+// ─── request_redemption ──────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct RequestRedemption<'info> {
+    #[account(mut)]
+    pub pot: Box<Account<'info, PotAccount>>,
+
+    /// CHECK: vault PDA (read-only here — NAV snapshot only, no SOL moves).
+    #[account(seeds = [VAULT_SEED, pot.key().as_ref()], bump = pot.vault_bump)]
+    pub vault: SystemAccount<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"member", pot.key().as_ref(), member.key().as_ref()],
+        bump = member_account.bump,
+    )]
+    pub member_account: Box<Account<'info, MemberAccount>>,
+
+    #[account(
+        init,
+        payer = member,
+        space = 8 + RedemptionRequest::INIT_SPACE,
+        seeds = [RedemptionRequest::SEED, pot.key().as_ref(), &pot.next_redemption_id.to_le_bytes()],
+        bump,
+    )]
+    pub request: Box<Account<'info, RedemptionRequest>>,
+
+    #[account(mut, constraint = token_mint.key() == pot.token_mint @ PotError::NotTokenized)]
+    pub token_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        constraint = member_token_ata.mint == token_mint.key() @ PotError::NavLegAccountInvalid,
+        constraint = member_token_ata.owner == member.key() @ PotError::NavLegAccountInvalid,
+    )]
+    pub member_token_ata: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut)]
+    pub member: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn request_redemption(ctx: Context<RequestRedemption>, token_amount: u64) -> Result<()> {
+    require!(ctx.accounts.pot.liquid_mode, PotError::NotLiquidMode);
+    require!(token_amount > 0, PotError::InvalidAmount);
+
+    let scale = ctx.accounts.pot.shares_per_sol;
+    require!(scale > 0, PotError::NotTokenized);
+    require!(token_amount % scale == 0, PotError::InvalidAmount);
+    let internal_shares = token_amount / scale;
+    require!(internal_shares > 0, PotError::InvalidAmount);
+
+    let now = Clock::get()?.unix_timestamp;
+    let rent_min = Rent::get()?.minimum_balance(0);
+    let raw = ctx.accounts.vault.lamports();
+
+    let pot = &ctx.accounts.pot;
+    // Distributable already nets out prior pending. owed is fixed here.
+    let distributable = pot.distributable_lamports(raw, rent_min);
+    let owed_lamports = pot.shares_to_lamports(internal_shares, distributable);
+    require!(owed_lamports > 0, PotError::InvalidAmount);
+    let nav_snapshot = pot.share_price(distributable);
+
+    // Burn the member's SPL shares now so they can't be double-spent while
+    // queued. The internal shares leave the live pool too.
+    token::burn(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Burn {
+                mint: ctx.accounts.token_mint.to_account_info(),
+                from: ctx.accounts.member_token_ata.to_account_info(),
+                authority: ctx.accounts.member.to_account_info(),
+            },
+        ),
+        token_amount,
+    )?;
+
+    let member_acct = &mut ctx.accounts.member_account;
+    member_acct.shares = member_acct
+        .shares
+        .checked_sub(internal_shares)
+        .ok_or(PotError::InsufficientShares)?;
+
+    let request = &mut ctx.accounts.request;
+    request.pot = ctx.accounts.pot.key();
+    request.member = ctx.accounts.member.key();
+    request.redemption_id = ctx.accounts.pot.next_redemption_id;
+    request.internal_shares = internal_shares;
+    request.owed_lamports = owed_lamports;
+    request.nav_snapshot = nav_snapshot;
+    request.requested_at = now;
+    request.status = RedemptionStatus::Pending;
+    request.bump = ctx.bumps.request;
+
+    let pot = &mut ctx.accounts.pot;
+    pot.total_shares = pot.total_shares.checked_sub(internal_shares).ok_or(PotError::ArithmeticOverflow)?;
+    pot.pending_redemption_lamports = pot
+        .pending_redemption_lamports
+        .checked_add(owed_lamports)
+        .ok_or(PotError::ArithmeticOverflow)?;
+    pot.next_redemption_id = pot.next_redemption_id.checked_add(1).ok_or(PotError::ArithmeticOverflow)?;
+    pot.last_activity_at = now;
+
+    emit!(RedemptionRequested {
+        pot: pot.key(),
+        request: request.key(),
+        member: request.member,
+        redemption_id: request.redemption_id,
+        internal_shares,
+        owed_lamports,
+    });
+    Ok(())
+}
+
+// ─── fulfill_redemption ──────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct FulfillRedemption<'info> {
+    #[account(mut)]
+    pub pot: Box<Account<'info, PotAccount>>,
+
+    /// CHECK: vault PDA, pays out via seeds-signed transfer.
+    #[account(mut, seeds = [VAULT_SEED, pot.key().as_ref()], bump = pot.vault_bump)]
+    pub vault: SystemAccount<'info>,
+
+    #[account(
+        mut,
+        has_one = pot @ PotError::UnauthorizedAccess,
+        constraint = request.status == RedemptionStatus::Pending @ PotError::RedemptionNotPending,
+    )]
+    pub request: Box<Account<'info, RedemptionRequest>>,
+
+    /// The recorded beneficiary. MUST equal request.member — the cranker
+    /// cannot redirect funds to itself.
+    /// CHECK: validated against request.member below.
+    #[account(mut, address = request.member @ PotError::UnauthorizedAccess)]
+    pub member: UncheckedAccount<'info>,
+
+    /// Permissionless crank (keeper or anyone). Pays gas only.
+    pub cranker: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn fulfill_redemption(ctx: Context<FulfillRedemption>) -> Result<()> {
+    let owed = ctx.accounts.request.owed_lamports;
+    let raw = ctx.accounts.vault.lamports();
+    let rent_min = Rent::get()?.minimum_balance(0);
+
+    // Must keep the account rent-exempt after paying `owed`. Because owed was
+    // earmarked in pending, the only failure mode is the vault hasn't been
+    // funded/unwound back to enough SOL yet.
+    require!(
+        raw.saturating_sub(owed) >= rent_min,
+        PotError::RedemptionStillIlliquid
+    );
+
+    let pot_key = ctx.accounts.pot.key();
+    let vault_bump = ctx.accounts.pot.vault_bump;
+    let signer_seeds: &[&[u8]] = &[VAULT_SEED, pot_key.as_ref(), core::slice::from_ref(&vault_bump)];
+    system_program::transfer(
+        CpiContext::new_with_signer(
+            ctx.accounts.system_program.to_account_info(),
+            system_program::Transfer {
+                from: ctx.accounts.vault.to_account_info(),
+                to: ctx.accounts.member.to_account_info(),
+            },
+            &[signer_seeds],
+        ),
+        owed,
+    )?;
+
+    let now = Clock::get()?.unix_timestamp;
+    ctx.accounts.request.status = RedemptionStatus::Fulfilled;
+    let pot = &mut ctx.accounts.pot;
+    pot.pending_redemption_lamports = pot.pending_redemption_lamports.saturating_sub(owed);
+    pot.last_activity_at = now;
+
+    emit!(RedemptionFulfilled {
+        pot: pot_key,
+        request: ctx.accounts.request.key(),
+        member: ctx.accounts.member.key(),
+        owed_lamports: owed,
+    });
+    Ok(())
+}
+
+// ─── cancel_redemption ───────────────────────────────────────────────────────
+
+#[derive(Accounts)]
+pub struct CancelRedemption<'info> {
+    #[account(mut)]
+    pub pot: Box<Account<'info, PotAccount>>,
+
+    #[account(
+        mut,
+        has_one = pot @ PotError::UnauthorizedAccess,
+        constraint = request.member == member.key() @ PotError::UnauthorizedAccess,
+        constraint = request.status == RedemptionStatus::Pending @ PotError::RedemptionNotPending,
+    )]
+    pub request: Box<Account<'info, RedemptionRequest>>,
+
+    #[account(
+        mut,
+        seeds = [b"member", pot.key().as_ref(), member.key().as_ref()],
+        bump = member_account.bump,
+    )]
+    pub member_account: Box<Account<'info, MemberAccount>>,
+
+    #[account(mut, constraint = token_mint.key() == pot.token_mint @ PotError::NotTokenized)]
+    pub token_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        constraint = member_token_ata.mint == token_mint.key() @ PotError::NavLegAccountInvalid,
+        constraint = member_token_ata.owner == member.key() @ PotError::NavLegAccountInvalid,
+    )]
+    pub member_token_ata: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut)]
+    pub member: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+pub fn cancel_redemption(ctx: Context<CancelRedemption>) -> Result<()> {
+    let internal_shares = ctx.accounts.request.internal_shares;
+    let owed = ctx.accounts.request.owed_lamports;
+    let scale = ctx.accounts.pot.shares_per_sol;
+    let mint_amount = internal_shares.checked_mul(scale).ok_or(PotError::ArithmeticOverflow)?;
+
+    // Re-mint the burned SPL shares back to the member.
+    let authority_key = ctx.accounts.pot.authority;
+    let pot_name = ctx.accounts.pot.name.clone();
+    let pot_bump = ctx.accounts.pot.pot_bump;
+    let signer_seeds: &[&[u8]] =
+        &[b"pot", authority_key.as_ref(), pot_name.as_bytes(), core::slice::from_ref(&pot_bump)];
+    token::mint_to(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            MintTo {
+                mint: ctx.accounts.token_mint.to_account_info(),
+                to: ctx.accounts.member_token_ata.to_account_info(),
+                authority: ctx.accounts.pot.to_account_info(),
+            },
+            &[signer_seeds],
+        ),
+        mint_amount,
+    )?;
+
+    let member_acct = &mut ctx.accounts.member_account;
+    member_acct.shares = member_acct.shares.checked_add(internal_shares).ok_or(PotError::ArithmeticOverflow)?;
+
+    ctx.accounts.request.status = RedemptionStatus::Cancelled;
+
+    let pot = &mut ctx.accounts.pot;
+    pot.total_shares = pot.total_shares.checked_add(internal_shares).ok_or(PotError::ArithmeticOverflow)?;
+    pot.pending_redemption_lamports = pot.pending_redemption_lamports.saturating_sub(owed);
+    pot.last_activity_at = Clock::get()?.unix_timestamp;
+
+    emit!(RedemptionCancelled {
+        pot: pot.key(),
+        request: ctx.accounts.request.key(),
+        member: ctx.accounts.member.key(),
+        internal_shares,
+    });
+    Ok(())
+}
+
+// ─── events ──────────────────────────────────────────────────────────────────
+
+#[event]
+pub struct RedemptionRequested {
+    pub pot: Pubkey,
+    pub request: Pubkey,
+    pub member: Pubkey,
+    pub redemption_id: u64,
+    pub internal_shares: u64,
+    pub owed_lamports: u64,
+}
+
+#[event]
+pub struct RedemptionFulfilled {
+    pub pot: Pubkey,
+    pub request: Pubkey,
+    pub member: Pubkey,
+    pub owed_lamports: u64,
+}
+
+#[event]
+pub struct RedemptionCancelled {
+    pub pot: Pubkey,
+    pub request: Pubkey,
+    pub member: Pubkey,
+    pub internal_shares: u64,
+}

--- a/packages/program/programs/pot_vault/src/instructions/redemption.rs
+++ b/packages/program/programs/pot_vault/src/instructions/redemption.rs
@@ -18,11 +18,19 @@ use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 use anchor_spl::token::{self, Burn, Mint, MintTo, Token, TokenAccount};
 
+// NOTE: the redemption queue operates purely on the SPL share-token + the
+// global total_shares ledger — the FUND claim. It deliberately does NOT touch
+// per-member `MemberAccount.shares`, which is a vote-weight field: SPL can be
+// transferred on a secondary market, so a holder's redeemable claim is their
+// token balance, not their (possibly stale) member.shares. Tying the queue to
+// member.shares would (a) wrongly let member.shares-based withdraw double-exit
+// and (b) block a legitimate secondary-market holder from redeeming. withdraw
+// is blocked for tokenized pots; member.shares ↔ SPL reconciliation for vote
+// weight is a Phase C governance item.
 use crate::constants::VAULT_SEED;
 use crate::errors::PotError;
 use crate::state::pot::PotAccount;
 use crate::state::redemption::{RedemptionRequest, RedemptionStatus};
-use crate::state::member::MemberAccount;
 
 // ─── request_redemption ──────────────────────────────────────────────────────
 
@@ -34,13 +42,6 @@ pub struct RequestRedemption<'info> {
     /// CHECK: vault PDA (read-only here — NAV snapshot only, no SOL moves).
     #[account(seeds = [VAULT_SEED, pot.key().as_ref()], bump = pot.vault_bump)]
     pub vault: SystemAccount<'info>,
-
-    #[account(
-        mut,
-        seeds = [b"member", pot.key().as_ref(), member.key().as_ref()],
-        bump = member_account.bump,
-    )]
-    pub member_account: Box<Account<'info, MemberAccount>>,
 
     #[account(
         init,
@@ -102,12 +103,6 @@ pub fn request_redemption(ctx: Context<RequestRedemption>, token_amount: u64) ->
         ),
         token_amount,
     )?;
-
-    let member_acct = &mut ctx.accounts.member_account;
-    member_acct.shares = member_acct
-        .shares
-        .checked_sub(internal_shares)
-        .ok_or(PotError::InsufficientShares)?;
 
     let request = &mut ctx.accounts.request;
     request.pot = ctx.accounts.pot.key();
@@ -175,11 +170,13 @@ pub fn fulfill_redemption(ctx: Context<FulfillRedemption>) -> Result<()> {
     let raw = ctx.accounts.vault.lamports();
     let rent_min = Rent::get()?.minimum_balance(0);
 
-    // Must keep the account rent-exempt after paying `owed`. Because owed was
-    // earmarked in pending, the only failure mode is the vault hasn't been
-    // funded/unwound back to enough SOL yet.
+    // Keep rent-exemption AND the rest of the queue's earmark covered after
+    // paying `owed`: require raw >= rent + pending (i.e. raw - owed >= rent +
+    // (pending - owed)). This prevents fulfilling one request out of order in
+    // a way that strands a later request's earmarked SOL (Finding 7).
+    let pending = ctx.accounts.pot.pending_redemption_lamports;
     require!(
-        raw.saturating_sub(owed) >= rent_min,
+        raw >= rent_min.saturating_add(pending),
         PotError::RedemptionStillIlliquid
     );
 
@@ -228,13 +225,6 @@ pub struct CancelRedemption<'info> {
     )]
     pub request: Box<Account<'info, RedemptionRequest>>,
 
-    #[account(
-        mut,
-        seeds = [b"member", pot.key().as_ref(), member.key().as_ref()],
-        bump = member_account.bump,
-    )]
-    pub member_account: Box<Account<'info, MemberAccount>>,
-
     #[account(mut, constraint = token_mint.key() == pot.token_mint @ PotError::NotTokenized)]
     pub token_mint: Box<Account<'info, Mint>>,
 
@@ -275,9 +265,6 @@ pub fn cancel_redemption(ctx: Context<CancelRedemption>) -> Result<()> {
         ),
         mint_amount,
     )?;
-
-    let member_acct = &mut ctx.accounts.member_account;
-    member_acct.shares = member_acct.shares.checked_add(internal_shares).ok_or(PotError::ArithmeticOverflow)?;
 
     ctx.accounts.request.status = RedemptionStatus::Cancelled;
 

--- a/packages/program/programs/pot_vault/src/instructions/withdraw.rs
+++ b/packages/program/programs/pot_vault/src/instructions/withdraw.rs
@@ -35,6 +35,14 @@ pub fn handler(ctx: Context<Withdraw>, shares: u64) -> Result<()> {
     let pot = &ctx.accounts.pot;
     let clock = Clock::get()?;
 
+    // CRITICAL: a tokenized pot's fund claim is the SPL share-token, not
+    // member.shares. Liquid deposit credits BOTH (member.shares for vote
+    // weight + SPL for redemption); allowing the member.shares-based withdraw
+    // here too would let a holder exit twice (redeem the SPL AND withdraw the
+    // shares) and drain other members. For a tokenized pot the only exit is
+    // redeem_tokens / the redemption queue.
+    require!(pot.token_mint == Pubkey::default(), PotError::TokenizedUseRedeem);
+
     require!(shares > 0 && shares <= member.shares, PotError::InsufficientShares);
     require!(shares <= pot.total_shares, PotError::InsufficientShares);
 

--- a/packages/program/programs/pot_vault/src/instructions/withdraw.rs
+++ b/packages/program/programs/pot_vault/src/instructions/withdraw.rs
@@ -44,14 +44,17 @@ pub fn handler(ctx: Context<Withdraw>, shares: u64) -> Result<()> {
     );
 
     let vault_lamports = ctx.accounts.vault.lamports();
-    let lamports_out = pot.shares_to_lamports(shares, vault_lamports);
-    require!(lamports_out > 0, PotError::ArithmeticOverflow);
-
     let rent = Rent::get()?;
     let min_balance = rent.minimum_balance(0);
+    // Price + pay against distributable (raw − rent − queued-owed) so an
+    // internal-shares exit can't drain SOL earmarked for the redemption queue.
+    let distributable = pot.distributable_lamports(vault_lamports, min_balance);
+    let lamports_out = pot.shares_to_lamports(shares, distributable);
+    require!(lamports_out > 0, PotError::ArithmeticOverflow);
+
     let remaining_lamports = vault_lamports.checked_sub(lamports_out).ok_or(PotError::InsufficientVaultBalance)?;
     require!(
-        remaining_lamports >= min_balance,
+        remaining_lamports >= min_balance.saturating_add(pot.pending_redemption_lamports),
         PotError::InsufficientVaultBalance
     );
 

--- a/packages/program/programs/pot_vault/src/lib.rs
+++ b/packages/program/programs/pot_vault/src/lib.rs
@@ -294,6 +294,23 @@ pub mod pot_vault {
         instructions::pot_admin::set_liquid_config(ctx, args)
     }
 
+    /// Queue a redemption: burn SPL shares, fix the SOL owed at request-time
+    /// NAV, earmark it. Used when the liquid reserve can't pay instantly.
+    pub fn request_redemption(ctx: Context<RequestRedemption>, token_amount: u64) -> Result<()> {
+        instructions::redemption::request_redemption(ctx, token_amount)
+    }
+
+    /// Permissionless crank: pay a queued redemption to its recorded member
+    /// once the vault holds the SOL. The cranker can never redirect funds.
+    pub fn fulfill_redemption(ctx: Context<FulfillRedemption>) -> Result<()> {
+        instructions::redemption::fulfill_redemption(ctx)
+    }
+
+    /// Cancel a Pending redemption — re-mint the member's shares.
+    pub fn cancel_redemption(ctx: Context<CancelRedemption>) -> Result<()> {
+        instructions::redemption::cancel_redemption(ctx)
+    }
+
     // ─── Yield routing (Phase 4 stub — emit-only) ─────────────────────────
 
     /// Route idle vault SOL to a yield protocol (Kamino / Meteora).

--- a/packages/program/programs/pot_vault/src/lib.rs
+++ b/packages/program/programs/pot_vault/src/lib.rs
@@ -284,6 +284,16 @@ pub mod pot_vault {
         instructions::pot_admin::set_oracle_config(ctx, args)
     }
 
+    /// Enable liquid mode (deposit auto-mints SPL shares at NAV) and set the
+    /// withdrawal reserve target (Phase B). Authority-only; pot must be
+    /// tokenized first.
+    pub fn set_liquid_config(
+        ctx: Context<SetLiquidConfig>,
+        args: SetLiquidConfigArgs,
+    ) -> Result<()> {
+        instructions::pot_admin::set_liquid_config(ctx, args)
+    }
+
     // ─── Yield routing (Phase 4 stub — emit-only) ─────────────────────────
 
     /// Route idle vault SOL to a yield protocol (Kamino / Meteora).

--- a/packages/program/programs/pot_vault/src/oracle/mod.rs
+++ b/packages/program/programs/pot_vault/src/oracle/mod.rs
@@ -56,6 +56,49 @@ pub fn deviation_bps(executed_x64: u128, oracle_mid_x64: u128) -> u16 {
     bps.min(u16::MAX as u128) as u16
 }
 
+/// Value a token leg in SOL lamports from two Pyth readings (the token's
+/// USD feed and the SOL/USD feed) plus the token's decimals. Pure integer
+/// math — no Q64 round-trip — so it is exact and unit-testable.
+///
+///   token_usd = t_mant · 10^t_expo ,  sol_usd = s_mant · 10^s_expo
+///   lamports  = token_amount · (token_usd / sol_usd) · 10^(9 − token_decimals)
+///             = token_amount · t_mant · 10^E / s_mant ,
+///   where E = t_expo − s_expo + 9 − token_decimals.
+///
+/// Returns None on non-positive prices or arithmetic overflow (caller treats
+/// None as "can't price → revert", fail-closed).
+pub fn leg_value_lamports(
+    token_amount: u64,
+    token_decimals: u8,
+    t_mant: i64,
+    t_expo: i32,
+    s_mant: i64,
+    s_expo: i32,
+) -> Option<u64> {
+    if t_mant <= 0 || s_mant <= 0 {
+        return None;
+    }
+    let amount = token_amount as u128;
+    let t = t_mant as u128;
+    let s = s_mant as u128;
+    let e: i32 = t_expo - s_expo + 9 - token_decimals as i32;
+
+    let mut num = amount.checked_mul(t)?;
+    let lamports = if e >= 0 {
+        let scale = 10u128.checked_pow(e as u32)?;
+        num = num.checked_mul(scale)?;
+        num.checked_div(s)?
+    } else {
+        let scale = 10u128.checked_pow((-e) as u32)?;
+        let denom = s.checked_mul(scale)?;
+        num.checked_div(denom)?
+    };
+    if lamports > u64::MAX as u128 {
+        return None;
+    }
+    Some(lamports as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,5 +131,39 @@ mod tests {
     fn deviation_saturates_huge_gap() {
         // 10x the mid → 90_000 bps, clamped to u16::MAX.
         assert_eq!(deviation_bps(100_000, 10_000), u16::MAX);
+    }
+
+    // ─── leg valuation ───────────────────────────────────────────────────
+
+    #[test]
+    fn leg_usdc_at_one_dollar_sol_at_150() {
+        // 1 USDC (6 decimals) with SOL at $150 → 1/150 SOL = 6_666_666 lamports.
+        let v = leg_value_lamports(1_000_000, 6, 100_000_000, -8, 15_000_000_000, -8);
+        assert_eq!(v, Some(6_666_666));
+    }
+
+    #[test]
+    fn leg_same_price_same_decimals_is_one_to_one() {
+        // A 9-decimal token priced exactly like SOL: amount → equal lamports.
+        let v = leg_value_lamports(2_500_000_000, 9, 15_000_000_000, -8, 15_000_000_000, -8);
+        assert_eq!(v, Some(2_500_000_000));
+    }
+
+    #[test]
+    fn leg_scales_with_token_price() {
+        // Token at $300 (2× SOL's $150), 9 decimals: 1 token → 2 SOL.
+        let v = leg_value_lamports(1_000_000_000, 9, 30_000_000_000, -8, 15_000_000_000, -8);
+        assert_eq!(v, Some(2_000_000_000));
+    }
+
+    #[test]
+    fn leg_rejects_nonpositive_price() {
+        assert_eq!(leg_value_lamports(1, 6, 0, -8, 1, -8), None);
+        assert_eq!(leg_value_lamports(1, 6, 1, -8, -5, -8), None);
+    }
+
+    #[test]
+    fn leg_zero_amount_is_zero() {
+        assert_eq!(leg_value_lamports(0, 6, 100_000_000, -8, 15_000_000_000, -8), Some(0));
     }
 }

--- a/packages/program/programs/pot_vault/src/pyth.rs
+++ b/packages/program/programs/pot_vault/src/pyth.rs
@@ -50,11 +50,15 @@ const STALENESS_SECONDS: i64 = 60;
 /// means the oracle is unsure — reject rather than trade on a fuzzy price.
 pub const DEFAULT_MAX_CONF_BPS: u16 = 200;
 
-/// A validated oracle reading: price as Q64.64, the confidence interval
-/// expressed in bps of price, and the publish timestamp.
+/// A validated oracle reading: price as Q64.64 plus the raw Pyth mantissa /
+/// exponent (kept so leg valuation can use clean integer math without the
+/// 2^64 fixed-point round-trip), the confidence interval in bps, and the
+/// publish timestamp.
 #[derive(Clone, Copy, Debug)]
 pub struct OraclePrice {
     pub price_x64: u128,
+    pub mantissa: i64,
+    pub expo: i32,
     pub conf_bps: u16,
     pub publish_time: i64,
 }
@@ -180,6 +184,8 @@ pub fn read_price_checked(account: &UncheckedAccount, max_conf_bps: u16) -> Resu
 
     Ok(OraclePrice {
         price_x64: price_to_q64(price, expo)?,
+        mantissa: price,
+        expo,
         conf_bps: conf_bps.min(u16::MAX as u64) as u16,
         publish_time,
     })

--- a/packages/program/programs/pot_vault/src/state/mod.rs
+++ b/packages/program/programs/pot_vault/src/state/mod.rs
@@ -12,6 +12,7 @@ pub mod private_pot;
 // Strategy layer v2
 pub mod strategy;
 pub mod proposal_swap;
+pub mod redemption;
 
 pub use pot::*;
 pub use member::*;
@@ -24,3 +25,4 @@ pub use tamagotchi_nft::*;
 pub use private_pot::*;
 pub use strategy::*;
 pub use proposal_swap::*;
+pub use redemption::*;

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -147,11 +147,18 @@ pub struct PotAccount {
     /// Monotonic id for RedemptionRequest PDAs under this pot.
     pub next_redemption_id: u64,
 
+    /// SOL owed to queued (Pending) redemptions, fixed at request-time NAV.
+    /// Earmarked in the vault: it is SUBTRACTED from distributable value
+    /// everywhere shares are priced or paid (deposit, redeem, withdraw), so
+    /// instant exits and new deposits can never touch funds owed to the queue
+    /// and remaining holders' NAV/share is unaffected by a pending exit.
+    pub pending_redemption_lamports: u64,
+
     /// Forward-compatibility tail. New fields are carved from here so the
     /// serialized layout never shifts and old accounts stay readable.
     /// Reduce this array by exactly the InitSpace of any field you add.
-    /// Phase B consumed 11 bytes (bool 1 + u16 2 + u64 8): 128 → 117.
-    pub reserved: [u8; 117],
+    /// Phase B consumed 19 bytes (bool 1 + u16 2 + u64 8 + u64 8): 128 → 109.
+    pub reserved: [u8; 109],
 }
 
 // ─── Config structs ───────────────────────────────────────────────────────
@@ -229,6 +236,16 @@ impl PotAccount {
                 acc.saturating_add(leg.lamport_value as u128)
             });
         nav_per_share_raw(self.total_shares, total_value)
+    }
+
+    /// Lamports in the vault that actually back live shares: raw balance minus
+    /// the rent-exempt minimum minus SOL already earmarked for the redemption
+    /// queue. This is the canonical base for pricing deposits and paying
+    /// instant exits — never let either dip into queued-owed funds.
+    pub fn distributable_lamports(&self, vault_lamports: u64, rent_min: u64) -> u64 {
+        vault_lamports
+            .saturating_sub(rent_min)
+            .saturating_sub(self.pending_redemption_lamports)
     }
 
     /// Calculate the share price: vault_lamports / total_shares (scaled ×10^9).

--- a/packages/program/programs/pot_vault/src/state/pot.rs
+++ b/packages/program/programs/pot_vault/src/state/pot.rs
@@ -132,11 +132,26 @@ pub struct PotAccount {
     /// mid, as bps. 0 = guard disabled (no oracle account required).
     pub max_oracle_deviation_bps: u16,
 
+    // ─── Liquid Vaults (Phase B) — carved from reserved, NO layout shift ──
+
+    /// When true, `deposit` mints SPL share-tokens to the depositor at NAV in
+    /// the same tx (frictionless join). False = legacy internal-shares path
+    /// (Seedling, saves SPL rent). Only meaningful once `token_mint` is set.
+    pub liquid_mode: bool,
+
+    /// Target fraction of NAV (bps) kept liquid in SOL for instant redemptions.
+    /// A redeem that would drop liquidity below this is queued instead of paid
+    /// instantly. 0 = no reserve target (instant whenever liquid SOL suffices).
+    pub withdrawal_reserve_bps: u16,
+
+    /// Monotonic id for RedemptionRequest PDAs under this pot.
+    pub next_redemption_id: u64,
+
     /// Forward-compatibility tail. New fields are carved from here so the
-    /// serialized layout never shifts and old accounts stay readable — this
-    /// is the LAST layout-breaking change before that guarantee holds.
+    /// serialized layout never shifts and old accounts stay readable.
     /// Reduce this array by exactly the InitSpace of any field you add.
-    pub reserved: [u8; 128],
+    /// Phase B consumed 11 bytes (bool 1 + u16 2 + u64 8): 128 → 117.
+    pub reserved: [u8; 117],
 }
 
 // ─── Config structs ───────────────────────────────────────────────────────

--- a/packages/program/programs/pot_vault/src/state/redemption.rs
+++ b/packages/program/programs/pot_vault/src/state/redemption.rs
@@ -1,0 +1,43 @@
+// PotBot v2 — RedemptionRequest (Phase B, Liquid Vaults)
+//
+// A queued redemption: created when a member's redeem cannot be paid instantly
+// (liquid SOL below the withdrawal reserve). The member's SPL share-tokens are
+// burned at request time (so they can't be double-spent while queued); the
+// recorded `shares` is the INTERNAL share amount owed. A keeper/curator unwinds
+// tokens→SOL via the normal propose/execute path, then `fulfill_redemption`
+// pays the recorded member from the vault. The member may `cancel_redemption`
+// to re-mint their shares while still Pending.
+//
+// Trust invariant: fulfillment can ONLY pay the `member` recorded here; the
+// keeper has no path to redirect funds to itself.
+
+use anchor_lang::prelude::*;
+
+#[account]
+#[derive(InitSpace)]
+pub struct RedemptionRequest {
+    pub pot: Pubkey,
+    pub member: Pubkey,
+    /// Monotonic id within the pot (pot.next_redemption_id at creation).
+    pub redemption_id: u64,
+    /// Internal share units owed (already burned from the member's SPL ATA).
+    pub internal_shares: u64,
+    /// NAV-per-share (×10^9) snapshotted at request time, for transparency /
+    /// UI. Payout is recomputed at fulfillment against live liquidity so the
+    /// member is never paid more than their pro-rata of the vault.
+    pub nav_snapshot: u64,
+    pub requested_at: i64,
+    pub status: RedemptionStatus,
+    pub bump: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace, PartialEq, Debug)]
+pub enum RedemptionStatus {
+    Pending,
+    Fulfilled,
+    Cancelled,
+}
+
+impl RedemptionRequest {
+    pub const SEED: &'static [u8] = b"redemption";
+}

--- a/packages/program/programs/pot_vault/src/state/redemption.rs
+++ b/packages/program/programs/pot_vault/src/state/redemption.rs
@@ -20,11 +20,13 @@ pub struct RedemptionRequest {
     pub member: Pubkey,
     /// Monotonic id within the pot (pot.next_redemption_id at creation).
     pub redemption_id: u64,
-    /// Internal share units owed (already burned from the member's SPL ATA).
+    /// Internal share units owed (already burned from the member's SPL ATA
+    /// and removed from total_shares at request time).
     pub internal_shares: u64,
-    /// NAV-per-share (×10^9) snapshotted at request time, for transparency /
-    /// UI. Payout is recomputed at fulfillment against live liquidity so the
-    /// member is never paid more than their pro-rata of the vault.
+    /// Lamports owed, FIXED at request-time NAV (Variant α). Fulfillment pays
+    /// exactly this; it is earmarked in pot.pending_redemption_lamports.
+    pub owed_lamports: u64,
+    /// NAV-per-share (×10^9) snapshotted at request time, for UI/transparency.
     pub nav_snapshot: u64,
     pub requested_at: i64,
     pub status: RedemptionStatus,

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -72,6 +72,22 @@ add_ix("fund_fee_reserve",
 add_ix("set_oracle_config", [POT_W, AUTH_S],
        [{"name": "args", "type": {"defined": {"name": "SetOracleConfigArgs"}}}],
        ["Configure the pot's oracle source, confidence bound, and swap deviation guard."])
+add_ix("set_liquid_config", [POT_W, AUTH_S],
+       [{"name": "args", "type": {"defined": {"name": "SetLiquidConfigArgs"}}}],
+       ["Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."])
+
+# ── deposit: optional liquid-mode SPL accounts (Phase B) ────────────────────
+for ins in idl["instructions"]:
+    if ins["name"] == "deposit":
+        acc_names = [a["name"] for a in ins["accounts"]]
+        if "token_mint" not in acc_names:
+            at = acc_names.index("system_program")
+            ins["accounts"][at:at] = [
+                {"name": "token_mint", "writable": True, "optional": True},
+                {"name": "depositor_ata", "writable": True, "optional": True},
+                {"name": "token_program", "optional": True,
+                 "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+            ]
 
 # ── instructions missing from the stale May-2026 IDL ────────────────────────
 add_ix("redeem_tokens",
@@ -173,6 +189,15 @@ add_type("SetOracleConfigArgs", [
     {"name": "max_oracle_conf_bps", "type": "u16"},
     {"name": "max_oracle_deviation_bps", "type": "u16"},
 ])
+add_type("SetLiquidConfigArgs", [
+    {"name": "liquid_mode", "type": "bool"},
+    {"name": "withdrawal_reserve_bps", "type": "u16"},
+])
+add_type("LiquidConfigUpdated", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "liquid_mode", "type": "bool"},
+    {"name": "withdrawal_reserve_bps", "type": "u16"},
+])
 add_type("OracleConfigUpdated", [
     {"name": "pot", "type": "pubkey"},
     {"name": "oracle_kind", "type": "u8"},
@@ -223,7 +248,7 @@ add_type("YieldRouted", [
 event_names = {e["name"] for e in idl["events"]}
 for ev in ["SentinelUpdated", "PotFrozenEvent", "ProposalCancelled",
            "AllowedProgramsUpdated", "PendingParamsApplied", "YieldRouted",
-           "OracleConfigUpdated"]:
+           "OracleConfigUpdated", "LiquidConfigUpdated"]:
     if ev not in event_names:
         idl["events"].append({"name": ev, "discriminator": disc("event", ev)})
 

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -31,14 +31,17 @@ for acc in idl["accounts"]:
     assert acc["discriminator"] == disc("account", acc["name"]), f"acct disc mismatch: {acc['name']}"
 print(f"self-check OK: {len(idl['instructions'])} ix, {len(idl['events'])} events, {len(idl['accounts'])} accounts")
 
-names = {i["name"] for i in idl["instructions"]}
-
 def add_ix(name, accounts, args, docs=None):
-    if name in names:
-        return
+    # Idempotent upsert: every add_ix target is an instruction THIS script
+    # owns (new, or one anchor's broken IDL-gen drops). Replace any existing
+    # copy so account-list changes (e.g. dropping member_account) re-apply when
+    # patching from an already-patched base. Real IDL-gen instructions
+    # (create_pot, deposit, vote, …) are never added here, only modified in
+    # place, so replacing managed names is safe.
     entry = {"name": name, "discriminator": disc("global", name), "accounts": accounts, "args": args}
     if docs:
         entry["docs"] = docs
+    idl["instructions"] = [i for i in idl["instructions"] if i["name"] != name]
     idl["instructions"].append(entry)
 
 POT_W = {"name": "pot", "writable": True}
@@ -81,7 +84,6 @@ _TOKEN_PROG = {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCW
 _SYS = {"name": "system_program", "address": "11111111111111111111111111111111"}
 add_ix("request_redemption",
        [POT_W, {"name": "vault"},
-        {"name": "member_account", "writable": True},
         {"name": "request", "writable": True},
         {"name": "token_mint", "writable": True},
         {"name": "member_token_ata", "writable": True},
@@ -99,13 +101,12 @@ add_ix("fulfill_redemption",
 add_ix("cancel_redemption",
        [POT_W,
         {"name": "request", "writable": True},
-        {"name": "member_account", "writable": True},
         {"name": "token_mint", "writable": True},
         {"name": "member_token_ata", "writable": True},
         {"name": "member", "writable": True, "signer": True},
         _TOKEN_PROG],
        [],
-       ["Cancel a Pending redemption — re-mint the member's shares."])
+       ["Cancel a Pending redemption — re-mint the member's SPL shares."])
 
 # ── deposit: optional liquid-mode SPL accounts (Phase B) ────────────────────
 for ins in idl["instructions"]:
@@ -348,6 +349,7 @@ TAIL_ERRORS = [
     ("RedemptionNotPending", "Redemption request is not in a Pending state"),
     ("RedemptionStillIlliquid", "Liquid vault still lacks the SOL to fulfil this redemption"),
     ("InvalidReserveBps", "Withdrawal reserve bps must be <= 10000"),
+    ("TokenizedUseRedeem", "Tokenized pot — exit via redeem_tokens / the redemption queue, not withdraw"),
 ]
 have = {e["name"] for e in idl["errors"]}
 next_code = max(e["code"] for e in idl["errors"]) + 1

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -76,6 +76,37 @@ add_ix("set_liquid_config", [POT_W, AUTH_S],
        [{"name": "args", "type": {"defined": {"name": "SetLiquidConfigArgs"}}}],
        ["Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."])
 
+# ── redemption queue (Phase B B3) ───────────────────────────────────────────
+_TOKEN_PROG = {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+_SYS = {"name": "system_program", "address": "11111111111111111111111111111111"}
+add_ix("request_redemption",
+       [POT_W, {"name": "vault"},
+        {"name": "member_account", "writable": True},
+        {"name": "request", "writable": True},
+        {"name": "token_mint", "writable": True},
+        {"name": "member_token_ata", "writable": True},
+        {"name": "member", "writable": True, "signer": True},
+        _TOKEN_PROG, _SYS],
+       [{"name": "token_amount", "type": "u64"}],
+       ["Queue a redemption: burn SPL shares, fix SOL owed at request-time NAV."])
+add_ix("fulfill_redemption",
+       [POT_W, {"name": "vault", "writable": True},
+        {"name": "request", "writable": True},
+        {"name": "member", "writable": True},
+        {"name": "cranker", "signer": True}, _SYS],
+       [],
+       ["Permissionless crank: pay a queued redemption to its recorded member."])
+add_ix("cancel_redemption",
+       [POT_W,
+        {"name": "request", "writable": True},
+        {"name": "member_account", "writable": True},
+        {"name": "token_mint", "writable": True},
+        {"name": "member_token_ata", "writable": True},
+        {"name": "member", "writable": True, "signer": True},
+        _TOKEN_PROG],
+       [],
+       ["Cancel a Pending redemption — re-mint the member's shares."])
+
 # ── deposit: optional liquid-mode SPL accounts (Phase B) ────────────────────
 for ins in idl["instructions"]:
     if ins["name"] == "deposit":
@@ -131,7 +162,8 @@ NEW_POT_FIELDS = [
     {"name": "liquid_mode", "docs": ["deposit auto-mints SPL shares at NAV when true."], "type": "bool"},
     {"name": "withdrawal_reserve_bps", "docs": ["Target % of NAV kept liquid in SOL for instant redemptions."], "type": "u16"},
     {"name": "next_redemption_id", "docs": ["Monotonic id for RedemptionRequest PDAs."], "type": "u64"},
-    {"name": "reserved", "docs": ["Forward-compat tail — carve new fields from here, never insert."], "type": {"array": ["u8", 117]}},
+    {"name": "pending_redemption_lamports", "docs": ["SOL owed to queued redemptions; subtracted from distributable everywhere."], "type": "u64"},
+    {"name": "reserved", "docs": ["Forward-compat tail — carve new fields from here, never insert."], "type": {"array": ["u8", 109]}},
 ]
 _managed = {f["name"] for f in NEW_POT_FIELDS}
 for t in idl["types"]:
@@ -193,6 +225,36 @@ add_type("SetLiquidConfigArgs", [
     {"name": "liquid_mode", "type": "bool"},
     {"name": "withdrawal_reserve_bps", "type": "u16"},
 ])
+# RedemptionRequest account (Phase B B3) — register account + its struct type.
+if not any(a["name"] == "RedemptionRequest" for a in idl["accounts"]):
+    idl["accounts"].append({"name": "RedemptionRequest", "discriminator": disc("account", "RedemptionRequest")})
+add_type("RedemptionRequest", [
+    {"name": "pot", "type": "pubkey"},
+    {"name": "member", "type": "pubkey"},
+    {"name": "redemption_id", "type": "u64"},
+    {"name": "internal_shares", "type": "u64"},
+    {"name": "owed_lamports", "type": "u64"},
+    {"name": "nav_snapshot", "type": "u64"},
+    {"name": "requested_at", "type": "i64"},
+    {"name": "status", "type": {"defined": {"name": "RedemptionStatus"}}},
+    {"name": "bump", "type": "u8"},
+])
+if not any(t["name"] == "RedemptionStatus" for t in idl["types"]):
+    idl["types"].append({"name": "RedemptionStatus", "type": {"kind": "enum", "variants": [
+        {"name": "Pending"}, {"name": "Fulfilled"}, {"name": "Cancelled"}]}})
+add_type("RedemptionRequested", [
+    {"name": "pot", "type": "pubkey"}, {"name": "request", "type": "pubkey"},
+    {"name": "member", "type": "pubkey"}, {"name": "redemption_id", "type": "u64"},
+    {"name": "internal_shares", "type": "u64"}, {"name": "owed_lamports", "type": "u64"},
+])
+add_type("RedemptionFulfilled", [
+    {"name": "pot", "type": "pubkey"}, {"name": "request", "type": "pubkey"},
+    {"name": "member", "type": "pubkey"}, {"name": "owed_lamports", "type": "u64"},
+])
+add_type("RedemptionCancelled", [
+    {"name": "pot", "type": "pubkey"}, {"name": "request", "type": "pubkey"},
+    {"name": "member", "type": "pubkey"}, {"name": "internal_shares", "type": "u64"},
+])
 add_type("LiquidConfigUpdated", [
     {"name": "pot", "type": "pubkey"},
     {"name": "liquid_mode", "type": "bool"},
@@ -248,7 +310,8 @@ add_type("YieldRouted", [
 event_names = {e["name"] for e in idl["events"]}
 for ev in ["SentinelUpdated", "PotFrozenEvent", "ProposalCancelled",
            "AllowedProgramsUpdated", "PendingParamsApplied", "YieldRouted",
-           "OracleConfigUpdated", "LiquidConfigUpdated"]:
+           "OracleConfigUpdated", "LiquidConfigUpdated",
+           "RedemptionRequested", "RedemptionFulfilled", "RedemptionCancelled"]:
     if ev not in event_names:
         idl["events"].append({"name": ev, "discriminator": disc("event", ev)})
 

--- a/packages/program/scripts/patch_idl.py
+++ b/packages/program/scripts/patch_idl.py
@@ -111,14 +111,21 @@ NEW_POT_FIELDS = [
     {"name": "oracle_kind", "docs": ["Oracle source: 0 = Pyth, 1 = Switchboard."], "type": "u8"},
     {"name": "max_oracle_conf_bps", "docs": ["Max accepted oracle confidence interval, bps. 0 = source default."], "type": "u16"},
     {"name": "max_oracle_deviation_bps", "docs": ["Max swap-vs-oracle deviation, bps. 0 = guard disabled."], "type": "u16"},
-    {"name": "reserved", "docs": ["Forward-compat tail — carve new fields from here, never insert."], "type": {"array": ["u8", 128]}},
+    # ── Liquid Vaults (Phase B) — carved from reserved (128 → 117) ──
+    {"name": "liquid_mode", "docs": ["deposit auto-mints SPL shares at NAV when true."], "type": "bool"},
+    {"name": "withdrawal_reserve_bps", "docs": ["Target % of NAV kept liquid in SOL for instant redemptions."], "type": "u16"},
+    {"name": "next_redemption_id", "docs": ["Monotonic id for RedemptionRequest PDAs."], "type": "u64"},
+    {"name": "reserved", "docs": ["Forward-compat tail — carve new fields from here, never insert."], "type": {"array": ["u8", 117]}},
 ]
+_managed = {f["name"] for f in NEW_POT_FIELDS}
 for t in idl["types"]:
     if t["name"] == "PotAccount":
-        existing = {f["name"] for f in t["type"]["fields"]}
-        for f in NEW_POT_FIELDS:
-            if f["name"] not in existing:
-                t["type"]["fields"].append(f)
+        # Idempotent: drop any managed fields already present (so a changed
+        # size like reserved[128]→[117] is corrected on re-run), then append
+        # the managed set in canonical order after the base fields.
+        t["type"]["fields"] = [
+            f for f in t["type"]["fields"] if f["name"] not in _managed
+        ] + NEW_POT_FIELDS
     if t["name"] == "ProposalStatus":
         if not any(v["name"] == "Cancelled" for v in t["type"]["variants"]):
             t["type"]["variants"].append({"name": "Cancelled"})
@@ -247,6 +254,12 @@ TAIL_ERRORS = [
     ("OracleKindUnsupported", "Configured oracle source is not supported"),
     ("OracleAccountMissing", "Oracle price account required for this guarded action"),
     ("OracleGuardUnavailable", "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"),
+    ("NotLiquidMode", "Pot is not in liquid (SPL share) mode"),
+    ("NavLegAccountInvalid", "A required token-leg account or its oracle feed is missing/mismatched"),
+    ("RedemptionNotQueued", "Redemption can be paid instantly — use redeem_tokens, not the queue"),
+    ("RedemptionNotPending", "Redemption request is not in a Pending state"),
+    ("RedemptionStillIlliquid", "Liquid vault still lacks the SOL to fulfil this redemption"),
+    ("InvalidReserveBps", "Withdrawal reserve bps must be <= 10000"),
 ]
 have = {e["name"] for e in idl["errors"]}
 next_code = max(e["code"] for e in idl["errors"]) + 1

--- a/packages/program/tests/liquid_deposit.test.ts
+++ b/packages/program/tests/liquid_deposit.test.ts
@@ -1,0 +1,109 @@
+// tests/liquid_deposit.test.ts
+//
+// Phase B B1 — liquid-mode deposit auto-mints SPL share-tokens at NAV.
+// Flow: create_pot → init_token_mint → set_liquid_config(true) →
+// deposit → assert depositor's ATA received shares*shares_per_sol SPL, and
+// total_shares grew. Also: set_liquid_config rejects enabling on a
+// non-tokenized pot and rejects reserve_bps > 10000.
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import {
+  getAssociatedTokenAddressSync,
+  getAccount as getTokenAccount,
+  createAssociatedTokenAccountIdempotentInstruction,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { PublicKey, SystemProgram, Transaction, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { expect } from 'chai'
+
+const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+
+describe('liquid deposit (Phase B)', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+  const program = (anchor.workspace as any).PotVault as Program
+  const authority = provider.wallet.publicKey
+
+  function pdas(name: string) {
+    const [pot] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), authority.toBuffer(), Buffer.from(name)], program.programId)
+    const [vault] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), pot.toBuffer()], program.programId)
+    const [tokenMint] = PublicKey.findProgramAddressSync(
+      [Buffer.from('token_mint'), pot.toBuffer()], program.programId)
+    const [member] = PublicKey.findProgramAddressSync(
+      [Buffer.from('member'), pot.toBuffer(), authority.toBuffer()], program.programId)
+    return { pot, vault, tokenMint, member }
+  }
+
+  async function createPot(name: string) {
+    const { pot, vault } = pdas(name)
+    await (program.methods as any).createPot({
+      name, emoji: '💧', isPublic: true, minDeposit: new BN(0), lockupSeconds: new BN(0),
+      yieldStrategy: 0, maxYieldAllocationBps: 0, maxTradeSizeBps: 0, maxMembers: 16,
+      tradeLevel: 0, withdrawLevel: 0, memberChangeLevel: 0, settingsChangeLevel: 0,
+      yieldChangeLevel: 0, voteTimeoutSeconds: new BN(3600), quorumBps: 0,
+      timelockSeconds: new BN(0), protocolFeeBps: 0,
+    }).accounts({ pot, vault, treasury: TREASURY, authority, systemProgram: SystemProgram.programId }).rpc()
+    return pdas(name)
+  }
+
+  async function expectError(p: Promise<any>, code: string) {
+    try { await p; expect.fail(`expected ${code}`) }
+    catch (e: any) { expect(String(e.error?.errorCode?.code ?? e)).to.include(code) }
+  }
+
+  it('rejects enabling liquid mode on a non-tokenized pot', async () => {
+    const { pot } = await createPot(`liq-notok-${Date.now() % 1e6}`)
+    await expectError(
+      (program.methods as any).setLiquidConfig({ liquidMode: true, withdrawalReserveBps: 2000 })
+        .accounts({ pot, authority }).rpc(),
+      'NotTokenized')
+  })
+
+  it('rejects reserve bps > 10000', async () => {
+    const { pot } = await createPot(`liq-bps-${Date.now() % 1e6}`)
+    await expectError(
+      (program.methods as any).setLiquidConfig({ liquidMode: false, withdrawalReserveBps: 12000 })
+        .accounts({ pot, authority }).rpc(),
+      'InvalidReserveBps')
+  })
+
+  it('auto-mints SPL shares to the depositor on a liquid deposit', async () => {
+    const { pot, vault, tokenMint, member } = await createPot(`liq-mint-${Date.now() % 1e6}`)
+
+    // Tokenize: create the pot-owned SPL mint.
+    await (program.methods as any).initTokenMint()
+      .accounts({ pot, tokenMint, authority, tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId, rent: anchor.web3.SYSVAR_RENT_PUBKEY }).rpc()
+
+    // Enable liquid mode with a 20% reserve target.
+    await (program.methods as any).setLiquidConfig({ liquidMode: true, withdrawalReserveBps: 2000 })
+      .accounts({ pot, authority }).rpc()
+
+    const ata = getAssociatedTokenAddressSync(tokenMint, authority)
+    await provider.sendAndConfirm(new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(authority, ata, authority, tokenMint)))
+
+    const potBefore: any = await (program.account as any).potAccount.fetch(pot)
+    const sharesPerSol = Number(potBefore.sharesPerSol)
+
+    // First liquid deposit of 1 SOL. First deposit mints shares 1:1 with
+    // lamports (lamports_to_shares seeds at lamports when total_shares==0).
+    await (program.methods as any).deposit(new BN(LAMPORTS_PER_SOL))
+      .accounts({
+        pot, vault, member, depositor: authority,
+        tokenMint, depositorAta: ata, tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      }).rpc()
+
+    const potAfter: any = await (program.account as any).potAccount.fetch(pot)
+    const internalShares = Number(potAfter.totalShares)
+    expect(internalShares).to.be.greaterThan(0)
+
+    const ataAcct = await getTokenAccount(provider.connection, ata)
+    // SPL minted == internal shares × shares_per_sol.
+    expect(Number(ataAcct.amount)).to.equal(internalShares * sharesPerSol)
+  })
+})

--- a/packages/program/tests/oracle_config.test.ts
+++ b/packages/program/tests/oracle_config.test.ts
@@ -65,7 +65,8 @@ describe('oracle config (Phase A)', () => {
     expect(s.oracleKind).to.equal(0)
     expect(s.maxOracleConfBps).to.equal(0)
     expect(s.maxOracleDeviationBps).to.equal(0)
-    expect(s.reserved.length).to.equal(128)
+    // Phase B carved 11 bytes from the reserved tail (128 → 117).
+    expect(s.reserved.length).to.equal(117)
   })
 
   it('stores and round-trips the confidence bound', async () => {

--- a/packages/program/tests/oracle_config.test.ts
+++ b/packages/program/tests/oracle_config.test.ts
@@ -65,8 +65,8 @@ describe('oracle config (Phase A)', () => {
     expect(s.oracleKind).to.equal(0)
     expect(s.maxOracleConfBps).to.equal(0)
     expect(s.maxOracleDeviationBps).to.equal(0)
-    // Phase B carved 11 bytes from the reserved tail (128 → 117).
-    expect(s.reserved.length).to.equal(117)
+    // Phase B carved 19 bytes from the reserved tail (128 → 109).
+    expect(s.reserved.length).to.equal(109)
   })
 
   it('stores and round-trips the confidence bound', async () => {

--- a/packages/program/tests/redeem_tokens.test.ts
+++ b/packages/program/tests/redeem_tokens.test.ts
@@ -104,6 +104,7 @@ describe('redeem_tokens', () => {
         vault: vaultPda,
         member: memberPda,
         depositor: provider.wallet.publicKey,
+        tokenMint: null, depositorAta: null, tokenProgram: null,
         systemProgram: SystemProgram.programId,
       })
       .rpc()

--- a/packages/program/tests/redemption_queue.test.ts
+++ b/packages/program/tests/redemption_queue.test.ts
@@ -89,7 +89,7 @@ describe('redemption queue (Phase B)', () => {
 
     const request = requestPda(pot, id)
     await (program.methods as any).requestRedemption(new BN(tokenAmount)).accounts({
-      pot, vault, memberAccount: member, request, tokenMint, memberTokenAta: ata,
+      pot, vault, request, tokenMint, memberTokenAta: ata,
       member: authority, tokenProgram: TOKEN_PROGRAM_ID, systemProgram: SystemProgram.programId }).rpc()
 
     // Shares burned; SOL earmarked.
@@ -123,6 +123,18 @@ describe('redemption queue (Phase B)', () => {
     expect(ps.pendingRedemptionLamports.toNumber()).to.equal(0)
   })
 
+  it('blocks the member.shares-based withdraw on a tokenized pot (no double-exit)', async () => {
+    const { pot, vault, member } = await liquidPotWithDeposit(`rq-wd-${Date.now() % 1e6}`, 0)
+    // withdraw uses member.shares; on a tokenized/liquid pot the only exit is
+    // redeem/queue, so this must revert — otherwise a holder could redeem the
+    // SPL AND withdraw the shares (CRITICAL double-exit found in audit).
+    await expectError(
+      (program.methods as any).withdraw(new BN(1)).accounts({
+        pot, vault, member, withdrawer: authority, systemProgram: SystemProgram.programId,
+      }).rpc(),
+      'TokenizedUseRedeem')
+  })
+
   it('cancels a Pending redemption and re-mints the shares', async () => {
     const { pot, vault, tokenMint, member, ata } = await liquidPotWithDeposit(`rq-cxl-${Date.now() % 1e6}`, 0)
     const potState: any = await (program.account as any).potAccount.fetch(pot)
@@ -133,11 +145,11 @@ describe('redemption queue (Phase B)', () => {
 
     const request = requestPda(pot, id)
     await (program.methods as any).requestRedemption(new BN(tokenAmount)).accounts({
-      pot, vault, memberAccount: member, request, tokenMint, memberTokenAta: ata,
+      pot, vault, request, tokenMint, memberTokenAta: ata,
       member: authority, tokenProgram: TOKEN_PROGRAM_ID, systemProgram: SystemProgram.programId }).rpc()
 
     await (program.methods as any).cancelRedemption().accounts({
-      pot, request, memberAccount: member, tokenMint, memberTokenAta: ata,
+      pot, request, tokenMint, memberTokenAta: ata,
       member: authority, tokenProgram: TOKEN_PROGRAM_ID }).rpc()
 
     const ataAfter = await getTokenAccount(provider.connection, ata)

--- a/packages/program/tests/redemption_queue.test.ts
+++ b/packages/program/tests/redemption_queue.test.ts
@@ -1,0 +1,150 @@
+// tests/redemption_queue.test.ts
+//
+// Phase B B3 — redemption queue (Variant α: payout fixed at request NAV).
+// Sets a 100% withdrawal reserve so instant redeem can't pay, forcing the
+// queue path. Covers: request burns shares + earmarks SOL; fulfill pays the
+// recorded member and only that member; cancel re-mints shares; a stranger
+// cannot redirect a fulfilment.
+
+import * as anchor from '@coral-xyz/anchor'
+import { Program, BN } from '@coral-xyz/anchor'
+import {
+  getAssociatedTokenAddressSync, getAccount as getTokenAccount,
+  createAssociatedTokenAccountIdempotentInstruction, TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { Keypair, PublicKey, SystemProgram, Transaction, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { expect } from 'chai'
+
+const TREASURY = new PublicKey('2LeG86xuss12WrYsamTGk4zLfBbXJpWZpr1yFrUqN98o')
+
+describe('redemption queue (Phase B)', () => {
+  const provider = anchor.AnchorProvider.env()
+  anchor.setProvider(provider)
+  const program = (anchor.workspace as any).PotVault as Program
+  const authority = provider.wallet.publicKey
+  const stranger = Keypair.generate()
+
+  function pdas(name: string) {
+    const [pot] = PublicKey.findProgramAddressSync(
+      [Buffer.from('pot'), authority.toBuffer(), Buffer.from(name)], program.programId)
+    const [vault] = PublicKey.findProgramAddressSync([Buffer.from('vault'), pot.toBuffer()], program.programId)
+    const [tokenMint] = PublicKey.findProgramAddressSync([Buffer.from('token_mint'), pot.toBuffer()], program.programId)
+    const [member] = PublicKey.findProgramAddressSync(
+      [Buffer.from('member'), pot.toBuffer(), authority.toBuffer()], program.programId)
+    return { pot, vault, tokenMint, member }
+  }
+  function requestPda(pot: PublicKey, id: number) {
+    return PublicKey.findProgramAddressSync(
+      [Buffer.from('redemption'), pot.toBuffer(), new BN(id).toArrayLike(Buffer, 'le', 8)], program.programId)[0]
+  }
+
+  async function expectError(p: Promise<any>, code: string) {
+    try { await p; expect.fail(`expected ${code}`) }
+    catch (e: any) { expect(String(e.error?.errorCode?.code ?? e)).to.include(code) }
+  }
+
+  // Build a liquid pot, deposit 1 SOL, return handles + the member ATA.
+  async function liquidPotWithDeposit(name: string, reserveBps: number) {
+    const { pot, vault, tokenMint, member } = pdas(name)
+    await (program.methods as any).createPot({
+      name, emoji: '🌊', isPublic: true, minDeposit: new BN(0), lockupSeconds: new BN(0),
+      yieldStrategy: 0, maxYieldAllocationBps: 0, maxTradeSizeBps: 0, maxMembers: 16,
+      tradeLevel: 0, withdrawLevel: 0, memberChangeLevel: 0, settingsChangeLevel: 0,
+      yieldChangeLevel: 0, voteTimeoutSeconds: new BN(3600), quorumBps: 0,
+      timelockSeconds: new BN(0), protocolFeeBps: 0,
+    }).accounts({ pot, vault, treasury: TREASURY, authority, systemProgram: SystemProgram.programId }).rpc()
+
+    await (program.methods as any).initTokenMint().accounts({
+      pot, tokenMint, authority, tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId, rent: anchor.web3.SYSVAR_RENT_PUBKEY }).rpc()
+    await (program.methods as any).setLiquidConfig({ liquidMode: true, withdrawalReserveBps: reserveBps })
+      .accounts({ pot, authority }).rpc()
+
+    const ata = getAssociatedTokenAddressSync(tokenMint, authority)
+    await provider.sendAndConfirm(new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(authority, ata, authority, tokenMint)))
+
+    await (program.methods as any).deposit(new BN(LAMPORTS_PER_SOL)).accounts({
+      pot, vault, member, depositor: authority,
+      tokenMint, depositorAta: ata, tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId }).rpc()
+
+    return { pot, vault, tokenMint, member, ata }
+  }
+
+  before(async () => {
+    const sig = await provider.connection.requestAirdrop(stranger.publicKey, LAMPORTS_PER_SOL)
+    await provider.connection.confirmTransaction(sig)
+  })
+
+  it('queues a redemption (burn + earmark), fulfils it to the member, and blocks fund redirection', async () => {
+    const { pot, vault, tokenMint, member, ata } = await liquidPotWithDeposit(`rq-fill-${Date.now() % 1e6}`, 0)
+
+    const potState: any = await (program.account as any).potAccount.fetch(pot)
+    const id = potState.nextRedemptionId.toNumber()
+    const sharesPerSol = Number(potState.sharesPerSol)
+    const ataBefore = await getTokenAccount(provider.connection, ata)
+    // Queue half the holding.
+    const tokenAmount = Math.floor(Number(ataBefore.amount) / 2 / sharesPerSol) * sharesPerSol
+
+    const request = requestPda(pot, id)
+    await (program.methods as any).requestRedemption(new BN(tokenAmount)).accounts({
+      pot, vault, memberAccount: member, request, tokenMint, memberTokenAta: ata,
+      member: authority, tokenProgram: TOKEN_PROGRAM_ID, systemProgram: SystemProgram.programId }).rpc()
+
+    // Shares burned; SOL earmarked.
+    const ataAfter = await getTokenAccount(provider.connection, ata)
+    expect(Number(ataAfter.amount)).to.equal(Number(ataBefore.amount) - tokenAmount)
+    let reqState: any = await (program.account as any).redemptionRequest.fetch(request)
+    expect(Object.keys(reqState.status)[0]).to.equal('pending')
+    expect(reqState.owedLamports.toNumber()).to.be.greaterThan(0)
+    let ps: any = await (program.account as any).potAccount.fetch(pot)
+    expect(ps.pendingRedemptionLamports.toNumber()).to.equal(reqState.owedLamports.toNumber())
+
+    // A stranger cannot redirect the payout to itself (address constraint).
+    await expectError(
+      (program.methods as any).fulfillRedemption().accounts({
+        pot, vault, request, member: stranger.publicKey, cranker: stranger.publicKey,
+        systemProgram: SystemProgram.programId }).signers([stranger]).rpc(),
+      'UnauthorizedAccess')
+
+    // Permissionless crank pays the recorded member. Assert the VAULT delta
+    // (the vault never pays tx fees, unlike the provider-wallet member).
+    const vaultBefore = await provider.connection.getBalance(vault)
+    await (program.methods as any).fulfillRedemption().accounts({
+      pot, vault, request, member: authority, cranker: stranger.publicKey,
+      systemProgram: SystemProgram.programId }).signers([stranger]).rpc()
+    const vaultAfter = await provider.connection.getBalance(vault)
+    expect(vaultBefore - vaultAfter).to.equal(reqState.owedLamports.toNumber())
+
+    reqState = await (program.account as any).redemptionRequest.fetch(request)
+    expect(Object.keys(reqState.status)[0]).to.equal('fulfilled')
+    ps = await (program.account as any).potAccount.fetch(pot)
+    expect(ps.pendingRedemptionLamports.toNumber()).to.equal(0)
+  })
+
+  it('cancels a Pending redemption and re-mints the shares', async () => {
+    const { pot, vault, tokenMint, member, ata } = await liquidPotWithDeposit(`rq-cxl-${Date.now() % 1e6}`, 0)
+    const potState: any = await (program.account as any).potAccount.fetch(pot)
+    const id = potState.nextRedemptionId.toNumber()
+    const sharesPerSol = Number(potState.sharesPerSol)
+    const ataBefore = await getTokenAccount(provider.connection, ata)
+    const tokenAmount = Math.floor(Number(ataBefore.amount) / 4 / sharesPerSol) * sharesPerSol
+
+    const request = requestPda(pot, id)
+    await (program.methods as any).requestRedemption(new BN(tokenAmount)).accounts({
+      pot, vault, memberAccount: member, request, tokenMint, memberTokenAta: ata,
+      member: authority, tokenProgram: TOKEN_PROGRAM_ID, systemProgram: SystemProgram.programId }).rpc()
+
+    await (program.methods as any).cancelRedemption().accounts({
+      pot, request, memberAccount: member, tokenMint, memberTokenAta: ata,
+      member: authority, tokenProgram: TOKEN_PROGRAM_ID }).rpc()
+
+    const ataAfter = await getTokenAccount(provider.connection, ata)
+    expect(Number(ataAfter.amount)).to.equal(Number(ataBefore.amount)) // re-minted
+    const reqState: any = await (program.account as any).redemptionRequest.fetch(request)
+    expect(Object.keys(reqState.status)[0]).to.equal('cancelled')
+    const ps: any = await (program.account as any).potAccount.fetch(pot)
+    expect(ps.pendingRedemptionLamports.toNumber()).to.equal(0)
+  })
+})

--- a/packages/program/tests/security.test.ts
+++ b/packages/program/tests/security.test.ts
@@ -97,6 +97,7 @@ describe('security hardening (Phase A)', () => {
         pot, vault,
         member: memberPda(pot, authority),
         depositor: authority,
+        tokenMint: null, depositorAta: null, tokenProgram: null,
         systemProgram: SystemProgram.programId,
       })
       .rpc()

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -600,6 +600,21 @@
           "signer": true
         },
         {
+          "name": "token_mint",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "depositor_ata",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -2891,6 +2906,42 @@
       "docs": [
         "Configure the pot's oracle source, confidence bound, and swap deviation guard."
       ]
+    },
+    {
+      "name": "set_liquid_config",
+      "discriminator": [
+        226,
+        61,
+        203,
+        209,
+        107,
+        28,
+        77,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SetLiquidConfigArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."
+      ]
     }
   ],
   "accounts": [
@@ -3245,6 +3296,19 @@
         155,
         34,
         68
+      ]
+    },
+    {
+      "name": "LiquidConfigUpdated",
+      "discriminator": [
+        144,
+        70,
+        46,
+        226,
+        62,
+        26,
+        39,
+        123
       ]
     }
   ],
@@ -6213,6 +6277,42 @@
           },
           {
             "name": "max_oracle_deviation_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetLiquidConfigArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquid_mode",
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidConfigUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquid_mode",
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
             "type": "u16"
           }
         ]

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -2942,6 +2942,157 @@
       "docs": [
         "Enable liquid mode (deposit auto-mints SPL shares at NAV) + reserve target."
       ]
+    },
+    {
+      "name": "request_redemption",
+      "discriminator": [
+        14,
+        62,
+        182,
+        237,
+        59,
+        79,
+        149,
+        22
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "member_account",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Queue a redemption: burn SPL shares, fix SOL owed at request-time NAV."
+      ]
+    },
+    {
+      "name": "fulfill_redemption",
+      "discriminator": [
+        135,
+        55,
+        160,
+        245,
+        203,
+        83,
+        197,
+        146
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true
+        },
+        {
+          "name": "cranker",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Permissionless crank: pay a queued redemption to its recorded member."
+      ]
+    },
+    {
+      "name": "cancel_redemption",
+      "discriminator": [
+        197,
+        243,
+        101,
+        86,
+        2,
+        37,
+        105,
+        106
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "request",
+          "writable": true
+        },
+        {
+          "name": "member_account",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [],
+      "docs": [
+        "Cancel a Pending redemption \u2014 re-mint the member's shares."
+      ]
     }
   ],
   "accounts": [
@@ -3073,6 +3224,19 @@
         202,
         115,
         33
+      ]
+    },
+    {
+      "name": "RedemptionRequest",
+      "discriminator": [
+        117,
+        157,
+        214,
+        214,
+        64,
+        160,
+        31,
+        58
       ]
     }
   ],
@@ -3309,6 +3473,45 @@
         26,
         39,
         123
+      ]
+    },
+    {
+      "name": "RedemptionRequested",
+      "discriminator": [
+        245,
+        155,
+        98,
+        131,
+        210,
+        25,
+        137,
+        146
+      ]
+    },
+    {
+      "name": "RedemptionFulfilled",
+      "discriminator": [
+        73,
+        134,
+        70,
+        2,
+        131,
+        17,
+        134,
+        141
+      ]
+    },
+    {
+      "name": "RedemptionCancelled",
+      "discriminator": [
+        22,
+        106,
+        118,
+        26,
+        83,
+        110,
+        71,
+        174
       ]
     }
   ],
@@ -4563,6 +4766,13 @@
             "type": "u64"
           },
           {
+            "name": "pending_redemption_lamports",
+            "docs": [
+              "SOL owed to queued redemptions; subtracted from distributable everywhere."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "docs": [
               "Forward-compat tail \u2014 carve new fields from here, never insert."
@@ -4570,7 +4780,7 @@
             "type": {
               "array": [
                 "u8",
-                117
+                109
               ]
             }
           }
@@ -6314,6 +6524,151 @@
           {
             "name": "withdrawal_reserve_bps",
             "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequest",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_id",
+            "type": "u64"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "nav_snapshot",
+            "type": "u64"
+          },
+          {
+            "name": "requested_at",
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "RedemptionStatus"
+              }
+            }
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pending"
+          },
+          {
+            "name": "Fulfilled"
+          },
+          {
+            "name": "Cancelled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_id",
+            "type": "u64"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionFulfilled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "owed_lamports",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionCancelled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pot",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "member",
+            "type": "pubkey"
+          },
+          {
+            "name": "internal_shares",
+            "type": "u64"
           }
         ]
       }

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -2779,99 +2779,6 @@
       ]
     },
     {
-      "name": "redeem_tokens",
-      "discriminator": [
-        246,
-        98,
-        134,
-        41,
-        152,
-        33,
-        120,
-        69
-      ],
-      "accounts": [
-        {
-          "name": "pot",
-          "writable": true
-        },
-        {
-          "name": "vault",
-          "writable": true
-        },
-        {
-          "name": "member",
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "token_mint",
-          "writable": true
-        },
-        {
-          "name": "member_token_ata",
-          "writable": true
-        },
-        {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
-        {
-          "name": "token_amount",
-          "type": "u64"
-        }
-      ],
-      "docs": [
-        "Burn SPL share-tokens and receive SOL from the vault at NAV."
-      ]
-    },
-    {
-      "name": "route_to_yield",
-      "discriminator": [
-        82,
-        31,
-        61,
-        118,
-        105,
-        209,
-        221,
-        31
-      ],
-      "accounts": [
-        {
-          "name": "pot",
-          "writable": true
-        },
-        {
-          "name": "vault"
-        },
-        {
-          "name": "authority",
-          "writable": true,
-          "signer": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "RouteToYieldArgs"
-            }
-          }
-        }
-      ],
-      "docs": [
-        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
-      ]
-    },
-    {
       "name": "set_oracle_config",
       "discriminator": [
         96,
@@ -2962,10 +2869,6 @@
         },
         {
           "name": "vault"
-        },
-        {
-          "name": "member_account",
-          "writable": true
         },
         {
           "name": "request",
@@ -3068,10 +2971,6 @@
           "writable": true
         },
         {
-          "name": "member_account",
-          "writable": true
-        },
-        {
           "name": "token_mint",
           "writable": true
         },
@@ -3091,7 +2990,100 @@
       ],
       "args": [],
       "docs": [
-        "Cancel a Pending redemption \u2014 re-mint the member's shares."
+        "Cancel a Pending redemption \u2014 re-mint the member's SPL shares."
+      ]
+    },
+    {
+      "name": "redeem_tokens",
+      "discriminator": [
+        246,
+        98,
+        134,
+        41,
+        152,
+        33,
+        120,
+        69
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "writable": true
+        },
+        {
+          "name": "member_token_ata",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_amount",
+          "type": "u64"
+        }
+      ],
+      "docs": [
+        "Burn SPL share-tokens and receive SOL from the vault at NAV."
+      ]
+    },
+    {
+      "name": "route_to_yield",
+      "discriminator": [
+        82,
+        31,
+        61,
+        118,
+        105,
+        209,
+        221,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "pot",
+          "writable": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RouteToYieldArgs"
+            }
+          }
+        }
+      ],
+      "docs": [
+        "Route idle vault SOL to a yield protocol (Phase 4 stub)."
       ]
     }
   ],
@@ -3975,6 +3967,11 @@
       "code": 6091,
       "name": "InvalidReserveBps",
       "msg": "Withdrawal reserve bps must be <= 10000"
+    },
+    {
+      "code": 6092,
+      "name": "TokenizedUseRedeem",
+      "msg": "Tokenized pot \u2014 exit via redeem_tokens / the redemption queue, not withdraw"
     }
   ],
   "types": [

--- a/packages/sdk/src/idl/pot_vault.json
+++ b/packages/sdk/src/idl/pot_vault.json
@@ -3678,6 +3678,36 @@
       "code": 6085,
       "name": "OracleGuardUnavailable",
       "msg": "Oracle deviation guard needs two-feed pricing (Phase B); not enableable yet"
+    },
+    {
+      "code": 6086,
+      "name": "NotLiquidMode",
+      "msg": "Pot is not in liquid (SPL share) mode"
+    },
+    {
+      "code": 6087,
+      "name": "NavLegAccountInvalid",
+      "msg": "A required token-leg account or its oracle feed is missing/mismatched"
+    },
+    {
+      "code": 6088,
+      "name": "RedemptionNotQueued",
+      "msg": "Redemption can be paid instantly \u2014 use redeem_tokens, not the queue"
+    },
+    {
+      "code": 6089,
+      "name": "RedemptionNotPending",
+      "msg": "Redemption request is not in a Pending state"
+    },
+    {
+      "code": 6090,
+      "name": "RedemptionStillIlliquid",
+      "msg": "Liquid vault still lacks the SOL to fulfil this redemption"
+    },
+    {
+      "code": 6091,
+      "name": "InvalidReserveBps",
+      "msg": "Withdrawal reserve bps must be <= 10000"
     }
   ],
   "types": [
@@ -4448,6 +4478,27 @@
             "type": "u16"
           },
           {
+            "name": "liquid_mode",
+            "docs": [
+              "deposit auto-mints SPL shares at NAV when true."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "withdrawal_reserve_bps",
+            "docs": [
+              "Target % of NAV kept liquid in SOL for instant redemptions."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "next_redemption_id",
+            "docs": [
+              "Monotonic id for RedemptionRequest PDAs."
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "docs": [
               "Forward-compat tail \u2014 carve new fields from here, never insert."
@@ -4455,7 +4506,7 @@
             "type": {
               "array": [
                 "u8",
-                128
+                117
               ]
             }
           }

--- a/packages/sdk/src/instructions/pot.ts
+++ b/packages/sdk/src/instructions/pot.ts
@@ -94,6 +94,7 @@ export async function depositToPot(
       vault: vaultPda,
       member: memberPda,
       depositor,
+      tokenMint: null, depositorAta: null, tokenProgram: null,
       systemProgram: SystemProgram.programId,
     })
     .rpc()

--- a/packages/sdk/src/premium.ts
+++ b/packages/sdk/src/premium.ts
@@ -144,6 +144,7 @@ export class PotSDK {
         privatePotAccount: privatePot,
         memberAccount,
         member,
+        tokenMint: null, depositorAta: null, tokenProgram: null,
         systemProgram: SystemProgram.programId,
       })
       .instruction();
@@ -362,6 +363,7 @@ export class PotSDK {
         vault,
         memberAccount,
         member,
+        tokenMint: null, depositorAta: null, tokenProgram: null,
         systemProgram: SystemProgram.programId,
       })
       .instruction();

--- a/skills/potbot-dev/SKILL.md
+++ b/skills/potbot-dev/SKILL.md
@@ -112,10 +112,11 @@ getProposalAddress(potPubkey, id)    // [b"proposal", potPubkey, id_bytes]
 ```bash
 # Web
 cd apps/web && npx next dev            # localhost:3000
-# Anchor
-cd packages/program && anchor build
+# Anchor (IDL gen is broken on rustc≥1.85 — see Build Logic below)
+cd packages/program && anchor build --no-idl
 anchor deploy --provider.cluster devnet
-anchor test
+anchor test --skip-build --provider.cluster localnet   # ts-mocha integration tests
+cargo test -p pot-vault --lib                           # pure-logic unit tests
 anchor keys list                        # show/verify program IDs
 solana airdrop 2 --url devnet
 # MCP
@@ -129,6 +130,34 @@ Full setup: `docs/operations/development.md`. Deploy: `docs/operations/deploy.md
 `apps/web` auto-detects deployment via `useIsProgramLive()` (hooks/usePots.ts):
 program account exists at PROGRAM_ID → on-chain; else mock (Zustand seed store).
 Enable on-chain: deploy program, set `NEXT_PUBLIC_RPC_URL` + `NEXT_PUBLIC_PROGRAM_ID` in `apps/web/.env.local`.
+
+## Build Logic (non-obvious, durable — read before touching the program)
+- **IDL gen is BROKEN on rustc ≥ 1.85.** anchor 0.30.1's `anchor-syn` calls
+  `proc_macro2::Span::source_file`, removed in recent proc-macro2/rustc. Never run a
+  bare `anchor build`. Workflow:
+  1. `anchor build --no-idl`
+  2. `python3 packages/program/scripts/patch_idl.py <sdk_idl> <sdk_idl>` — patches the IDL
+     and self-checks discriminators in place.
+  3. Copy the patched IDL to `packages/sdk/src/idl` **and** `apps/web/src/idl`.
+  Keep the `Cargo.lock` pins (`proc-macro2 1.0.86`, `borsh 1.5.7`, etc.) — bumping them
+  re-breaks the build.
+- **4KB BPF stack limit.** `PotAccount` is large; in instruction contexts it MUST be
+  `Box<Account<'info, PotAccount>>` or `try_accounts` blows the stack. Most contexts already
+  box it; `mint_tamagotchi_nft` is a known remaining offender (~4848 bytes).
+- **`reserved` tail is sacred.** New `PotAccount` fields are CARVED from `reserved`
+  (shrink the array, append the field just above it) — never inserted mid-struct. This keeps
+  the serialized layout stable so already-deployed accounts stay readable. Standing rule for
+  every account-shape change.
+- **Vault payouts must be seeds-signed `system_program::transfer`.** The vault PDA is
+  System-owned, so direct lamport debits are runtime-rejected. Sign with
+  `[b"vault", pot_key, &[vault_bump]]` (see `withdraw.rs`).
+- **Tests:** Anchor.toml runs `npx ts-mocha` (not yarn). Integration: `anchor build --no-idl`
+  then `anchor test --skip-build --provider.cluster localnet`. Pure logic gets cargo unit tests
+  (`cargo test -p pot-vault --lib`).
+- **Oracle:** Pyth decoding is devnet-legacy `PriceAccount` layout only. Mainnet needs the
+  Pyth receiver `PriceUpdateV2` decode — tracked Phase B follow-up. The swap deviation guard is
+  plumbed + unit-tested but gated off (`set_oracle_config` rejects `max_oracle_deviation_bps > 0`)
+  until two-feed pricing lands.
 
 ## Known Blockers / Gates (check before claiming "done")
 - 🔴 **Jupiter swap CPI** needs the executor wallet funded + program deployed (this is the mainnet gate).
@@ -148,9 +177,9 @@ Enable on-chain: deploy program, set `NEXT_PUBLIC_RPC_URL` + `NEXT_PUBLIC_PROGRA
 - Design tokens: bg `#0D1117`, card `#111827`, border `#1A2332`, green `#14F195`, accent `#9945FF`, muted `#6B7280`.
 
 ## When Adding Features
-1. Read the relevant `docs/architecture/*` first; mirror new program fields in `packages/sdk` + IDL.
+1. Read the relevant `docs/architecture/*` first; mirror new program fields in `packages/sdk` + IDL (regenerate via the `--no-idl` + `patch_idl.py` flow in Build Logic).
 2. Keep `pot_vault` minimal/auditable; new monetization (subscriptions, etc.) as separate modules.
-3. Backward-compatible account changes; document migration impact before mainnet.
+3. Account changes must carve from `PotAccount.reserved` (never shift layout); document migration impact before mainnet.
 4. Update mock store (`apps/web/src/lib/mock-store.ts`) so demo mode keeps working.
-5. Add/extend anchor tests; run `anchor build && anchor test` green before deploy.
+5. Add/extend tests; `anchor build --no-idl` then `anchor test --skip-build` (+ `cargo test -p pot-vault --lib`) green before deploy.
 ```


### PR DESCRIPTION
Phase B (Liquid Vaults), **стек на #73**. Devnet/localnet only — NO MAINNET. Решения owner: NAV = Variant 2 (oracle multi-asset), redemption = Variant B + **α** (выплата фиксируется при запросе).

Этот PR — **B0 + B1 + B3**. Остаётся **B4** (мультиассетный on-chain NAV через remaining_accounts + Pyth-фикстуры) и receiver-SDK decode для mainnet — идут следом.

## B0 — state + NAV-ядро
- `PotAccount`: `liquid_mode` / `withdrawal_reserve_bps` / `next_redemption_id` / `pending_redemption_lamports` — **вырезаны из reserved (128→109), без сдвига layout**. `RedemptionRequest` аккаунт.
- `oracle::leg_value_lamports` — точная оценка токен-ноги в лампортах из двух Pyth-цен + decimals (целочисленная математика). 5 unit-тестов.

## B1 — liquid-mode deposit
- `set_liquid_config` + `deposit` минтит SPL-шары по NAV в той же tx (без голосования, без отдельного tokenize). Seedling-путь не тронут.

## B3 — redemption reserve + queue (Midas-стиль, Variant α)
- `request_redemption`: жжёт SPL-шары, **фиксирует owed по NAV запроса**, резервирует в `pending_redemption_lamports`.
- `fulfill_redemption`: permissionless-кранк платит **записанному member ровно owed** (`address = request.member` — кранкер не может перенаправить средства, тест есть).
- `cancel_redemption`: member ремитит шары, пока Pending.
- **Ключевой учёт:** `pending_redemption_lamports` вычитается из distributable в deposit + redeem_tokens + withdraw → зарезервированный SOL не двойного счёта; pending-выход не раздувает NAV остальных, instant-выходы не трогают earmark. Хелпер `distributable_lamports()`.

## Тесты
22 cargo unit + 23 localnet зелёные (liquid-deposit ×3, redemption-queue ×3, + весь прежний набор) · tsc (web+sdk) · next build.

## ⚠️ Mainnet-гейт (усилен в READINESS)
On-chain Pyth-чтение декодит legacy devnet-layout. Mainnet = receiver `PriceUpdateV2`. До mainnet нужен `pyth-solana-receiver-sdk` decode — жёсткий гейт.

## Адверсариальный аудит
Очередь (фонд-логика) проходит adversarial-ревью — результат добавлю комментарием.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
