### PR TITLE
feat(sns): fix v3 subdomain claim flow + flat 0.05 SOL launch promo

### DIFF
--- a/apps/web/src/app/name/page.tsx
+++ b/apps/web/src/app/name/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import ClaimWidget from '@/components/sns/ClaimWidget'
 import MyNames from '@/components/sns/MyNames'
-import { PRICE_TIERS, DEFAULT_PRICING } from '@/lib/sns'
+import { PRICE_TIERS, DEFAULT_PRICING, SNS_PROMO_FLAT } from '@/lib/sns'
 
 export const metadata: Metadata = {
   title: 'Claim your .potbot.sol — PotBot',
@@ -14,7 +14,12 @@ export default function NamePage({ searchParams }: { searchParams?: { name?: str
   return (
     <main className="min-h-screen bg-pot-dark text-white" style={{ padding: '64px 20px 96px' }}>
       <div style={{ maxWidth: 720, margin: '0 auto', textAlign: 'center' }}>
-        <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-pot-border bg-pot-card text-pot-green text-xs" style={{ marginBottom: 20 }}>{'🌿'} Powered by Solana Name Service</div>
+        <div className="inline-flex items-center gap-2" style={{ marginBottom: 20 }}>
+          <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-pot-border bg-pot-card text-pot-green text-xs">{'🌿'} Powered by Solana Name Service</span>
+          {SNS_PROMO_FLAT && (
+            <span className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border border-pot-green/40 bg-pot-green/10 text-pot-green text-xs font-bold">{'🔥'} PROMO</span>
+          )}
+        </div>
         <h1 className="text-4xl font-extrabold" style={{ lineHeight: 1.1, margin: '0 0 14px', letterSpacing: -0.5 }}>Claim your <span className="text-pot-green">.potbot.sol</span></h1>
         <p className="text-pot-muted" style={{ fontSize: 17, maxWidth: 520, margin: '0 auto 36px' }}>One human-readable name for the whole PotBot ecosystem. It resolves to your wallet today — and to your pots tomorrow.</p>
       </div>
@@ -41,6 +46,22 @@ function Feature({ title, body }: { title: string; body: string }) {
 }
 
 function PricingTable() {
+  // Launch promo: one flat price for every name. The length-based ladder is
+  // preserved behind the !SNS_PROMO_FLAT branch so flipping the flag restores it.
+  if (SNS_PROMO_FLAT) {
+    return (
+      <div style={{ maxWidth: 560, margin: '48px auto 0', width: '100%' }}>
+        <div className="text-pot-muted text-xs mb-2.5">Pricing</div>
+        <div className="bg-pot-card border border-pot-green/40 rounded-xl overflow-hidden">
+          <div className="flex justify-between px-4 py-3 text-sm">
+            <span>Any name</span>
+            <span className="text-pot-green font-semibold">{DEFAULT_PRICING.sol} SOL · {DEFAULT_PRICING.usdc} USDC</span>
+          </div>
+        </div>
+        <div className="text-pot-muted text-xs mt-2">Launch promo — flat price for every name, any length. Pay once, no renewals.</div>
+      </div>
+    )
+  }
   const rows = [
     { len: '1 char', p: PRICE_TIERS[1] }, { len: '2 chars', p: PRICE_TIERS[2] },
     { len: '3 chars', p: PRICE_TIERS[3] }, { len: '4 chars', p: PRICE_TIERS[4] },

--- a/apps/web/src/lib/sns-server.ts
+++ b/apps/web/src/lib/sns-server.ts
@@ -8,12 +8,13 @@ import {
   createTransferCheckedInstruction, TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
 import {
-  getDomainKeySync, NameRegistryState, resolve, createSubdomain, findSubdomains,
+  getDomainKeySync, NameRegistryState, resolve, createSubdomain, transferSubdomain,
+  findSubdomains,
 } from '@bonfida/spl-name-service'
 import bs58 from 'bs58'
 
 import {
-  PARENT_LABEL, DEFAULT_PRICING, PRICE_TIERS, type PriceConfig, type Currency,
+  PARENT_LABEL, DEFAULT_PRICING, PRICE_TIERS, SNS_PROMO_FLAT, type PriceConfig, type Currency,
   type AvailabilityResult, type OwnedName, toFqdn, validateLabel, USDC_DECIMALS,
   LAMPORTS_PER_SOL_SNS,
 } from './sns'
@@ -64,6 +65,10 @@ export function getPricing(): PriceConfig {
 }
 
 export function priceForLabelServer(label: string): PriceConfig {
+  // Mirror the client promo: while SNS_PROMO_FLAT, every label is the standard
+  // env-overridable price (0.05 SOL / 5 USDC) regardless of length. Env
+  // overrides (POTBOT_SNS_PRICE_SOL / _USDC) still win via getPricing().
+  if (SNS_PROMO_FLAT) return getPricing()
   return PRICE_TIERS[label.length] ?? getPricing()
 }
 
@@ -117,8 +122,26 @@ export async function buildClaimTransaction({ label, buyer, currency }: BuildCla
     ))
   }
 
-  const subIxs = await createSubdomain(connection, `${label}.${PARENT_LABEL}`, buyer, undefined, buyer)
-  for (const ix of flattenInstructions(subIxs)) ixs.push(ix)
+  // Subdomain build (@bonfida/spl-name-service v3.0.21). VERIFIED against the
+  // installed package source:
+  //   createSubdomain(connection, subdomain, owner, space?, feePayer?) → TransactionInstruction[]
+  //     The new subdomain is created OWNED BY `owner` (3rd arg). The previous
+  //     code passed `buyer` here, which also made the reverse-name record use
+  //     the buyer as the (wrong) parent authority. Correct: create it owned by
+  //     the potbot.sol PARENT owner, with the buyer as fee payer (buyer pays
+  //     rent), then transfer it to the buyer in the same tx.
+  //   transferSubdomain(connection, subdomain, newOwner, isParentOwnerSigner?, owner?) → TransactionInstruction
+  //     We pass owner=parent owner (5th arg) explicitly: without it the SDK
+  //     retrieves the subdomain registry to find the current owner, which does
+  //     NOT exist yet inside this same (not-yet-sent) transaction and would
+  //     throw at build time. isParentOwnerSigner=true → the parent owner
+  //     authorizes; the buyer needs no registry signature, only fee payer.
+  const fqdn = `${label}.${PARENT_LABEL}`
+  const createRes = await createSubdomain(connection, fqdn, owner.publicKey, undefined, buyer)
+  for (const ix of flattenInstructions(createRes as any)) ixs.push(ix)
+
+  const transferIx = await transferSubdomain(connection, fqdn, buyer, true, owner.publicKey)
+  for (const ix of flattenInstructions([transferIx] as any)) ixs.push(ix)
 
   const tx = new Transaction()
   tx.feePayer = buyer

--- a/apps/web/src/lib/sns.ts
+++ b/apps/web/src/lib/sns.ts
@@ -346,6 +346,9 @@ export interface PriceConfig {
   usdc: number
 }
 
+// Launch promo: flat price for all label lengths. Set false to restore the length-based ladder.
+export const SNS_PROMO_FLAT = true
+
 export const PRICE_TIERS: Record<number, PriceConfig> = {
   1: { sol: 2, usdc: 200 },
   2: { sol: 1, usdc: 100 },
@@ -359,10 +362,14 @@ export function priceForLabel(
   label: string,
   standard: PriceConfig = DEFAULT_PRICING,
 ): PriceConfig {
+  // During the launch promo every name is the flat standard tier (0.05 SOL /
+  // 5 USDC), regardless of length. Flip SNS_PROMO_FLAT to restore the ladder.
+  if (SNS_PROMO_FLAT) return standard
   return PRICE_TIERS[label.length] ?? standard
 }
 
 export function tierName(label: string): string {
+  if (SNS_PROMO_FLAT) return 'promo'
   if (label.length <= 4) return `${label.length}-char premium`
   return 'standard'
 }


### PR DESCRIPTION
`apps/web` only — программа/SDK не тронуты. Mock-режим и не-SNS страницы без изменений.

## CHANGE 1 — починка subdomain-сборки для `@bonfida/spl-name-service` v3.0.21

**Подтверждено по исходнику в `node_modules`** (`dist/cjs/bindings/createSubdomain.js`, `createNameRegistry.js`, `transferSubdomain.js`):

- `createSubdomain(connection, subdomain, owner, space?, feePayer?) → TransactionInstruction[]` — сабдомен создаётся **во владении 3-го аргумента** (`owner`), rent платит `feePayer` (`m||o` в источнике). Старый код передавал `buyer` как `owner` → reverse-record создавался с **неверным** parent-authority (buyer вместо parent owner).
- **Фикс:** создаём во владении **parent owner** (`owner.publicKey`), `feePayer = buyer` → **rent платит покупатель**; затем `transferSubdomain(connection, fqdn, buyer, true, owner.publicKey)` передаёт сабдомен покупателю в той же транзакции.
- **Ключевая деталь из источника:** 5-й арг (`owner = parent`) обязателен — без него `transferSubdomain` делает `NameRegistryState.retrieve` ещё не созданного в этой же tx реестра сабдомена и падает на этапе сборки. `isParentOwnerSigner = true` → авторизует parent owner (он `partialSign`-ит). Покупатель — только fee payer.

Платёжный блок и `checkAvailability`/`listOwned` не тронуты.

## CHANGE 2 — промо: единая цена 0.05 SOL / 5 USDC на ВСЕ имена

Один переключатель `SNS_PROMO_FLAT` (`sns.ts`). `priceForLabel`/`tierName` и серверный `priceForLabelServer` его уважают; env-оверрайды (`POTBOT_SNS_PRICE_SOL`/`_USDC`) по-прежнему выигрывают на сервере. Лестница `PRICE_TIERS` сохранена за `!SNS_PROMO_FLAT` — флип флага возвращает её. На `/name` — одна строка «Any name — 0.05 SOL · 5 USDC» + PROMO-pill.

**Self-check:** метки длиной 1 / 4 / 8 символов все резолвятся в 0.05 SOL / 5 USDC, tier=`promo`.

## Проверки
`type-check` ✓ · `lint` ✓ · `build` ✓ (все зелёные).

## Env на Vercel для живого claim
- `POTBOT_SNS_OWNER_SECRET` — секрет владельца `potbot.sol` (bs58 или JSON-массив), partial-signs.
- `POTBOT_SNS_RPC_URL` — mainnet RPC (SNS только на mainnet).
- `POTBOT_SNS_TREASURY` — кошелёк-получатель оплаты.
- (опц.) `POTBOT_SNS_PRICE_SOL` / `POTBOT_SNS_PRICE_USDC` — переопределяют промо-цену на сервере; `POTBOT_SNS_USDC_MINT` для не-дефолтного USDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
